### PR TITLE
Add regression infrastructure and symmetry-aware vibrational analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ inputs
 install
 .DS*
 bin
+.claude

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.15)
 project(planck LANGUAGES CXX)
 
+include(CTest)
+
 # C++ standard settings
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -192,4 +194,69 @@ if(BUILD_TOOLS)
     message(STATUS "Tools : chkdump enabled")
 else()
     message(STATUS "Tools : disabled (BUILD_TOOLS=OFF)")
+endif()
+
+find_package(Python3 COMPONENTS Interpreter)
+
+if(BUILD_TESTING AND Python3_Interpreter_FOUND)
+    add_test(
+        NAME planck-regression-smoke
+        COMMAND ${Python3_EXECUTABLE}
+                ${CMAKE_SOURCE_DIR}/tests/run_regressions.py
+                --build-dir ${CMAKE_BINARY_DIR}
+                --suite smoke
+    )
+
+    add_test(
+        NAME planck-regression-core
+        COMMAND ${Python3_EXECUTABLE}
+                ${CMAKE_SOURCE_DIR}/tests/run_regressions.py
+                --build-dir ${CMAKE_BINARY_DIR}
+                --suite core
+    )
+
+    add_test(
+        NAME planck-regression-extended
+        COMMAND ${Python3_EXECUTABLE}
+                ${CMAKE_SOURCE_DIR}/tests/run_regressions.py
+                --build-dir ${CMAKE_BINARY_DIR}
+                --suite extended
+    )
+
+    add_custom_target(regression-smoke
+        COMMAND ${Python3_EXECUTABLE}
+                ${CMAKE_SOURCE_DIR}/tests/run_regressions.py
+                --build-dir ${CMAKE_BINARY_DIR}
+                --suite smoke
+        DEPENDS hartree-fock
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        USES_TERMINAL
+    )
+
+    add_custom_target(regression-core
+        COMMAND ${Python3_EXECUTABLE}
+                ${CMAKE_SOURCE_DIR}/tests/run_regressions.py
+                --build-dir ${CMAKE_BINARY_DIR}
+                --suite core
+        DEPENDS hartree-fock
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        USES_TERMINAL
+    )
+
+    add_custom_target(regression-extended
+        COMMAND ${Python3_EXECUTABLE}
+                ${CMAKE_SOURCE_DIR}/tests/run_regressions.py
+                --build-dir ${CMAKE_BINARY_DIR}
+                --suite extended
+        DEPENDS hartree-fock
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        USES_TERMINAL
+    )
+
+    add_custom_target(teaching-site
+        COMMAND ${Python3_EXECUTABLE}
+                ${CMAKE_SOURCE_DIR}/docs/build_teaching_site.py
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        USES_TERMINAL
+    )
 endif()

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,10 +1,8 @@
-# Quickstart
+### Quickstart
 
 This guide gets you from zero to a converged Hartree-Fock calculation in five minutes.
 
----
-
-## 1. Build
+### 1. Build
 
 ```bash
 git clone https://github.com/HemanthHaridas/planck-refactored.git
@@ -16,9 +14,7 @@ cmake --install build
 
 The first build fetches Eigen and libmsym automatically. The executable is `./install/bin/hartree-fock`.
 
----
-
-## 2. First calculation
+### 2. First calculation
 
 Save the following as `water.hfinp`:
 
@@ -82,9 +78,7 @@ Iter  Energy              DeltaE         RMS(D)      ...
 
 The total energy is printed in Hartree, eV, and kcal/mol.
 
----
-
-## 3. Open-shell calculation (UHF)
+### 3. Open-shell calculation (UHF)
 
 For open-shell systems set `scf_type uhf` and the correct multiplicity. Triplet water (M=3):
 
@@ -109,9 +103,8 @@ UHF output includes spin contamination diagnostics:
 <S>   :   1.415390
 ```
 
----
 
-## 4. Checkpoint and restart
+### 4. Checkpoint and restart
 
 ### Same-basis restart
 
@@ -140,9 +133,8 @@ After a converged run, `water.hfchk` is written automatically. Add `guess read` 
     ...
 ```
 
----
 
-## 5. Analytic gradient and geometry optimization
+### 5. Analytic gradient and geometry optimization
 
 ### Gradient only
 
@@ -276,9 +268,8 @@ The log will confirm which coordinates are frozen before optimization starts:
 [INF]  Constraints :   2 IC(s) frozen, 0 atom(s) frozen
 ```
 
----
 
-## 6. Vibrational frequency analysis
+### 6. Vibrational frequency analysis
 
 Set `calculation freq` to compute vibrational frequencies at the current geometry. The program uses a semi-numerical Hessian (central finite differences of analytic gradients): for each Cartesian DOF, two displaced SCF+gradient evaluations are performed, requiring 2×3N gradient calls in total (18 for water).
 
@@ -343,9 +334,8 @@ A common pattern: optimize to a minimum, then compute frequencies to confirm it 
 %end_scf
 ```
 
----
 
-## 7. Z-matrix input
+### 7. Z-matrix input
 
 Coordinates can be given in Z-matrix (internal coordinate) format. Set `coord_type zmatrix` in `%begin_geom`. Bond lengths are in the units from `coord_units`; angles and dihedrals are always in degrees.
 
@@ -367,9 +357,8 @@ H  1  0.9572  2  104.52
 
 Each row after the header gives the element symbol followed by reference atom index, bond length, and (for atom 3+) additional reference indices, angle, and dihedral. Atom indices are 1-based. The converted Cartesian coordinates are passed through the rest of the pipeline, so symmetry detection (`use_symm .true.`) works normally.
 
----
 
-## 8. SCF mode
+### 8. SCF mode
 
 | Mode | Keyword | When to use |
 |---|---|---|
@@ -394,9 +383,8 @@ For large systems set `scf_mode direct` or lower `threshold`:
     ...
 ```
 
----
 
-## 9. Basis sets
+### 9. Basis sets
 
 | Keyword | Description |
 |---|---|
@@ -405,9 +393,8 @@ For large systems set `scf_mode direct` or lower `threshold`:
 | `6-31g` | Standard split-valence |
 | `6-31g*` | 6-31G + d polarization on heavy atoms |
 
----
 
-## 10. Convergence tips
+### 10. Convergence tips
 
 | Problem | Fix |
 |---|---|
@@ -418,9 +405,8 @@ For large systems set `scf_mode direct` or lower `threshold`:
 | Wrong energy on restart | Delete `.hfchk` and re-run from scratch |
 | MO labels are Ag/Bg/Au/Bu instead of Eg/Eu | Expected — for non-Abelian groups (D3d, Oh, …) the program uses the largest Abelian subgroup (e.g. C2h for D3d). The active group is printed to the log. |
 
----
 
-## 11. All input keywords at a glance
+### 11. All input keywords at a glance
 
 ```
 %begin_control

--- a/docs/PLANCK_TEACHING_GUIDE.md
+++ b/docs/PLANCK_TEACHING_GUIDE.md
@@ -1,0 +1,779 @@
+# Planck Teaching Guide
+
+This document is a teaching-oriented guide to the `planck-refactored` codebase.
+It explains what the program does, how the major algorithms work, how the
+source tree is organized, and how the quantum-chemistry theory maps onto the
+implementation.
+
+The intended audience is:
+
+- a student learning Hartree-Fock and post-Hartree-Fock methods
+- a contributor trying to understand where to change the code
+- a researcher who wants to audit the mathematical and software structure
+
+The guide is written in the same order that a calculation usually happens in
+the executable:
+
+1. parse the input
+2. build the molecule and basis
+3. generate shell pairs and integrals
+4. solve SCF
+5. optionally run correlation methods
+6. optionally compute gradients, optimize geometry, or build vibrational data
+
+## 1. What Planck Is
+
+Planck is a compact quantum chemistry program centered on Gaussian-basis
+electronic structure methods. At the moment it implements:
+
+- RHF and UHF self-consistent field theory
+- Obara-Saika one- and two-electron integrals
+- conventional and direct SCF modes
+- DIIS acceleration
+- point-group detection and MO irrep labeling
+- RMP2 and UMP2 correlation energies
+- RHF and UHF analytic nuclear gradients
+- geometry optimization in Cartesian and internal coordinates
+- semi-numerical Hessians and vibrational frequencies
+- CASSCF and RASSCF active-space calculations
+- binary checkpoint restart support
+
+There is also in-progress infrastructure for a true analytic RMP2 gradient:
+
+- RHF response matrix construction
+- MP2 amplitudes
+- MP2 unrelaxed density builders
+- MP2 Z-vector and relaxed-density helpers
+
+Important implementation status:
+
+- RHF and UHF gradients are analytic
+- the current public RMP2 gradient path is still central-difference total-energy
+  differentiation, even though the codebase now contains some response-theory
+  building blocks for a future analytic implementation
+
+## 2. Big-Picture Architecture
+
+At a high level, the executable in [src/driver.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/driver.cpp)
+orchestrates everything.
+
+The main data object is `HartreeFock::Calculator` in
+[src/base/types.h](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/base/types.h).
+It holds:
+
+- input options
+- molecule and coordinates
+- basis and shell information
+- SCF state
+- integral tensors and one-electron matrices
+- post-HF energies and active-space results
+- gradient, Hessian, and geometry optimization state
+
+Conceptually, `Calculator` is the shared world-state for one calculation.
+
+### Directory Map
+
+### `src/base`
+
+- `types.h`: central enums, options, molecule/basis containers, SCF state, DIIS
+  state, checkpoint-related data, and the `Calculator` object
+- `tables.h`: chemical or optimization helper tables
+- `basis.h.in` and generated `basis.h`: compiled-in basis path configuration
+
+### `src/io`
+
+- `io.cpp/.h`: input parsing from `.hfinp`
+- `checkpoint.cpp/.h`: binary checkpoint load/save and projection support
+- `logging.h`: formatted program output
+
+### `src/lookup`
+
+- periodic-table and Boys-function support data
+
+### `src/basis`
+
+- Gaussian primitives, contractions, and `.gbs` basis parsing
+
+### `src/integrals`
+
+- shell-pair generation
+- Obara-Saika recursions for overlap, kinetic, nuclear attraction, ERIs
+- derivative integral kernels for gradients
+
+### `src/scf`
+
+- orthogonalization
+- initial density construction
+- RHF and UHF SCF loops
+
+### `src/symmetry`
+
+- point-group detection through `libmsym`
+- symmetry-adapted orbital basis support
+- MO irrep assignment
+
+### `src/post_hf`
+
+- MP2 energy code
+- MP2 gradient-response support code
+- CASSCF and RASSCF code
+- AO to MO integral transformations
+- RHF response matrix builders
+
+### `src/gradient`
+
+- analytic RHF and UHF nuclear gradients
+- current numerical RMP2 gradient driver
+- shared closed-shell AO derivative contraction helper
+
+### `src/opt`
+
+- geometry optimization in Cartesian and internal coordinates
+- generalized internal coordinate construction and constraint handling
+
+### `src/freq`
+
+- finite-difference Hessian and vibrational analysis
+
+### `tests`
+
+- manifest-driven executable regression tests
+
+## 3. Core Data Structures
+
+The most important single file is
+[src/base/types.h](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/base/types.h).
+
+### `Molecule`
+
+The molecule object stores:
+
+- atomic numbers
+- charge and multiplicity
+- input-frame coordinates
+- standard-orientation coordinates
+- flags such as whether coordinates are already in Bohr
+
+Two coordinate representations are important:
+
+- `coordinates`: user-facing geometry, often in Angstrom
+- `_standard` and `_coordinates`: internal Bohr-space geometry used by the
+  integrals and optimization machinery
+
+### `Basis`
+
+The basis object contains:
+
+- shells
+- basis functions / contracted Cartesian components
+- bookkeeping like number of shells and number of basis functions
+
+### `DataSCF` and `SpinChannel`
+
+The SCF state stores, per spin channel:
+
+- density matrix
+- Fock matrix
+- MO energies
+- MO coefficients
+- optional MO symmetry labels
+
+This is enough to reconstruct most later quantities.
+
+### `DIISState`
+
+The DIIS object stores:
+
+- a history of Fock matrices
+- a history of Pulay error matrices
+- the subspace dimension
+
+It then solves the standard augmented Pulay linear system to build an
+extrapolated Fock matrix.
+
+### `Calculator`
+
+`Calculator` gathers everything together and also owns:
+
+- `_overlap` and `_hcore`
+- `_eri` if conventional SCF has stored the AO ERI tensor
+- energies
+- gradient and Hessian storage
+- active-space results such as natural occupations
+- SAO blocking data for symmetry-aware diagonalization
+
+If you want to understand “where state lives,” it is almost always here.
+
+## 4. Theoretical Foundations
+
+This section summarizes the theory behind the implemented methods and explains
+how the code mirrors that theory.
+
+## 5. Gaussian Basis Functions
+
+The code works in an atom-centered Gaussian basis:
+
+\[
+\chi_\mu(\mathbf r) = \sum_p d_{p\mu} \, (x-A_x)^{l_x}(y-A_y)^{l_y}(z-A_z)^{l_z}
+e^{-\alpha_p |\mathbf r-\mathbf A|^2}
+\]
+
+Why Gaussians?
+
+- products of Gaussians on different centers are again Gaussians
+- integrals can be reduced recursively
+- this makes them practical for Hartree-Fock and post-HF methods
+
+The implementation details are split across:
+
+- [src/basis/basis.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/basis/basis.cpp)
+- [src/basis/gaussian.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/basis/gaussian.cpp)
+- [src/integrals/shellpair.h](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/integrals/shellpair.h)
+- [src/integrals/shellpair.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/integrals/shellpair.cpp)
+
+`ShellPair` precomputes Gaussian-product data such as:
+
+- combined exponent
+- prefactors
+- Gaussian product center
+- displacement vectors needed in recurrence relations
+
+That is a classic quantum-chemistry optimization: precompute shell-pair data
+once and reuse it many times.
+
+## 6. One- and Two-Electron Integrals
+
+Electronic structure in a Gaussian basis depends on several integral classes:
+
+- overlap:
+  \[
+  S_{\mu\nu} = \langle \chi_\mu | \chi_\nu \rangle
+  \]
+- kinetic:
+  \[
+  T_{\mu\nu} = \left\langle \chi_\mu \left| -\frac{1}{2}\nabla^2 \right| \chi_\nu \right\rangle
+  \]
+- nuclear attraction:
+  \[
+  V_{\mu\nu} = \sum_A \left\langle \chi_\mu \left| -\frac{Z_A}{r_A} \right| \chi_\nu \right\rangle
+  \]
+- electron repulsion:
+  \[
+  (\mu\nu|\lambda\sigma) =
+  \iint \chi_\mu(1)\chi_\nu(1)\frac{1}{r_{12}}\chi_\lambda(2)\chi_\sigma(2)\, d1\, d2
+  \]
+
+Planck computes these with Obara-Saika recursions in:
+
+- [src/integrals/os.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/integrals/os.cpp)
+- [src/integrals/os.h](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/integrals/os.h)
+
+The important implementation split is:
+
+- `_compute_1e(...)`: overlap and kinetic
+- `_compute_nuclear_attraction(...)`: nuclear attraction
+- `_compute_2e(...)`: full AO ERI tensor
+- `_compute_fock_rhf(...)` and `_compute_fock_uhf(...)`: ERI contraction into
+  Coulomb and exchange contributions
+
+### Conventional vs Direct SCF
+
+There are two major strategies for ERIs:
+
+- conventional SCF:
+  build the full AO ERI tensor once and reuse it
+- direct SCF:
+  recompute or contract on the fly each iteration
+
+This is controlled in [src/scf/scf.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/scf/scf.cpp).
+
+Tradeoff:
+
+- conventional is faster per SCF iteration
+- direct uses less memory
+
+The code also uses Schwarz screening thresholds to skip negligible quartets.
+
+## 7. Hartree-Fock Theory
+
+Hartree-Fock approximates the many-electron wavefunction as a Slater
+determinant built from molecular orbitals.
+
+Each spatial orbital is expanded in the AO basis:
+
+\[
+\phi_i = \sum_\mu C_{\mu i}\chi_\mu
+\]
+
+The RHF variational equations become the Roothaan equations:
+
+\[
+\mathbf F \mathbf C = \mathbf S \mathbf C \boldsymbol \varepsilon
+\]
+
+where:
+
+- `S` is the overlap matrix
+- `F` is the Fock matrix
+- `C` contains molecular orbital coefficients
+- `ε` are orbital energies
+
+For RHF, the closed-shell density is:
+
+\[
+P_{\mu\nu} = 2\sum_{i \in occ} C_{\mu i} C_{\nu i}
+\]
+
+and the Fock matrix is:
+
+\[
+F_{\mu\nu} = H_{\mu\nu}^{core} + G_{\mu\nu}
+\]
+
+with:
+
+\[
+G_{\mu\nu} = \sum_{\lambda\sigma} P_{\lambda\sigma}
+\left[(\mu\nu|\lambda\sigma) - \frac{1}{2}(\mu\lambda|\nu\sigma)\right]
+\]
+
+For UHF, alpha and beta densities are separate, and the exchange is
+spin-dependent.
+
+### Where It Lives in Code
+
+- [src/scf/scf.h](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/scf/scf.h)
+- [src/scf/scf.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/scf/scf.cpp)
+
+Important functions:
+
+- `build_orthogonalizer`: constructs \(S^{-1/2}\)
+- `initial_density`: core-Hamiltonian guess
+- `run_rhf`
+- `run_uhf`
+
+### SCF Cycle
+
+Each iteration does roughly this:
+
+1. build `G`
+2. form `F = H + G`
+3. compute energy
+4. optionally update DIIS
+5. diagonalize in an orthonormal basis
+6. rebuild density
+7. test convergence
+
+The orthogonalization step uses:
+
+\[
+\mathbf X = \mathbf S^{-1/2}
+\]
+
+and diagonalizes:
+
+\[
+\mathbf F' = \mathbf X^T \mathbf F \mathbf X
+\]
+
+then transforms back:
+
+\[
+\mathbf C = \mathbf X \mathbf C'
+\]
+
+## 8. DIIS Convergence Acceleration
+
+Planck uses Pulay DIIS to accelerate SCF convergence.
+
+The key idea is:
+
+- store several recent Fock matrices
+- store the corresponding error matrices
+- solve for a linear combination of Fock matrices that minimizes the residual
+
+The residual is the commutator in the orthonormal basis:
+
+\[
+\mathbf e = \mathbf X^T(\mathbf F \mathbf P \mathbf S - \mathbf S \mathbf P \mathbf F)\mathbf X
+\]
+
+When the SCF is converged, this should go to zero.
+
+This is implemented in the `DIISState` object in
+[src/base/types.h](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/base/types.h).
+
+## 9. Symmetry
+
+Planck can:
+
+- detect molecular point groups
+- rotate the molecule to a standard frame
+- construct symmetry-adapted AO block structure
+- label converged MOs by irreducible representation
+
+This logic lives in:
+
+- [src/symmetry/symmetry.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/symmetry/symmetry.cpp)
+- [src/symmetry/mo_symmetry.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/symmetry/mo_symmetry.cpp)
+
+The code uses `libmsym` for group theory tasks.
+
+The main implementation point is not “using symmetry to derive the HF
+equations,” but “using symmetry to block orbital spaces and label results in a
+chemically meaningful way.”
+
+## 10. MP2 Correlation Energy
+
+Second-order Moller-Plesset perturbation theory adds a perturbative correction
+to the Hartree-Fock energy.
+
+For closed-shell RHF, the standard spatial-orbital expression is:
+
+\[
+E_{MP2} =
+\sum_{ijab}
+\frac{(ia|jb)\left[2(ia|jb) - (ib|ja)\right]}
+{\varepsilon_i + \varepsilon_j - \varepsilon_a - \varepsilon_b}
+\]
+
+Indices:
+
+- `i, j`: occupied orbitals
+- `a, b`: virtual orbitals
+
+For UMP2, same-spin and opposite-spin channels are treated separately.
+
+### Where It Lives
+
+- [src/post_hf/mp2.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/post_hf/mp2.cpp)
+- [src/post_hf/mp2.h](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/post_hf/mp2.h)
+- [src/post_hf/integrals.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/post_hf/integrals.cpp)
+- [src/post_hf/integrals.h](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/post_hf/integrals.h)
+
+The post-HF integral helper code does AO to MO tensor transformations. That is
+needed because MP2 is naturally expressed in MO-space two-electron integrals,
+while SCF and integrals are generated in AO space.
+
+### MP2 Gradient Infrastructure
+
+Files:
+
+- [src/post_hf/mp2_gradient.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/post_hf/mp2_gradient.cpp)
+- [src/post_hf/mp2_gradient.h](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/post_hf/mp2_gradient.h)
+- [src/post_hf/rhf_response.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/post_hf/rhf_response.cpp)
+- [src/post_hf/rhf_response.h](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/post_hf/rhf_response.h)
+
+This code now contains:
+
+- RMP2 amplitudes
+- unrelaxed MP2 one-particle density pieces
+- RHF response matrix construction
+- MP2 Z-vector source terms
+- MP2 relaxed-density helpers
+
+But the production `compute_rmp2_gradient` entry point still uses numerical
+central differences, not the fully assembled analytic MP2 Lagrangian.
+
+That distinction is important for both science and software maintenance.
+
+## 11. Active-Space Methods: CASSCF and RASSCF
+
+CASSCF combines:
+
+- a CI problem in an active orbital space
+- orbital optimization outside and inside that space
+
+The core idea is that the wavefunction is no longer a single determinant:
+
+\[
+|\Psi\rangle = \sum_I c_I |D_I\rangle
+\]
+
+where the determinants `|D_I>` span the active space.
+
+The energy is optimized with respect to:
+
+- CI coefficients
+- orbital rotations
+
+Planck’s implementation is in:
+
+- [src/post_hf/casscf.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/post_hf/casscf.cpp)
+- [src/post_hf/casscf.h](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/post_hf/casscf.h)
+
+Main ingredients:
+
+- active-space selection
+- determinant generation
+- exact CI diagonalization in the active space
+- 1-RDM and 2-RDM construction
+- orbital gradient evaluation
+- macro-iterations for orbital optimization
+
+The recent fixes in this area centered on:
+
+- making the initial CI energy variational relative to RHF
+- repairing density reconstruction
+- stabilizing orbital updates
+
+From a teaching perspective, the most important concept is:
+
+- HF optimizes a single determinant
+- CASSCF optimizes both multiconfigurational CI coefficients and orbitals
+
+## 12. Analytic Nuclear Gradients
+
+For RHF and UHF, Planck computes analytic nuclear gradients.
+
+The RHF gradient has several contributions:
+
+1. one-electron derivative terms
+2. nuclear-attraction center derivatives
+3. two-electron ERI derivative terms
+4. Pulay overlap terms
+5. nuclear repulsion derivative
+
+The code explains this directly in
+[src/gradient/gradient.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/gradient/gradient.cpp).
+
+Symbolically:
+
+\[
+\frac{dE}{dR_A}
+=
+\sum_{\mu\nu} P_{\mu\nu}\frac{dh_{\mu\nu}}{dR_A}
++
+\frac{1}{2}\sum_{\mu\nu\lambda\sigma}\Gamma_{\mu\nu\lambda\sigma}
+\frac{d(\mu\nu|\lambda\sigma)}{dR_A}
+ E_{Pulay}
+ \frac{dE_{nuc}}{dR_A}
+\]
+
+The Pulay term is needed because the AO basis itself depends on nuclear
+positions. In a finite atom-centered basis, moving nuclei changes the basis
+functions, so there are extra overlap-related contributions even when the
+orbital coefficients are variationally optimized.
+
+### Where It Lives
+
+- [src/gradient/gradient.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/gradient/gradient.cpp)
+- [src/integrals/os.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/integrals/os.cpp)
+
+Recent refactoring added a reusable closed-shell derivative assembly helper that
+takes:
+
+- density matrix `P`
+- energy-weighted density `W`
+- a generic two-particle contraction function `Gamma`
+
+That was done specifically to make future correlated gradients easier to plug
+in without duplicating the entire RHF derivative engine.
+
+### UHF Gradient
+
+The UHF gradient is similar but uses separate alpha and beta densities and the
+appropriate spin-resolved two-particle structure.
+
+### Current RMP2 Gradient Status
+
+The current public `RMP2` gradient path:
+
+- recomputes the total MP2 energy at slightly displaced geometries
+- forms a central difference
+
+This is numerically useful but not a true analytic gradient.
+
+## 13. Geometry Optimization
+
+Planck supports geometry optimization in:
+
+- Cartesian coordinates
+- internal coordinates
+
+Files:
+
+- [src/opt/geomopt.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/opt/geomopt.cpp)
+- [src/opt/intcoords.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/opt/intcoords.cpp)
+
+### Cartesian Optimization
+
+Uses an L-BFGS strategy on the flattened Cartesian coordinate vector.
+
+Why L-BFGS?
+
+- full BFGS stores an approximate Hessian explicitly
+- that becomes expensive for larger systems
+- L-BFGS stores only recent update history
+
+### Internal-Coordinate Optimization
+
+Uses generalized internal coordinates:
+
+- bond stretches
+- angle bends
+- torsions
+
+Why internal coordinates?
+
+- they align better with chemically relevant motions
+- optimization often converges in fewer steps
+- constraints are much easier to impose naturally
+
+The internal-coordinate machinery uses:
+
+- a Wilson B matrix
+- generalized inverse / back-transformation steps
+- Schlegel-style microiterations
+
+## 14. Vibrational Frequencies and Hessians
+
+Files:
+
+- [src/freq/hessian.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/freq/hessian.cpp)
+- [src/freq/hessian.h](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/freq/hessian.h)
+
+The Hessian is obtained by finite differences of analytic gradients.
+
+That is a common compromise:
+
+- gradients are much cheaper and more reliable than total-energy Hessians
+- full analytic Hessians are substantially more complicated
+
+Workflow:
+
+1. displace each Cartesian coordinate positively and negatively
+2. compute analytic gradients
+3. build the Hessian by central differences
+4. mass-weight
+5. project translations and rotations
+6. diagonalize
+7. convert eigenvalues into frequencies
+
+This yields:
+
+- vibrational frequencies
+- normal modes
+- zero-point energy
+
+## 15. Checkpointing and Restart
+
+Files:
+
+- [src/io/checkpoint.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/io/checkpoint.cpp)
+- [src/io/checkpoint.h](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/io/checkpoint.h)
+
+The checkpoint system stores:
+
+- density data
+- geometry
+- basis-related data
+- optimization metadata
+
+It supports:
+
+- density restart in the same basis
+- full geometry + density restart
+- cross-basis projection using overlap-based techniques
+
+Pedagogically, this is a good example of how practical electronic structure
+codes reduce wall time by reusing chemically meaningful state.
+
+## 16. Execution Flow of a Typical Run
+
+The main calculation path in
+[src/driver.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/driver.cpp)
+looks like this:
+
+1. parse the input file
+2. construct `Calculator`
+3. convert coordinates to internal Bohr form
+4. optionally restore checkpoint geometry
+5. detect symmetry and standard orientation
+6. read the basis set
+7. initialize matrices and options
+8. build shell pairs
+9. compute one-electron integrals
+10. run SCF
+11. optionally run MP2 or CASSCF/RASSCF
+12. optionally compute gradient
+13. optionally run geometry optimization
+14. optionally run frequency analysis
+15. optionally write checkpoint
+
+This ordering is why `driver.cpp` is the best “map file” for new contributors.
+
+## 17. Teaching Map: How Theory Matches Functions
+
+Use this section as a quick lookup table.
+
+| Theory topic | Main implementation files |
+|---|---|
+| molecule/options/state | [src/base/types.h](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/base/types.h) |
+| input parsing | [src/io/io.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/io/io.cpp) |
+| basis parsing | [src/basis/basis.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/basis/basis.cpp) |
+| shell-pair construction | [src/integrals/shellpair.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/integrals/shellpair.cpp) |
+| one-electron integrals | [src/integrals/os.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/integrals/os.cpp) |
+| ERIs and Fock builds | [src/integrals/os.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/integrals/os.cpp) |
+| RHF/UHF SCF | [src/scf/scf.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/scf/scf.cpp) |
+| symmetry and MO labels | [src/symmetry/symmetry.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/symmetry/symmetry.cpp), [src/symmetry/mo_symmetry.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/symmetry/mo_symmetry.cpp) |
+| MP2 energy | [src/post_hf/mp2.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/post_hf/mp2.cpp) |
+| MP2 response groundwork | [src/post_hf/mp2_gradient.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/post_hf/mp2_gradient.cpp), [src/post_hf/rhf_response.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/post_hf/rhf_response.cpp) |
+| CASSCF/RASSCF | [src/post_hf/casscf.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/post_hf/casscf.cpp) |
+| analytic HF gradients | [src/gradient/gradient.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/gradient/gradient.cpp) |
+| geometry optimization | [src/opt/geomopt.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/opt/geomopt.cpp) |
+| internal coordinates | [src/opt/intcoords.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/opt/intcoords.cpp) |
+| vibrational analysis | [src/freq/hessian.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/freq/hessian.cpp) |
+| checkpointing | [src/io/checkpoint.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/io/checkpoint.cpp) |
+
+## 18. Limitations and Honest Status Notes
+
+This is the section a teacher or contributor should read before presenting the
+program as “finished.”
+
+- RHF and UHF are mature enough for small teaching calculations.
+- MP2 energies are implemented for RHF and UHF.
+- RHF and UHF analytic gradients are implemented.
+- The public RMP2 gradient path is still numerical, not fully analytic.
+- The code contains partial response-theory infrastructure for future analytic
+  RMP2 gradients, but the final Lagrangian assembly is not yet wired into the
+  production gradient entry point.
+- CASSCF and RASSCF are present and the recently fixed cases now behave
+  variationally in the tested inputs.
+- Hessians are finite-difference of gradients, not fully analytic second
+  derivatives.
+
+## 19. How to Study This Codebase Efficiently
+
+Recommended reading order:
+
+1. [src/base/types.h](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/base/types.h)
+2. [src/driver.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/driver.cpp)
+3. [src/io/io.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/io/io.cpp)
+4. [src/scf/scf.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/scf/scf.cpp)
+5. [src/integrals/os.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/integrals/os.cpp)
+6. [src/gradient/gradient.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/gradient/gradient.cpp)
+7. [src/post_hf/mp2.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/post_hf/mp2.cpp)
+8. [src/post_hf/casscf.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/post_hf/casscf.cpp)
+9. [src/opt/geomopt.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/opt/geomopt.cpp)
+10. [src/freq/hessian.cpp](/Users/hemanthharidas/Desktop/codes/planck-refactored/src/freq/hessian.cpp)
+
+This order follows the dependency graph from basic state and control flow to
+methods and then to downstream workflows.
+
+## 20. Summary
+
+Planck is a compact but nontrivial electronic-structure code. It is useful for
+teaching because the theory-to-code mapping is still visible:
+
+- basis functions become shell and primitive objects
+- integrals become explicit recursive kernels
+- SCF becomes a density-Fock fixed-point iteration
+- DIIS becomes a small linear algebra problem on stored residuals
+- MP2 becomes AO-to-MO integral transformation plus perturbative energy sums
+- CASSCF becomes CI + orbital optimization + reduced density matrices
+- gradients become derivative integral contractions plus Pulay terms
+- geometry optimization becomes an iterative minimization around those
+  gradients
+
+That transparency is the main educational value of the codebase.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,26 @@
+# Documentation Export
+
+The main teaching document is:
+
+- `docs/PLANCK_TEACHING_GUIDE.md`
+
+To export it as a standalone static webpage:
+
+```bash
+python3 docs/build_teaching_site.py
+```
+
+This writes:
+
+- `docs/site/index.html`
+
+You can also use the CMake helper target:
+
+```bash
+cmake --build build --target teaching-site
+```
+
+The exporter is intentionally lightweight and repository-local. It does not
+require MkDocs, Sphinx, or a JavaScript bundler. The generated page is a single
+HTML file with embedded CSS, so it can be hosted from any static file server or
+opened directly in a browser.

--- a/docs/build_teaching_site.py
+++ b/docs/build_teaching_site.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import html
+import re
+from pathlib import Path
+
+
+def slugify(text: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9]+", "-", text.strip().lower()).strip("-")
+    return slug or "section"
+
+
+def inline_format(text: str) -> str:
+    text = html.escape(text)
+    text = re.sub(r"`([^`]+)`", r"<code>\1</code>", text)
+    text = re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", text)
+    text = re.sub(r"\*([^*]+)\*", r"<em>\1</em>", text)
+    text = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r'<a href="\2">\1</a>', text)
+    return text
+
+
+def render_markdown(markdown_text: str) -> tuple[str, list[tuple[int, str, str]]]:
+    lines = markdown_text.splitlines()
+    output: list[str] = []
+    toc: list[tuple[int, str, str]] = []
+    in_code = False
+    code_lang = ""
+    in_list = False
+    paragraph: list[str] = []
+
+    def flush_paragraph() -> None:
+        nonlocal paragraph
+        if paragraph:
+            text = " ".join(part.strip() for part in paragraph if part.strip())
+            if text:
+                output.append(f"<p>{inline_format(text)}</p>")
+            paragraph = []
+
+    def close_list() -> None:
+        nonlocal in_list
+        if in_list:
+            output.append("</ul>")
+            in_list = False
+
+    for raw_line in lines:
+        line = raw_line.rstrip("\n")
+
+        if line.startswith("```"):
+            flush_paragraph()
+            close_list()
+            if not in_code:
+                in_code = True
+                code_lang = line[3:].strip()
+                cls = f' class="language-{html.escape(code_lang)}"' if code_lang else ""
+                output.append(f"<pre><code{cls}>")
+            else:
+                in_code = False
+                output.append("</code></pre>")
+            continue
+
+        if in_code:
+            output.append(html.escape(line))
+            continue
+
+        if not line.strip():
+            flush_paragraph()
+            close_list()
+            continue
+
+        heading = re.match(r"^(#{1,6})\s+(.*)$", line)
+        if heading:
+            flush_paragraph()
+            close_list()
+            level = len(heading.group(1))
+            text = heading.group(2).strip()
+            anchor = slugify(text)
+            toc.append((level, text, anchor))
+            output.append(
+                f'<h{level} id="{anchor}">{inline_format(text)}</h{level}>'
+            )
+            continue
+
+        if line.startswith("- "):
+            flush_paragraph()
+            if not in_list:
+                output.append("<ul>")
+                in_list = True
+            output.append(f"<li>{inline_format(line[2:].strip())}</li>")
+            continue
+
+        if re.match(r"^\d+\.\s+", line):
+            flush_paragraph()
+            close_list()
+            output.append(f"<p>{inline_format(line)}</p>")
+            continue
+
+        if line.startswith("|") and line.endswith("|"):
+            flush_paragraph()
+            close_list()
+            cells = [inline_format(cell.strip()) for cell in line.strip("|").split("|")]
+            if all(re.fullmatch(r"[-: ]+", cell.replace("&amp;", "&")) for cell in cells):
+                continue
+            row = "".join(f"<td>{cell}</td>" for cell in cells)
+            if not output or not output[-1].startswith("<table"):
+                output.append("<table>")
+                output.append("<tbody>")
+            output.append(f"<tr>{row}</tr>")
+            continue
+
+        if output and output[-1] == "</tbody>" and not line.startswith("|"):
+            output.append("</table>")
+
+        paragraph.append(line)
+
+    flush_paragraph()
+    close_list()
+
+    if output and output[-1] == "</tbody>":
+        output.append("</table>")
+
+    html_body = "\n".join(output).replace("<table>\n<tbody>\n", "<table>\n<tbody>\n")
+    html_body = html_body.replace("</tbody>\n<table>", "</tbody>\n</table>\n<table>")
+    html_body = html_body.replace("<table>\n<tbody>", "<table>\n<tbody>")
+    if "<table>" in html_body and "</tbody>" not in html_body:
+        html_body += "\n</tbody>\n</table>"
+    if "<tbody>" in html_body and "</table>" not in html_body:
+        html_body += "\n</table>"
+
+    return html_body, toc
+
+
+def build_toc(toc: list[tuple[int, str, str]]) -> str:
+    items = []
+    for level, text, anchor in toc:
+        cls = f"toc-level-{level}"
+        items.append(
+            f'<li class="{cls}"><a href="#{anchor}">{html.escape(text)}</a></li>'
+        )
+    return "<ul>\n" + "\n".join(items) + "\n</ul>"
+
+
+def page_template(title: str, toc_html: str, content_html: str) -> str:
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{html.escape(title)}</title>
+  <style>
+    :root {{
+      --bg: #f6f1e8;
+      --panel: #fffdf8;
+      --ink: #1d2b36;
+      --muted: #566472;
+      --accent: #9a3d22;
+      --rule: #dbcdb9;
+      --code-bg: #f2ece2;
+      --shadow: 0 18px 60px rgba(42, 33, 20, 0.08);
+    }}
+    * {{ box-sizing: border-box; }}
+    body {{
+      margin: 0;
+      font-family: Georgia, "Iowan Old Style", "Palatino Linotype", serif;
+      color: var(--ink);
+      background:
+        radial-gradient(circle at top left, rgba(154, 61, 34, 0.08), transparent 22rem),
+        linear-gradient(180deg, #fbf7f0 0%, var(--bg) 100%);
+      line-height: 1.65;
+    }}
+    .page {{
+      max-width: 1280px;
+      margin: 0 auto;
+      padding: 32px 20px 56px;
+    }}
+    .hero {{
+      background: linear-gradient(135deg, rgba(154, 61, 34, 0.95), rgba(123, 53, 31, 0.92));
+      color: #fff9f2;
+      border-radius: 24px;
+      padding: 28px 30px;
+      box-shadow: var(--shadow);
+      margin-bottom: 24px;
+    }}
+    .hero h1 {{
+      margin: 0 0 8px;
+      font-size: clamp(2rem, 3vw, 3.2rem);
+      line-height: 1.1;
+    }}
+    .hero p {{
+      margin: 0;
+      max-width: 65ch;
+      color: rgba(255, 249, 242, 0.92);
+    }}
+    .layout {{
+      display: grid;
+      grid-template-columns: 300px minmax(0, 1fr);
+      gap: 24px;
+      align-items: start;
+    }}
+    .sidebar, .content {{
+      background: var(--panel);
+      border: 1px solid var(--rule);
+      border-radius: 22px;
+      box-shadow: var(--shadow);
+    }}
+    .sidebar {{
+      position: sticky;
+      top: 20px;
+      padding: 22px 20px;
+    }}
+    .sidebar h2 {{
+      margin: 0 0 12px;
+      font-size: 1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--accent);
+    }}
+    .sidebar ul {{
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }}
+    .sidebar li {{
+      margin: 0;
+      padding: 0;
+    }}
+    .sidebar a {{
+      display: block;
+      padding: 6px 0;
+      color: var(--muted);
+      text-decoration: none;
+    }}
+    .sidebar a:hover {{
+      color: var(--accent);
+    }}
+    .toc-level-2 a {{ padding-left: 12px; }}
+    .toc-level-3 a {{ padding-left: 24px; font-size: 0.96rem; }}
+    .content {{
+      padding: 34px;
+    }}
+    .content h1, .content h2, .content h3, .content h4 {{
+      line-height: 1.2;
+      color: #13202b;
+      scroll-margin-top: 24px;
+    }}
+    .content h1 {{
+      font-size: 2.1rem;
+      padding-bottom: 10px;
+      border-bottom: 1px solid var(--rule);
+    }}
+    .content h2 {{
+      font-size: 1.55rem;
+      margin-top: 2.3rem;
+      padding-top: 0.2rem;
+    }}
+    .content h3 {{
+      font-size: 1.18rem;
+      margin-top: 1.8rem;
+    }}
+    .content p, .content li {{
+      font-size: 1.02rem;
+    }}
+    .content code {{
+      background: var(--code-bg);
+      border: 1px solid #e0d7c9;
+      border-radius: 6px;
+      padding: 0.08rem 0.35rem;
+      font-family: "SFMono-Regular", "Menlo", "Consolas", monospace;
+      font-size: 0.94em;
+    }}
+    .content pre {{
+      background: #201a17;
+      color: #f8efe5;
+      border-radius: 16px;
+      padding: 18px;
+      overflow-x: auto;
+    }}
+    .content pre code {{
+      background: transparent;
+      border: 0;
+      padding: 0;
+      color: inherit;
+    }}
+    .content table {{
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.2rem 0;
+      font-size: 0.96rem;
+    }}
+    .content td {{
+      border: 1px solid var(--rule);
+      padding: 10px 12px;
+      vertical-align: top;
+    }}
+    .content a {{
+      color: var(--accent);
+    }}
+    @media (max-width: 980px) {{
+      .layout {{
+        grid-template-columns: 1fr;
+      }}
+      .sidebar {{
+        position: static;
+      }}
+      .content {{
+        padding: 24px 18px;
+      }}
+    }}
+  </style>
+</head>
+<body>
+  <div class="page">
+    <section class="hero">
+      <h1>{html.escape(title)}</h1>
+      <p>A teaching-first, theory-linked walkthrough of the Planck codebase and its current quantum chemistry methods.</p>
+    </section>
+    <div class="layout">
+      <aside class="sidebar">
+        <h2>Contents</h2>
+        {toc_html}
+      </aside>
+      <main class="content">
+        {content_html}
+      </main>
+    </div>
+  </div>
+</body>
+</html>
+"""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build a static HTML page from the teaching guide markdown")
+    parser.add_argument("--input", default="docs/PLANCK_TEACHING_GUIDE.md")
+    parser.add_argument("--output", default="docs/site/index.html")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[1]
+    input_path = repo_root / args.input
+    output_path = repo_root / args.output
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    markdown_text = input_path.read_text(encoding="utf-8")
+    content_html, toc = render_markdown(markdown_text)
+    toc_html = build_toc(toc)
+    title = "Planck Teaching Guide"
+    output_path.write_text(page_template(title, toc_html, content_html), encoding="utf-8")
+    print(f"Wrote {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -1,0 +1,856 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Planck Teaching Guide</title>
+  <style>
+    :root {
+      --bg: #f6f1e8;
+      --panel: #fffdf8;
+      --ink: #1d2b36;
+      --muted: #566472;
+      --accent: #9a3d22;
+      --rule: #dbcdb9;
+      --code-bg: #f2ece2;
+      --shadow: 0 18px 60px rgba(42, 33, 20, 0.08);
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: Georgia, "Iowan Old Style", "Palatino Linotype", serif;
+      color: var(--ink);
+      background:
+        radial-gradient(circle at top left, rgba(154, 61, 34, 0.08), transparent 22rem),
+        linear-gradient(180deg, #fbf7f0 0%, var(--bg) 100%);
+      line-height: 1.65;
+    }
+    .page {
+      max-width: 1280px;
+      margin: 0 auto;
+      padding: 32px 20px 56px;
+    }
+    .hero {
+      background: linear-gradient(135deg, rgba(154, 61, 34, 0.95), rgba(123, 53, 31, 0.92));
+      color: #fff9f2;
+      border-radius: 24px;
+      padding: 28px 30px;
+      box-shadow: var(--shadow);
+      margin-bottom: 24px;
+    }
+    .hero h1 {
+      margin: 0 0 8px;
+      font-size: clamp(2rem, 3vw, 3.2rem);
+      line-height: 1.1;
+    }
+    .hero p {
+      margin: 0;
+      max-width: 65ch;
+      color: rgba(255, 249, 242, 0.92);
+    }
+    .layout {
+      display: grid;
+      grid-template-columns: 300px minmax(0, 1fr);
+      gap: 24px;
+      align-items: start;
+    }
+    .sidebar, .content {
+      background: var(--panel);
+      border: 1px solid var(--rule);
+      border-radius: 22px;
+      box-shadow: var(--shadow);
+    }
+    .sidebar {
+      position: sticky;
+      top: 20px;
+      padding: 22px 20px;
+    }
+    .sidebar h2 {
+      margin: 0 0 12px;
+      font-size: 1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--accent);
+    }
+    .sidebar ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
+    .sidebar li {
+      margin: 0;
+      padding: 0;
+    }
+    .sidebar a {
+      display: block;
+      padding: 6px 0;
+      color: var(--muted);
+      text-decoration: none;
+    }
+    .sidebar a:hover {
+      color: var(--accent);
+    }
+    .toc-level-2 a { padding-left: 12px; }
+    .toc-level-3 a { padding-left: 24px; font-size: 0.96rem; }
+    .content {
+      padding: 34px;
+    }
+    .content h1, .content h2, .content h3, .content h4 {
+      line-height: 1.2;
+      color: #13202b;
+      scroll-margin-top: 24px;
+    }
+    .content h1 {
+      font-size: 2.1rem;
+      padding-bottom: 10px;
+      border-bottom: 1px solid var(--rule);
+    }
+    .content h2 {
+      font-size: 1.55rem;
+      margin-top: 2.3rem;
+      padding-top: 0.2rem;
+    }
+    .content h3 {
+      font-size: 1.18rem;
+      margin-top: 1.8rem;
+    }
+    .content p, .content li {
+      font-size: 1.02rem;
+    }
+    .content code {
+      background: var(--code-bg);
+      border: 1px solid #e0d7c9;
+      border-radius: 6px;
+      padding: 0.08rem 0.35rem;
+      font-family: "SFMono-Regular", "Menlo", "Consolas", monospace;
+      font-size: 0.94em;
+    }
+    .content pre {
+      background: #201a17;
+      color: #f8efe5;
+      border-radius: 16px;
+      padding: 18px;
+      overflow-x: auto;
+    }
+    .content pre code {
+      background: transparent;
+      border: 0;
+      padding: 0;
+      color: inherit;
+    }
+    .content table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.2rem 0;
+      font-size: 0.96rem;
+    }
+    .content td {
+      border: 1px solid var(--rule);
+      padding: 10px 12px;
+      vertical-align: top;
+    }
+    .content a {
+      color: var(--accent);
+    }
+    @media (max-width: 980px) {
+      .layout {
+        grid-template-columns: 1fr;
+      }
+      .sidebar {
+        position: static;
+      }
+      .content {
+        padding: 24px 18px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <section class="hero">
+      <h1>Planck Teaching Guide</h1>
+      <p>A teaching-first, theory-linked walkthrough of the Planck codebase and its current quantum chemistry methods.</p>
+    </section>
+    <div class="layout">
+      <aside class="sidebar">
+        <h2>Contents</h2>
+        <ul>
+<li class="toc-level-1"><a href="#planck-teaching-guide">Planck Teaching Guide</a></li>
+<li class="toc-level-2"><a href="#1-what-planck-is">1. What Planck Is</a></li>
+<li class="toc-level-2"><a href="#2-big-picture-architecture">2. Big-Picture Architecture</a></li>
+<li class="toc-level-3"><a href="#directory-map">Directory Map</a></li>
+<li class="toc-level-3"><a href="#src-base">`src/base`</a></li>
+<li class="toc-level-3"><a href="#src-io">`src/io`</a></li>
+<li class="toc-level-3"><a href="#src-lookup">`src/lookup`</a></li>
+<li class="toc-level-3"><a href="#src-basis">`src/basis`</a></li>
+<li class="toc-level-3"><a href="#src-integrals">`src/integrals`</a></li>
+<li class="toc-level-3"><a href="#src-scf">`src/scf`</a></li>
+<li class="toc-level-3"><a href="#src-symmetry">`src/symmetry`</a></li>
+<li class="toc-level-3"><a href="#src-post-hf">`src/post_hf`</a></li>
+<li class="toc-level-3"><a href="#src-gradient">`src/gradient`</a></li>
+<li class="toc-level-3"><a href="#src-opt">`src/opt`</a></li>
+<li class="toc-level-3"><a href="#src-freq">`src/freq`</a></li>
+<li class="toc-level-3"><a href="#tests">`tests`</a></li>
+<li class="toc-level-2"><a href="#3-core-data-structures">3. Core Data Structures</a></li>
+<li class="toc-level-3"><a href="#molecule">`Molecule`</a></li>
+<li class="toc-level-3"><a href="#basis">`Basis`</a></li>
+<li class="toc-level-3"><a href="#datascf-and-spinchannel">`DataSCF` and `SpinChannel`</a></li>
+<li class="toc-level-3"><a href="#diisstate">`DIISState`</a></li>
+<li class="toc-level-3"><a href="#calculator">`Calculator`</a></li>
+<li class="toc-level-2"><a href="#4-theoretical-foundations">4. Theoretical Foundations</a></li>
+<li class="toc-level-2"><a href="#5-gaussian-basis-functions">5. Gaussian Basis Functions</a></li>
+<li class="toc-level-2"><a href="#6-one-and-two-electron-integrals">6. One- and Two-Electron Integrals</a></li>
+<li class="toc-level-3"><a href="#conventional-vs-direct-scf">Conventional vs Direct SCF</a></li>
+<li class="toc-level-2"><a href="#7-hartree-fock-theory">7. Hartree-Fock Theory</a></li>
+<li class="toc-level-3"><a href="#where-it-lives-in-code">Where It Lives in Code</a></li>
+<li class="toc-level-3"><a href="#scf-cycle">SCF Cycle</a></li>
+<li class="toc-level-2"><a href="#8-diis-convergence-acceleration">8. DIIS Convergence Acceleration</a></li>
+<li class="toc-level-2"><a href="#9-symmetry">9. Symmetry</a></li>
+<li class="toc-level-2"><a href="#10-mp2-correlation-energy">10. MP2 Correlation Energy</a></li>
+<li class="toc-level-3"><a href="#where-it-lives">Where It Lives</a></li>
+<li class="toc-level-3"><a href="#mp2-gradient-infrastructure">MP2 Gradient Infrastructure</a></li>
+<li class="toc-level-2"><a href="#11-active-space-methods-casscf-and-rasscf">11. Active-Space Methods: CASSCF and RASSCF</a></li>
+<li class="toc-level-2"><a href="#12-analytic-nuclear-gradients">12. Analytic Nuclear Gradients</a></li>
+<li class="toc-level-3"><a href="#where-it-lives">Where It Lives</a></li>
+<li class="toc-level-3"><a href="#uhf-gradient">UHF Gradient</a></li>
+<li class="toc-level-3"><a href="#current-rmp2-gradient-status">Current RMP2 Gradient Status</a></li>
+<li class="toc-level-2"><a href="#13-geometry-optimization">13. Geometry Optimization</a></li>
+<li class="toc-level-3"><a href="#cartesian-optimization">Cartesian Optimization</a></li>
+<li class="toc-level-3"><a href="#internal-coordinate-optimization">Internal-Coordinate Optimization</a></li>
+<li class="toc-level-2"><a href="#14-vibrational-frequencies-and-hessians">14. Vibrational Frequencies and Hessians</a></li>
+<li class="toc-level-2"><a href="#15-checkpointing-and-restart">15. Checkpointing and Restart</a></li>
+<li class="toc-level-2"><a href="#16-execution-flow-of-a-typical-run">16. Execution Flow of a Typical Run</a></li>
+<li class="toc-level-2"><a href="#17-teaching-map-how-theory-matches-functions">17. Teaching Map: How Theory Matches Functions</a></li>
+<li class="toc-level-2"><a href="#18-limitations-and-honest-status-notes">18. Limitations and Honest Status Notes</a></li>
+<li class="toc-level-2"><a href="#19-how-to-study-this-codebase-efficiently">19. How to Study This Codebase Efficiently</a></li>
+<li class="toc-level-2"><a href="#20-summary">20. Summary</a></li>
+</ul>
+      </aside>
+      <main class="content">
+        <h1 id="planck-teaching-guide">Planck Teaching Guide</h1>
+<p>This document is a teaching-oriented guide to the <code>planck-refactored</code> codebase. It explains what the program does, how the major algorithms work, how the source tree is organized, and how the quantum-chemistry theory maps onto the implementation.</p>
+<p>The intended audience is:</p>
+<ul>
+<li>a student learning Hartree-Fock and post-Hartree-Fock methods</li>
+<li>a contributor trying to understand where to change the code</li>
+<li>a researcher who wants to audit the mathematical and software structure</li>
+</ul>
+<p>The guide is written in the same order that a calculation usually happens in the executable:</p>
+<p>1. parse the input</p>
+<p>2. build the molecule and basis</p>
+<p>3. generate shell pairs and integrals</p>
+<p>4. solve SCF</p>
+<p>5. optionally run correlation methods</p>
+<p>6. optionally compute gradients, optimize geometry, or build vibrational data</p>
+<h2 id="1-what-planck-is">1. What Planck Is</h2>
+<p>Planck is a compact quantum chemistry program centered on Gaussian-basis electronic structure methods. At the moment it implements:</p>
+<ul>
+<li>RHF and UHF self-consistent field theory</li>
+<li>Obara-Saika one- and two-electron integrals</li>
+<li>conventional and direct SCF modes</li>
+<li>DIIS acceleration</li>
+<li>point-group detection and MO irrep labeling</li>
+<li>RMP2 and UMP2 correlation energies</li>
+<li>RHF and UHF analytic nuclear gradients</li>
+<li>geometry optimization in Cartesian and internal coordinates</li>
+<li>semi-numerical Hessians and vibrational frequencies</li>
+<li>CASSCF and RASSCF active-space calculations</li>
+<li>binary checkpoint restart support</li>
+</ul>
+<p>There is also in-progress infrastructure for a true analytic RMP2 gradient:</p>
+<ul>
+<li>RHF response matrix construction</li>
+<li>MP2 amplitudes</li>
+<li>MP2 unrelaxed density builders</li>
+<li>MP2 Z-vector and relaxed-density helpers</li>
+</ul>
+<p>Important implementation status:</p>
+<ul>
+<li>RHF and UHF gradients are analytic</li>
+<li>the current public RMP2 gradient path is still central-difference total-energy</li>
+<p>differentiation, even though the codebase now contains some response-theory building blocks for a future analytic implementation</p>
+</ul>
+<h2 id="2-big-picture-architecture">2. Big-Picture Architecture</h2>
+<p>At a high level, the executable in <a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/driver.cpp">src/driver.cpp</a> orchestrates everything.</p>
+<p>The main data object is <code>HartreeFock::Calculator</code> in <a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/base/types.h">src/base/types.h</a>. It holds:</p>
+<ul>
+<li>input options</li>
+<li>molecule and coordinates</li>
+<li>basis and shell information</li>
+<li>SCF state</li>
+<li>integral tensors and one-electron matrices</li>
+<li>post-HF energies and active-space results</li>
+<li>gradient, Hessian, and geometry optimization state</li>
+</ul>
+<p>Conceptually, <code>Calculator</code> is the shared world-state for one calculation.</p>
+<h3 id="directory-map">Directory Map</h3>
+<h3 id="src-base"><code>src/base</code></h3>
+<ul>
+<li><code>types.h</code>: central enums, options, molecule/basis containers, SCF state, DIIS</li>
+<p>state, checkpoint-related data, and the <code>Calculator</code> object</p>
+<li><code>tables.h</code>: chemical or optimization helper tables</li>
+<li><code>basis.h.in</code> and generated <code>basis.h</code>: compiled-in basis path configuration</li>
+</ul>
+<h3 id="src-io"><code>src/io</code></h3>
+<ul>
+<li><code>io.cpp/.h</code>: input parsing from <code>.hfinp</code></li>
+<li><code>checkpoint.cpp/.h</code>: binary checkpoint load/save and projection support</li>
+<li><code>logging.h</code>: formatted program output</li>
+</ul>
+<h3 id="src-lookup"><code>src/lookup</code></h3>
+<ul>
+<li>periodic-table and Boys-function support data</li>
+</ul>
+<h3 id="src-basis"><code>src/basis</code></h3>
+<ul>
+<li>Gaussian primitives, contractions, and <code>.gbs</code> basis parsing</li>
+</ul>
+<h3 id="src-integrals"><code>src/integrals</code></h3>
+<ul>
+<li>shell-pair generation</li>
+<li>Obara-Saika recursions for overlap, kinetic, nuclear attraction, ERIs</li>
+<li>derivative integral kernels for gradients</li>
+</ul>
+<h3 id="src-scf"><code>src/scf</code></h3>
+<ul>
+<li>orthogonalization</li>
+<li>initial density construction</li>
+<li>RHF and UHF SCF loops</li>
+</ul>
+<h3 id="src-symmetry"><code>src/symmetry</code></h3>
+<ul>
+<li>point-group detection through <code>libmsym</code></li>
+<li>symmetry-adapted orbital basis support</li>
+<li>MO irrep assignment</li>
+</ul>
+<h3 id="src-post-hf"><code>src/post_hf</code></h3>
+<ul>
+<li>MP2 energy code</li>
+<li>MP2 gradient-response support code</li>
+<li>CASSCF and RASSCF code</li>
+<li>AO to MO integral transformations</li>
+<li>RHF response matrix builders</li>
+</ul>
+<h3 id="src-gradient"><code>src/gradient</code></h3>
+<ul>
+<li>analytic RHF and UHF nuclear gradients</li>
+<li>current numerical RMP2 gradient driver</li>
+<li>shared closed-shell AO derivative contraction helper</li>
+</ul>
+<h3 id="src-opt"><code>src/opt</code></h3>
+<ul>
+<li>geometry optimization in Cartesian and internal coordinates</li>
+<li>generalized internal coordinate construction and constraint handling</li>
+</ul>
+<h3 id="src-freq"><code>src/freq</code></h3>
+<ul>
+<li>finite-difference Hessian and vibrational analysis</li>
+</ul>
+<h3 id="tests"><code>tests</code></h3>
+<ul>
+<li>manifest-driven executable regression tests</li>
+</ul>
+<h2 id="3-core-data-structures">3. Core Data Structures</h2>
+<p>The most important single file is <a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/base/types.h">src/base/types.h</a>.</p>
+<h3 id="molecule"><code>Molecule</code></h3>
+<p>The molecule object stores:</p>
+<ul>
+<li>atomic numbers</li>
+<li>charge and multiplicity</li>
+<li>input-frame coordinates</li>
+<li>standard-orientation coordinates</li>
+<li>flags such as whether coordinates are already in Bohr</li>
+</ul>
+<p>Two coordinate representations are important:</p>
+<ul>
+<li><code>coordinates</code>: user-facing geometry, often in Angstrom</li>
+<li><code>_standard</code> and <code>_coordinates</code>: internal Bohr-space geometry used by the</li>
+<p>integrals and optimization machinery</p>
+</ul>
+<h3 id="basis"><code>Basis</code></h3>
+<p>The basis object contains:</p>
+<ul>
+<li>shells</li>
+<li>basis functions / contracted Cartesian components</li>
+<li>bookkeeping like number of shells and number of basis functions</li>
+</ul>
+<h3 id="datascf-and-spinchannel"><code>DataSCF</code> and <code>SpinChannel</code></h3>
+<p>The SCF state stores, per spin channel:</p>
+<ul>
+<li>density matrix</li>
+<li>Fock matrix</li>
+<li>MO energies</li>
+<li>MO coefficients</li>
+<li>optional MO symmetry labels</li>
+</ul>
+<p>This is enough to reconstruct most later quantities.</p>
+<h3 id="diisstate"><code>DIISState</code></h3>
+<p>The DIIS object stores:</p>
+<ul>
+<li>a history of Fock matrices</li>
+<li>a history of Pulay error matrices</li>
+<li>the subspace dimension</li>
+</ul>
+<p>It then solves the standard augmented Pulay linear system to build an extrapolated Fock matrix.</p>
+<h3 id="calculator"><code>Calculator</code></h3>
+<p><code>Calculator</code> gathers everything together and also owns:</p>
+<ul>
+<li><code>_overlap</code> and <code>_hcore</code></li>
+<li><code>_eri</code> if conventional SCF has stored the AO ERI tensor</li>
+<li>energies</li>
+<li>gradient and Hessian storage</li>
+<li>active-space results such as natural occupations</li>
+<li>SAO blocking data for symmetry-aware diagonalization</li>
+</ul>
+<p>If you want to understand “where state lives,” it is almost always here.</p>
+<h2 id="4-theoretical-foundations">4. Theoretical Foundations</h2>
+<p>This section summarizes the theory behind the implemented methods and explains how the code mirrors that theory.</p>
+<h2 id="5-gaussian-basis-functions">5. Gaussian Basis Functions</h2>
+<p>The code works in an atom-centered Gaussian basis:</p>
+<p>\[ \chi_\mu(\mathbf r) = \sum_p d_{p\mu} \, (x-A_x)^{l_x}(y-A_y)^{l_y}(z-A_z)^{l_z} e^{-\alpha_p |\mathbf r-\mathbf A|^2} \]</p>
+<p>Why Gaussians?</p>
+<ul>
+<li>products of Gaussians on different centers are again Gaussians</li>
+<li>integrals can be reduced recursively</li>
+<li>this makes them practical for Hartree-Fock and post-HF methods</li>
+</ul>
+<p>The implementation details are split across:</p>
+<ul>
+<li><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/basis/basis.cpp">src/basis/basis.cpp</a></li>
+<li><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/basis/gaussian.cpp">src/basis/gaussian.cpp</a></li>
+<li><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/integrals/shellpair.h">src/integrals/shellpair.h</a></li>
+<li><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/integrals/shellpair.cpp">src/integrals/shellpair.cpp</a></li>
+</ul>
+<p><code>ShellPair</code> precomputes Gaussian-product data such as:</p>
+<ul>
+<li>combined exponent</li>
+<li>prefactors</li>
+<li>Gaussian product center</li>
+<li>displacement vectors needed in recurrence relations</li>
+</ul>
+<p>That is a classic quantum-chemistry optimization: precompute shell-pair data once and reuse it many times.</p>
+<h2 id="6-one-and-two-electron-integrals">6. One- and Two-Electron Integrals</h2>
+<p>Electronic structure in a Gaussian basis depends on several integral classes:</p>
+<ul>
+<li>overlap:</li>
+<p>\[ S_{\mu\nu} = \langle \chi_\mu | \chi_\nu \rangle \]</p>
+<li>kinetic:</li>
+<p>\[ T_{\mu\nu} = \left\langle \chi_\mu \left| -\frac{1}{2}\nabla^2 \right| \chi_\nu \right\rangle \]</p>
+<li>nuclear attraction:</li>
+<p>\[ V_{\mu\nu} = \sum_A \left\langle \chi_\mu \left| -\frac{Z_A}{r_A} \right| \chi_\nu \right\rangle \]</p>
+<li>electron repulsion:</li>
+<p>\[ (\mu\nu|\lambda\sigma) = \iint \chi_\mu(1)\chi_\nu(1)\frac{1}{r_{12}}\chi_\lambda(2)\chi_\sigma(2)\, d1\, d2 \]</p>
+</ul>
+<p>Planck computes these with Obara-Saika recursions in:</p>
+<ul>
+<li><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/integrals/os.cpp">src/integrals/os.cpp</a></li>
+<li><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/integrals/os.h">src/integrals/os.h</a></li>
+</ul>
+<p>The important implementation split is:</p>
+<ul>
+<li><code>_compute_1e(...)</code>: overlap and kinetic</li>
+<li><code>_compute_nuclear_attraction(...)</code>: nuclear attraction</li>
+<li><code>_compute_2e(...)</code>: full AO ERI tensor</li>
+<li><code>_compute_fock_rhf(...)</code> and <code>_compute_fock_uhf(...)</code>: ERI contraction into</li>
+<p>Coulomb and exchange contributions</p>
+</ul>
+<h3 id="conventional-vs-direct-scf">Conventional vs Direct SCF</h3>
+<p>There are two major strategies for ERIs:</p>
+<ul>
+<li>conventional SCF:</li>
+<p>build the full AO ERI tensor once and reuse it</p>
+<li>direct SCF:</li>
+<p>recompute or contract on the fly each iteration</p>
+</ul>
+<p>This is controlled in <a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/scf/scf.cpp">src/scf/scf.cpp</a>.</p>
+<p>Tradeoff:</p>
+<ul>
+<li>conventional is faster per SCF iteration</li>
+<li>direct uses less memory</li>
+</ul>
+<p>The code also uses Schwarz screening thresholds to skip negligible quartets.</p>
+<h2 id="7-hartree-fock-theory">7. Hartree-Fock Theory</h2>
+<p>Hartree-Fock approximates the many-electron wavefunction as a Slater determinant built from molecular orbitals.</p>
+<p>Each spatial orbital is expanded in the AO basis:</p>
+<p>\[ \phi_i = \sum_\mu C_{\mu i}\chi_\mu \]</p>
+<p>The RHF variational equations become the Roothaan equations:</p>
+<p>\[ \mathbf F \mathbf C = \mathbf S \mathbf C \boldsymbol \varepsilon \]</p>
+<p>where:</p>
+<ul>
+<li><code>S</code> is the overlap matrix</li>
+<li><code>F</code> is the Fock matrix</li>
+<li><code>C</code> contains molecular orbital coefficients</li>
+<li><code>ε</code> are orbital energies</li>
+</ul>
+<p>For RHF, the closed-shell density is:</p>
+<p>\[ P_{\mu\nu} = 2\sum_{i \in occ} C_{\mu i} C_{\nu i} \]</p>
+<p>and the Fock matrix is:</p>
+<p>\[ F_{\mu\nu} = H_{\mu\nu}^{core} + G_{\mu\nu} \]</p>
+<p>with:</p>
+<p>\[ G_{\mu\nu} = \sum_{\lambda\sigma} P_{\lambda\sigma} \left[(\mu\nu|\lambda\sigma) - \frac{1}{2}(\mu\lambda|\nu\sigma)\right] \]</p>
+<p>For UHF, alpha and beta densities are separate, and the exchange is spin-dependent.</p>
+<h3 id="where-it-lives-in-code">Where It Lives in Code</h3>
+<ul>
+<li><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/scf/scf.h">src/scf/scf.h</a></li>
+<li><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/scf/scf.cpp">src/scf/scf.cpp</a></li>
+</ul>
+<p>Important functions:</p>
+<ul>
+<li><code>build_orthogonalizer</code>: constructs \(S^{-1/2}\)</li>
+<li><code>initial_density</code>: core-Hamiltonian guess</li>
+<li><code>run_rhf</code></li>
+<li><code>run_uhf</code></li>
+</ul>
+<h3 id="scf-cycle">SCF Cycle</h3>
+<p>Each iteration does roughly this:</p>
+<p>1. build <code>G</code></p>
+<p>2. form <code>F = H + G</code></p>
+<p>3. compute energy</p>
+<p>4. optionally update DIIS</p>
+<p>5. diagonalize in an orthonormal basis</p>
+<p>6. rebuild density</p>
+<p>7. test convergence</p>
+<p>The orthogonalization step uses:</p>
+<p>\[ \mathbf X = \mathbf S^{-1/2} \]</p>
+<p>and diagonalizes:</p>
+<p>\[ \mathbf F&#x27; = \mathbf X^T \mathbf F \mathbf X \]</p>
+<p>then transforms back:</p>
+<p>\[ \mathbf C = \mathbf X \mathbf C&#x27; \]</p>
+<h2 id="8-diis-convergence-acceleration">8. DIIS Convergence Acceleration</h2>
+<p>Planck uses Pulay DIIS to accelerate SCF convergence.</p>
+<p>The key idea is:</p>
+<ul>
+<li>store several recent Fock matrices</li>
+<li>store the corresponding error matrices</li>
+<li>solve for a linear combination of Fock matrices that minimizes the residual</li>
+</ul>
+<p>The residual is the commutator in the orthonormal basis:</p>
+<p>\[ \mathbf e = \mathbf X^T(\mathbf F \mathbf P \mathbf S - \mathbf S \mathbf P \mathbf F)\mathbf X \]</p>
+<p>When the SCF is converged, this should go to zero.</p>
+<p>This is implemented in the <code>DIISState</code> object in <a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/base/types.h">src/base/types.h</a>.</p>
+<h2 id="9-symmetry">9. Symmetry</h2>
+<p>Planck can:</p>
+<ul>
+<li>detect molecular point groups</li>
+<li>rotate the molecule to a standard frame</li>
+<li>construct symmetry-adapted AO block structure</li>
+<li>label converged MOs by irreducible representation</li>
+</ul>
+<p>This logic lives in:</p>
+<ul>
+<li><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/symmetry/symmetry.cpp">src/symmetry/symmetry.cpp</a></li>
+<li><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/symmetry/mo_symmetry.cpp">src/symmetry/mo_symmetry.cpp</a></li>
+</ul>
+<p>The code uses <code>libmsym</code> for group theory tasks.</p>
+<p>The main implementation point is not “using symmetry to derive the HF equations,” but “using symmetry to block orbital spaces and label results in a chemically meaningful way.”</p>
+<h2 id="10-mp2-correlation-energy">10. MP2 Correlation Energy</h2>
+<p>Second-order Moller-Plesset perturbation theory adds a perturbative correction to the Hartree-Fock energy.</p>
+<p>For closed-shell RHF, the standard spatial-orbital expression is:</p>
+<p>\[ E_{MP2} = \sum_{ijab} \frac{(ia|jb)\left[2(ia|jb) - (ib|ja)\right]} {\varepsilon_i + \varepsilon_j - \varepsilon_a - \varepsilon_b} \]</p>
+<p>Indices:</p>
+<ul>
+<li><code>i, j</code>: occupied orbitals</li>
+<li><code>a, b</code>: virtual orbitals</li>
+</ul>
+<p>For UMP2, same-spin and opposite-spin channels are treated separately.</p>
+<h3 id="where-it-lives">Where It Lives</h3>
+<ul>
+<li><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/post_hf/mp2.cpp">src/post_hf/mp2.cpp</a></li>
+<li><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/post_hf/mp2.h">src/post_hf/mp2.h</a></li>
+<li><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/post_hf/integrals.cpp">src/post_hf/integrals.cpp</a></li>
+<li><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/post_hf/integrals.h">src/post_hf/integrals.h</a></li>
+</ul>
+<p>The post-HF integral helper code does AO to MO tensor transformations. That is needed because MP2 is naturally expressed in MO-space two-electron integrals, while SCF and integrals are generated in AO space.</p>
+<h3 id="mp2-gradient-infrastructure">MP2 Gradient Infrastructure</h3>
+<p>Files:</p>
+<ul>
+<li><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/post_hf/mp2_gradient.cpp">src/post_hf/mp2_gradient.cpp</a></li>
+<li><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/post_hf/mp2_gradient.h">src/post_hf/mp2_gradient.h</a></li>
+<li><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/post_hf/rhf_response.cpp">src/post_hf/rhf_response.cpp</a></li>
+<li><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/post_hf/rhf_response.h">src/post_hf/rhf_response.h</a></li>
+</ul>
+<p>This code now contains:</p>
+<ul>
+<li>RMP2 amplitudes</li>
+<li>unrelaxed MP2 one-particle density pieces</li>
+<li>RHF response matrix construction</li>
+<li>MP2 Z-vector source terms</li>
+<li>MP2 relaxed-density helpers</li>
+</ul>
+<p>But the production <code>compute_rmp2_gradient</code> entry point still uses numerical central differences, not the fully assembled analytic MP2 Lagrangian.</p>
+<p>That distinction is important for both science and software maintenance.</p>
+<h2 id="11-active-space-methods-casscf-and-rasscf">11. Active-Space Methods: CASSCF and RASSCF</h2>
+<p>CASSCF combines:</p>
+<ul>
+<li>a CI problem in an active orbital space</li>
+<li>orbital optimization outside and inside that space</li>
+</ul>
+<p>The core idea is that the wavefunction is no longer a single determinant:</p>
+<p>\[ |\Psi\rangle = \sum_I c_I |D_I\rangle \]</p>
+<p>where the determinants <code>|D_I&gt;</code> span the active space.</p>
+<p>The energy is optimized with respect to:</p>
+<ul>
+<li>CI coefficients</li>
+<li>orbital rotations</li>
+</ul>
+<p>Planck’s implementation is in:</p>
+<ul>
+<li><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/post_hf/casscf.cpp">src/post_hf/casscf.cpp</a></li>
+<li><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/post_hf/casscf.h">src/post_hf/casscf.h</a></li>
+</ul>
+<p>Main ingredients:</p>
+<ul>
+<li>active-space selection</li>
+<li>determinant generation</li>
+<li>exact CI diagonalization in the active space</li>
+<li>1-RDM and 2-RDM construction</li>
+<li>orbital gradient evaluation</li>
+<li>macro-iterations for orbital optimization</li>
+</ul>
+<p>The recent fixes in this area centered on:</p>
+<ul>
+<li>making the initial CI energy variational relative to RHF</li>
+<li>repairing density reconstruction</li>
+<li>stabilizing orbital updates</li>
+</ul>
+<p>From a teaching perspective, the most important concept is:</p>
+<ul>
+<li>HF optimizes a single determinant</li>
+<li>CASSCF optimizes both multiconfigurational CI coefficients and orbitals</li>
+</ul>
+<h2 id="12-analytic-nuclear-gradients">12. Analytic Nuclear Gradients</h2>
+<p>For RHF and UHF, Planck computes analytic nuclear gradients.</p>
+<p>The RHF gradient has several contributions:</p>
+<p>1. one-electron derivative terms</p>
+<p>2. nuclear-attraction center derivatives</p>
+<p>3. two-electron ERI derivative terms</p>
+<p>4. Pulay overlap terms</p>
+<p>5. nuclear repulsion derivative</p>
+<p>The code explains this directly in <a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/gradient/gradient.cpp">src/gradient/gradient.cpp</a>.</p>
+<p>Symbolically:</p>
+<p>\[ \frac{dE}{dR_A} = \sum_{\mu\nu} P_{\mu\nu}\frac{dh_{\mu\nu}}{dR_A} + \frac{1}{2}\sum_{\mu\nu\lambda\sigma}\Gamma_{\mu\nu\lambda\sigma} \frac{d(\mu\nu|\lambda\sigma)}{dR_A} E_{Pulay} \frac{dE_{nuc}}{dR_A} \]</p>
+<p>The Pulay term is needed because the AO basis itself depends on nuclear positions. In a finite atom-centered basis, moving nuclei changes the basis functions, so there are extra overlap-related contributions even when the orbital coefficients are variationally optimized.</p>
+<h3 id="where-it-lives">Where It Lives</h3>
+<ul>
+<li><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/gradient/gradient.cpp">src/gradient/gradient.cpp</a></li>
+<li><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/integrals/os.cpp">src/integrals/os.cpp</a></li>
+</ul>
+<p>Recent refactoring added a reusable closed-shell derivative assembly helper that takes:</p>
+<ul>
+<li>density matrix <code>P</code></li>
+<li>energy-weighted density <code>W</code></li>
+<li>a generic two-particle contraction function <code>Gamma</code></li>
+</ul>
+<p>That was done specifically to make future correlated gradients easier to plug in without duplicating the entire RHF derivative engine.</p>
+<h3 id="uhf-gradient">UHF Gradient</h3>
+<p>The UHF gradient is similar but uses separate alpha and beta densities and the appropriate spin-resolved two-particle structure.</p>
+<h3 id="current-rmp2-gradient-status">Current RMP2 Gradient Status</h3>
+<p>The current public <code>RMP2</code> gradient path:</p>
+<ul>
+<li>recomputes the total MP2 energy at slightly displaced geometries</li>
+<li>forms a central difference</li>
+</ul>
+<p>This is numerically useful but not a true analytic gradient.</p>
+<h2 id="13-geometry-optimization">13. Geometry Optimization</h2>
+<p>Planck supports geometry optimization in:</p>
+<ul>
+<li>Cartesian coordinates</li>
+<li>internal coordinates</li>
+</ul>
+<p>Files:</p>
+<ul>
+<li><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/opt/geomopt.cpp">src/opt/geomopt.cpp</a></li>
+<li><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/opt/intcoords.cpp">src/opt/intcoords.cpp</a></li>
+</ul>
+<h3 id="cartesian-optimization">Cartesian Optimization</h3>
+<p>Uses an L-BFGS strategy on the flattened Cartesian coordinate vector.</p>
+<p>Why L-BFGS?</p>
+<ul>
+<li>full BFGS stores an approximate Hessian explicitly</li>
+<li>that becomes expensive for larger systems</li>
+<li>L-BFGS stores only recent update history</li>
+</ul>
+<h3 id="internal-coordinate-optimization">Internal-Coordinate Optimization</h3>
+<p>Uses generalized internal coordinates:</p>
+<ul>
+<li>bond stretches</li>
+<li>angle bends</li>
+<li>torsions</li>
+</ul>
+<p>Why internal coordinates?</p>
+<ul>
+<li>they align better with chemically relevant motions</li>
+<li>optimization often converges in fewer steps</li>
+<li>constraints are much easier to impose naturally</li>
+</ul>
+<p>The internal-coordinate machinery uses:</p>
+<ul>
+<li>a Wilson B matrix</li>
+<li>generalized inverse / back-transformation steps</li>
+<li>Schlegel-style microiterations</li>
+</ul>
+<h2 id="14-vibrational-frequencies-and-hessians">14. Vibrational Frequencies and Hessians</h2>
+<p>Files:</p>
+<ul>
+<li><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/freq/hessian.cpp">src/freq/hessian.cpp</a></li>
+<li><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/freq/hessian.h">src/freq/hessian.h</a></li>
+</ul>
+<p>The Hessian is obtained by finite differences of analytic gradients.</p>
+<p>That is a common compromise:</p>
+<ul>
+<li>gradients are much cheaper and more reliable than total-energy Hessians</li>
+<li>full analytic Hessians are substantially more complicated</li>
+</ul>
+<p>Workflow:</p>
+<p>1. displace each Cartesian coordinate positively and negatively</p>
+<p>2. compute analytic gradients</p>
+<p>3. build the Hessian by central differences</p>
+<p>4. mass-weight</p>
+<p>5. project translations and rotations</p>
+<p>6. diagonalize</p>
+<p>7. convert eigenvalues into frequencies</p>
+<p>This yields:</p>
+<ul>
+<li>vibrational frequencies</li>
+<li>normal modes</li>
+<li>zero-point energy</li>
+</ul>
+<h2 id="15-checkpointing-and-restart">15. Checkpointing and Restart</h2>
+<p>Files:</p>
+<ul>
+<li><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/io/checkpoint.cpp">src/io/checkpoint.cpp</a></li>
+<li><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/io/checkpoint.h">src/io/checkpoint.h</a></li>
+</ul>
+<p>The checkpoint system stores:</p>
+<ul>
+<li>density data</li>
+<li>geometry</li>
+<li>basis-related data</li>
+<li>optimization metadata</li>
+</ul>
+<p>It supports:</p>
+<ul>
+<li>density restart in the same basis</li>
+<li>full geometry + density restart</li>
+<li>cross-basis projection using overlap-based techniques</li>
+</ul>
+<p>Pedagogically, this is a good example of how practical electronic structure codes reduce wall time by reusing chemically meaningful state.</p>
+<h2 id="16-execution-flow-of-a-typical-run">16. Execution Flow of a Typical Run</h2>
+<p>The main calculation path in <a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/driver.cpp">src/driver.cpp</a> looks like this:</p>
+<p>1. parse the input file</p>
+<p>2. construct <code>Calculator</code></p>
+<p>3. convert coordinates to internal Bohr form</p>
+<p>4. optionally restore checkpoint geometry</p>
+<p>5. detect symmetry and standard orientation</p>
+<p>6. read the basis set</p>
+<p>7. initialize matrices and options</p>
+<p>8. build shell pairs</p>
+<p>9. compute one-electron integrals</p>
+<p>10. run SCF</p>
+<p>11. optionally run MP2 or CASSCF/RASSCF</p>
+<p>12. optionally compute gradient</p>
+<p>13. optionally run geometry optimization</p>
+<p>14. optionally run frequency analysis</p>
+<p>15. optionally write checkpoint</p>
+<p>This ordering is why <code>driver.cpp</code> is the best “map file” for new contributors.</p>
+<h2 id="17-teaching-map-how-theory-matches-functions">17. Teaching Map: How Theory Matches Functions</h2>
+<p>Use this section as a quick lookup table.</p>
+<table>
+<tbody>
+<tr><td>Theory topic</td><td>Main implementation files</td></tr>
+<table>
+<tbody>
+<tr><td>molecule/options/state</td><td><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/base/types.h">src/base/types.h</a></td></tr>
+<table>
+<tbody>
+<tr><td>input parsing</td><td><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/io/io.cpp">src/io/io.cpp</a></td></tr>
+<table>
+<tbody>
+<tr><td>basis parsing</td><td><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/basis/basis.cpp">src/basis/basis.cpp</a></td></tr>
+<table>
+<tbody>
+<tr><td>shell-pair construction</td><td><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/integrals/shellpair.cpp">src/integrals/shellpair.cpp</a></td></tr>
+<table>
+<tbody>
+<tr><td>one-electron integrals</td><td><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/integrals/os.cpp">src/integrals/os.cpp</a></td></tr>
+<table>
+<tbody>
+<tr><td>ERIs and Fock builds</td><td><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/integrals/os.cpp">src/integrals/os.cpp</a></td></tr>
+<table>
+<tbody>
+<tr><td>RHF/UHF SCF</td><td><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/scf/scf.cpp">src/scf/scf.cpp</a></td></tr>
+<table>
+<tbody>
+<tr><td>symmetry and MO labels</td><td><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/symmetry/symmetry.cpp">src/symmetry/symmetry.cpp</a>, <a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/symmetry/mo_symmetry.cpp">src/symmetry/mo_symmetry.cpp</a></td></tr>
+<table>
+<tbody>
+<tr><td>MP2 energy</td><td><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/post_hf/mp2.cpp">src/post_hf/mp2.cpp</a></td></tr>
+<table>
+<tbody>
+<tr><td>MP2 response groundwork</td><td><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/post_hf/mp2_gradient.cpp">src/post_hf/mp2_gradient.cpp</a>, <a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/post_hf/rhf_response.cpp">src/post_hf/rhf_response.cpp</a></td></tr>
+<table>
+<tbody>
+<tr><td>CASSCF/RASSCF</td><td><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/post_hf/casscf.cpp">src/post_hf/casscf.cpp</a></td></tr>
+<table>
+<tbody>
+<tr><td>analytic HF gradients</td><td><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/gradient/gradient.cpp">src/gradient/gradient.cpp</a></td></tr>
+<table>
+<tbody>
+<tr><td>geometry optimization</td><td><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/opt/geomopt.cpp">src/opt/geomopt.cpp</a></td></tr>
+<table>
+<tbody>
+<tr><td>internal coordinates</td><td><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/opt/intcoords.cpp">src/opt/intcoords.cpp</a></td></tr>
+<table>
+<tbody>
+<tr><td>vibrational analysis</td><td><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/freq/hessian.cpp">src/freq/hessian.cpp</a></td></tr>
+<table>
+<tbody>
+<tr><td>checkpointing</td><td><a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/io/checkpoint.cpp">src/io/checkpoint.cpp</a></td></tr>
+<h2 id="18-limitations-and-honest-status-notes">18. Limitations and Honest Status Notes</h2>
+<p>This is the section a teacher or contributor should read before presenting the program as “finished.”</p>
+<ul>
+<li>RHF and UHF are mature enough for small teaching calculations.</li>
+<li>MP2 energies are implemented for RHF and UHF.</li>
+<li>RHF and UHF analytic gradients are implemented.</li>
+<li>The public RMP2 gradient path is still numerical, not fully analytic.</li>
+<li>The code contains partial response-theory infrastructure for future analytic</li>
+<p>RMP2 gradients, but the final Lagrangian assembly is not yet wired into the production gradient entry point.</p>
+<li>CASSCF and RASSCF are present and the recently fixed cases now behave</li>
+<p>variationally in the tested inputs.</p>
+<li>Hessians are finite-difference of gradients, not fully analytic second</li>
+<p>derivatives.</p>
+</ul>
+<h2 id="19-how-to-study-this-codebase-efficiently">19. How to Study This Codebase Efficiently</h2>
+<p>Recommended reading order:</p>
+<p>1. <a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/base/types.h">src/base/types.h</a></p>
+<p>2. <a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/driver.cpp">src/driver.cpp</a></p>
+<p>3. <a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/io/io.cpp">src/io/io.cpp</a></p>
+<p>4. <a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/scf/scf.cpp">src/scf/scf.cpp</a></p>
+<p>5. <a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/integrals/os.cpp">src/integrals/os.cpp</a></p>
+<p>6. <a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/gradient/gradient.cpp">src/gradient/gradient.cpp</a></p>
+<p>7. <a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/post_hf/mp2.cpp">src/post_hf/mp2.cpp</a></p>
+<p>8. <a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/post_hf/casscf.cpp">src/post_hf/casscf.cpp</a></p>
+<p>9. <a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/opt/geomopt.cpp">src/opt/geomopt.cpp</a></p>
+<p>10. <a href="/Users/hemanthharidas/Desktop/codes/planck-refactored/src/freq/hessian.cpp">src/freq/hessian.cpp</a></p>
+<p>This order follows the dependency graph from basic state and control flow to methods and then to downstream workflows.</p>
+<h2 id="20-summary">20. Summary</h2>
+<p>Planck is a compact but nontrivial electronic-structure code. It is useful for teaching because the theory-to-code mapping is still visible:</p>
+<ul>
+<li>basis functions become shell and primitive objects</li>
+<li>integrals become explicit recursive kernels</li>
+<li>SCF becomes a density-Fock fixed-point iteration</li>
+<li>DIIS becomes a small linear algebra problem on stored residuals</li>
+<li>MP2 becomes AO-to-MO integral transformation plus perturbative energy sums</li>
+<li>CASSCF becomes CI + orbital optimization + reduced density matrices</li>
+<li>gradients become derivative integral contractions plus Pulay terms</li>
+<li>geometry optimization becomes an iterative minimization around those</li>
+<p>gradients</p>
+</ul>
+<p>That transparency is the main educational value of the codebase.</p>
+</tbody>
+</table>
+      </main>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/base/types.h
+++ b/src/base/types.h
@@ -68,7 +68,8 @@ namespace HartreeFock
         SinglePoint,    // Single point Energy Calculation
         Gradient,       // Analytic nuclear gradient
         GeomOpt,        // Geometry Optimization
-        Frequency       // Frequency Calculation
+        Frequency,      // Frequency Calculation
+        GeomOptFrequency // Geometry optimization followed by frequency calculation
     };
 
     enum class SCFMode
@@ -689,6 +690,7 @@ namespace HartreeFock
         Eigen::MatrixXd _hessian;           // 3N×3N Cartesian Hessian, Ha/Bohr²
         Eigen::VectorXd _frequencies;       // n_vib vibrational frequencies in cm⁻¹
         Eigen::MatrixXd _normal_modes;      // 3N × n_vib mass-unweighted normal modes
+        std::vector<std::string> _vibrational_symmetry; // n_vib Mulliken labels
         double          _zpe = 0.0;         // zero-point energy in Ha
         double          _hessian_step = 5e-3; // finite-difference step in Bohr
 

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -571,7 +571,20 @@ int main(int argc, const char* argv[])
         HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "Gradient :", "Computing analytic nuclear gradient");
 
         Eigen::MatrixXd grad;
-        if (calculator._info._scf.is_uhf)
+        if (calculator._correlation == HartreeFock::PostHF::RMP2)
+        {
+            HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "Gradient :",
+                "Using central-difference RMP2 total-energy gradient");
+            calculator._total_energy += calculator._correlation_energy;
+            grad = HartreeFock::Gradient::compute_rmp2_gradient(calculator);
+        }
+        else if (calculator._correlation == HartreeFock::PostHF::UMP2)
+        {
+            HartreeFock::Logger::logging(HartreeFock::LogLevel::Error, "Gradient :",
+                "UMP2 gradient is not implemented");
+            return EXIT_FAILURE;
+        }
+        else if (calculator._info._scf.is_uhf)
             grad = HartreeFock::Gradient::compute_uhf_gradient(calculator, shellpairs);
         else
             grad = HartreeFock::Gradient::compute_rhf_gradient(calculator, shellpairs);
@@ -616,7 +629,8 @@ int main(int argc, const char* argv[])
 
     // ── Geometry optimization ─────────────────────────────────────────────────
     if (calculator._info._is_converged &&
-        calculator._calculation == HartreeFock::CalculationType::GeomOpt)
+        (calculator._calculation == HartreeFock::CalculationType::GeomOpt ||
+         calculator._calculation == HartreeFock::CalculationType::GeomOptFrequency))
     {
         const bool use_ic = (calculator._opt_coords == HartreeFock::OptCoords::Internal);
         HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "Geometry Optimization :",
@@ -820,7 +834,8 @@ int main(int argc, const char* argv[])
 
     // ── Vibrational frequency analysis ───────────────────────────────────────
     if (calculator._info._is_converged &&
-        calculator._calculation == HartreeFock::CalculationType::Frequency)
+        (calculator._calculation == HartreeFock::CalculationType::Frequency ||
+         calculator._calculation == HartreeFock::CalculationType::GeomOptFrequency))
     {
         // Ensure gradient has been computed for the reference geometry.
         // (For a frequency-only run the analytic gradient was not computed above;
@@ -839,6 +854,7 @@ int main(int argc, const char* argv[])
             calculator._hessian      = freq_result.hessian;
             calculator._frequencies  = freq_result.frequencies;
             calculator._normal_modes = freq_result.normal_modes;
+            calculator._vibrational_symmetry = freq_result.mode_symmetry;
             calculator._zpe          = freq_result.zpe;
 
             // ── Print frequency table ─────────────────────────────────────────
@@ -852,26 +868,47 @@ int main(int argc, const char* argv[])
             HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "",
                 std::format("  Molecule: {} ({} T+R modes removed, {} vibrational modes)",
                             geo_label, n_tr, n_vib));
+            const bool have_mode_symmetry =
+                freq_result.mode_symmetry.size() == static_cast<std::size_t>(n_vib) &&
+                !freq_result.mode_symmetry.empty();
             HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "",
-                "  ──────────────────────────────────────────");
+                have_mode_symmetry
+                    ? "  ─────────────────────────────────────────────────────"
+                    : "  ──────────────────────────────────────────");
             HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "",
-                "    Mode    Frequency (cm⁻¹)");
+                have_mode_symmetry
+                    ? "    Mode    Symmetry    Frequency (cm⁻¹)"
+                    : "    Mode    Frequency (cm⁻¹)");
             HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "",
-                "  ────────────────────────────────────────────");
+                have_mode_symmetry
+                    ? "  ─────────────────────────────────────────────────────"
+                    : "  ────────────────────────────────────────────");
 
             for (int i = 0; i < n_vib; ++i)
             {
                 const double freq = freq_result.frequencies[i];
                 if (freq < 0.0)
                     HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "",
-                        std::format("  {:6d}  {:14.2f}i  (imaginary)", i + 1, -freq));
+                        have_mode_symmetry
+                            ? std::format("  {:6d}  {:10s}  {:14.2f}i  (imaginary)",
+                                          i + 1,
+                                          freq_result.mode_symmetry[static_cast<std::size_t>(i)],
+                                          -freq)
+                            : std::format("  {:6d}  {:14.2f}i  (imaginary)", i + 1, -freq));
                 else
                     HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "",
-                        std::format("  {:6d}  {:14.2f}", i + 1, freq));
+                        have_mode_symmetry
+                            ? std::format("  {:6d}  {:10s}  {:14.2f}",
+                                          i + 1,
+                                          freq_result.mode_symmetry[static_cast<std::size_t>(i)],
+                                          freq)
+                            : std::format("  {:6d}  {:14.2f}", i + 1, freq));
             }
 
             HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "",
-                "  ────────────────────────────────────────────");
+                have_mode_symmetry
+                    ? "  ─────────────────────────────────────────────────────"
+                    : "  ────────────────────────────────────────────");
 
             if (freq_result.n_imaginary > 0)
                 HartreeFock::Logger::logging(HartreeFock::LogLevel::Warning,

--- a/src/freq/hessian.cpp
+++ b/src/freq/hessian.cpp
@@ -17,6 +17,7 @@
 #include "integrals/base.h"
 #include "scf/scf.h"
 #include "gradient/gradient.h"
+#include "symmetry/vibrational_symmetry.h"
 
 // ─── Physical constants ────────────────────────────────────────────────────────
 //
@@ -218,6 +219,8 @@ void HartreeFock::Freq::vibrational_analysis(
         if (norm > 1e-12) L_cart.col(c) /= norm;
     }
     result.normal_modes = std::move(L_cart);
+    result.mode_symmetry = HartreeFock::Symmetry::assign_vibrational_symmetry(
+        calc, result.normal_modes);
 
     // Zero-point energy (sum over real modes only)
     result.zpe = 0.0;

--- a/src/freq/hessian.h
+++ b/src/freq/hessian.h
@@ -3,6 +3,8 @@
 
 #include "base/types.h"
 #include <Eigen/Dense>
+#include <string>
+#include <vector>
 
 namespace HartreeFock
 {
@@ -13,6 +15,7 @@ namespace HartreeFock
             Eigen::MatrixXd hessian;        // 3N×3N Cartesian Hessian, Ha/Bohr²
             Eigen::VectorXd frequencies;    // n_vib, cm⁻¹ (negative = imaginary)
             Eigen::MatrixXd normal_modes;   // 3N × n_vib mass-unweighted, column-normalised
+            std::vector<std::string> mode_symmetry; // n_vib Mulliken labels when symmetry analysis succeeds
             double          zpe;            // zero-point energy, Ha
             int             n_imaginary;    // count of imaginary frequencies
             bool            is_linear;      // molecule linearity flag

--- a/src/gradient/gradient.cpp
+++ b/src/gradient/gradient.cpp
@@ -4,8 +4,12 @@
 #include <vector>
 #include <stdexcept>
 
+#include "basis/basis.h"
 #include "integrals/os.h"
+#include "integrals/base.h"
 #include "integrals/shellpair.h"
+#include "post_hf/mp2.h"
+#include "scf/scf.h"
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -38,58 +42,71 @@ static std::vector<int> build_shell_atom_map(
     return map;
 }
 
-// ─── RHF Gradient ─────────────────────────────────────────────────────────────
-//
-// g[A,x] = 2 Σ_{μ∈A,ν} P_μν (dT_μν/dA_x + dV_μν/dA_x)  [1e GTO-centre]
-//        + Σ_{μν}       P_μν dV_μν^{C=A}/dR_{A,x}         [nucleus-position V]
-//        + ½ Σ_{μνλσ}   Γ_μνλσ d(μν|λσ)/dA_x              [2e ERI]
-//        - 2 Σ_{μ∈A,ν}  W_μν dS_μν/dA_x                   [Pulay]
-//        + Σ_{B≠A}      Z_A Z_B (R_A-R_B)/|R_A-R_B|³      [nuclear repulsion]
+// Rebuild the RHF + RMP2 total energy for the geometry currently stored in
+// calc._molecule._standard (Bohr). Used by the semi-numerical RMP2 gradient.
+static double run_sp_rmp2_energy(HartreeFock::Calculator& calc)
+{
+    calc._molecule._coordinates = calc._molecule._standard;
+    calc._molecule.coordinates  = calc._molecule._standard / ANGSTROM_TO_BOHR;
 
-Eigen::MatrixXd HartreeFock::Gradient::compute_rhf_gradient(
+    const std::string gbs_path =
+        calc._basis._basis_path + "/" + calc._basis._basis_name;
+    calc._shells = HartreeFock::BasisFunctions::read_gbs_basis(
+        gbs_path, calc._molecule, calc._basis._basis);
+
+    calc._info._scf = HartreeFock::DataSCF(false);
+    calc._info._scf.initialize(calc._shells.nbasis());
+    calc._scf.set_scf_mode_auto(calc._shells.nbasis());
+    calc._info._is_converged   = false;
+    calc._use_sao_blocking     = false;
+    calc._correlation_energy   = 0.0;
+    calc._eri.clear();
+
+    calc._compute_nuclear_repulsion();
+
+    auto shell_pairs = build_shellpairs(calc._shells);
+    auto [S, T] = _compute_1e(shell_pairs, calc._shells.nbasis(), calc._integral._engine);
+    auto V = _compute_nuclear_attraction(shell_pairs, calc._shells.nbasis(),
+                                         calc._molecule, calc._integral._engine);
+    calc._overlap = S;
+    calc._hcore   = T + V;
+
+    if (auto scf_res = HartreeFock::SCF::run_rhf(calc, shell_pairs); !scf_res)
+        throw std::runtime_error("RMP2 gradient RHF failed: " + scf_res.error());
+
+    if (auto mp2_res = HartreeFock::Correlation::run_rmp2(calc, shell_pairs); !mp2_res)
+        throw std::runtime_error("RMP2 gradient MP2 failed: " + mp2_res.error());
+
+    calc._total_energy += calc._correlation_energy;
+    return calc._total_energy;
+}
+
+template <typename GammaFn>
+static Eigen::MatrixXd compute_closed_shell_gradient_from_density(
     const HartreeFock::Calculator& calc,
-    const std::vector<HartreeFock::ShellPair>& shell_pairs)
+    const std::vector<HartreeFock::ShellPair>& shell_pairs,
+    const Eigen::MatrixXd& P,
+    const Eigen::MatrixXd& W,
+    GammaFn&& gamma_fn)
 {
     const auto& mol    = calc._molecule;
     const auto& basis  = calc._shells;
     const std::size_t natoms = mol.natoms;
     const std::size_t nb     = basis.nbasis();
 
-    // Density and MO info
-    const Eigen::MatrixXd& P = calc._info._scf.alpha.density;   // already has factor 2
-
-    // Electron count
-    int n_elec = 0;
-    for (std::size_t a = 0; a < natoms; ++a) n_elec += mol.atomic_numbers[a];
-    n_elec -= mol.charge;
-    const int n_occ = n_elec / 2;
-
-    const Eigen::MatrixXd C_occ = calc._info._scf.alpha.mo_coefficients.leftCols(n_occ);
-    const Eigen::VectorXd eps   = calc._info._scf.alpha.mo_energies.head(n_occ);
-
-    // Energy-weighted density: W_μν = 2 Σ_{i occ} ε_i C_μi C_νi
-    const Eigen::MatrixXd W = 2.0 * C_occ * eps.asDiagonal() * C_occ.transpose();
-
     Eigen::MatrixXd grad = Eigen::MatrixXd::Zero(natoms, 3);
 
-    // Shell → atom map
     const std::vector<int> shell_atom = build_shell_atom_map(calc);
-
-    // Build per-shell AO start index
     const auto& shells = basis._shells;
     const auto& bfs    = basis._basis_functions;
     const std::size_t nshells = shells.size();
 
-    // Build ALL (ii,jj) basis-function pairs (including ii>jj) for the ERI loop.
-    // Term 3 must iterate over ALL orderings, not just unique (ii≤jj) pairs,
-    // matching the Python reference which iterates over all shell combinations.
     std::vector<HartreeFock::ShellPair> all_pairs;
     all_pairs.reserve(nb * nb);
     for (std::size_t ii = 0; ii < nb; ++ii)
         for (std::size_t jj = 0; jj < nb; ++jj)
             all_pairs.emplace_back(bfs[ii], bfs[jj]);
 
-    // Map each basis function to its shell index
     std::vector<int> bf_shell(nb, -1);
     for (std::size_t s = 0; s < nshells; ++s)
     {
@@ -98,15 +115,6 @@ Eigen::MatrixXd HartreeFock::Gradient::compute_rhf_gradient(
                 bf_shell[mu] = static_cast<int>(s);
     }
 
-    // ── Term 1+Pulay: iterate over ALL (μ, ν) basis function pairs ────────────
-    // For each pair, atom_a = atom of shell containing μ.
-    // Contribution: grad[atom_a] += 2*P[μ,ν]*(dT+dV) - 2*W[μ,ν]*dS
-    // Factor 2 comes from Hermitian symmetry of P (covers both μ∈A and ν∈A contributions
-    // by iterating over all (μ,ν) including both orderings via the shell_pairs).
-    //
-    // For unique pairs (μ ≤ ν) we handle both the (μ,ν) contribution to atom(μ)
-    // and the (ν,μ) contribution to atom(ν) by creating the reversed ShellPair.
-
     for (const auto& sp : shell_pairs)
     {
         const std::size_t ii = sp.A._index;
@@ -114,7 +122,6 @@ Eigen::MatrixXd HartreeFock::Gradient::compute_rhf_gradient(
         const int atom_ii = shell_atom[bf_shell[ii]];
         const int atom_jj = shell_atom[bf_shell[jj]];
 
-        // A-side derivative: d<μ|..|ν>/dA contributes to grad[atom(μ)]
         const auto dST_A = HartreeFock::ObaraSaika::_compute_1e_deriv_A(sp);
         const auto dV_A  = HartreeFock::ObaraSaika::_compute_nuclear_deriv_A_elem(sp, mol);
 
@@ -124,8 +131,6 @@ Eigen::MatrixXd HartreeFock::Gradient::compute_rhf_gradient(
             grad(atom_ii, q) += contrib;
         }
 
-        // B-side derivative (reversed pair): d<ν|..|μ>/dB contributes to grad[atom(ν)]
-        // Only needed for off-diagonal pairs (ii != jj); use symmetry of matrix elements.
         if (ii != jj)
         {
             HartreeFock::ShellPair sp_rev(sp.B, sp.A);
@@ -140,8 +145,6 @@ Eigen::MatrixXd HartreeFock::Gradient::compute_rhf_gradient(
         }
     }
 
-    // ── Term 2: nucleus-position V derivative ─────────────────────────────────
-    // grad[A,q] += Σ_{μν} P[μ,ν] * dV_μν^{C=A}/dR_{A,q}
     for (std::size_t atom_a = 0; atom_a < natoms; ++atom_a)
     {
         const double Z_A = static_cast<double>(mol.atomic_numbers[atom_a]);
@@ -158,7 +161,6 @@ Eigen::MatrixXd HartreeFock::Gradient::compute_rhf_gradient(
                 const std::size_t jj = sp.B._index;
                 const double dv = HartreeFock::ObaraSaika::_compute_nuclear_deriv_C_elem(
                                       sp, C_A, Z_A, q);
-                // P is symmetric; unique pair (ii,jj) with ii≤jj covers both orderings
                 if (ii == jj)
                     dV_sum += P(ii, jj) * dv;
                 else
@@ -168,12 +170,6 @@ Eigen::MatrixXd HartreeFock::Gradient::compute_rhf_gradient(
         }
     }
 
-    // ── Term 3: ERI gradient ──────────────────────────────────────────────────
-    // contrib[cen,q] = 0.25 * Σ_{ALL ijkl} Gamma[i,j,k,l] * dI[i,j,k,l,cen,q]
-    // Γ_μνλσ = 2*P_μν*P_λσ - P_μλ*P_νσ
-    //
-    // Must iterate over ALL (ii,jj) × ALL (kk,ll) combinations (not just unique pairs).
-    // This matches the Python reference which iterates all shell combinations.
     for (const auto& spAB : all_pairs)
     {
         const std::size_t ii = spAB.A._index;
@@ -188,14 +184,10 @@ Eigen::MatrixXd HartreeFock::Gradient::compute_rhf_gradient(
             const int atom_C = shell_atom[bf_shell[kk]];
             const int atom_D = shell_atom[bf_shell[ll]];
 
-            // Two-particle density matrix element
-            // Gamma = 2*P[i,j]*P[k,l] - P[i,k]*P[j,l]
-            const double Gamma = 2.0 * P(ii, jj) * P(kk, ll) - P(ii, kk) * P(jj, ll);
+            const double Gamma = gamma_fn(ii, jj, kk, ll);
             if (std::abs(Gamma) < 1e-14) continue;
 
             const auto dI = HartreeFock::ObaraSaika::_compute_eri_deriv_elem(spAB, spCD);
-
-            // contrib[cen,q] = 0.25 * Gamma * dI[cen*3+q]
             const double fac = 0.25 * Gamma;
             for (int q = 0; q < 3; ++q) {
                 grad(atom_A, q) += fac * dI[0*3 + q];
@@ -206,7 +198,6 @@ Eigen::MatrixXd HartreeFock::Gradient::compute_rhf_gradient(
         }
     }
 
-    // ── Term 4: nuclear repulsion gradient ───────────────────────────────────
     for (std::size_t a = 0; a < natoms; ++a)
     {
         for (std::size_t b = 0; b < natoms; ++b)
@@ -227,6 +218,33 @@ Eigen::MatrixXd HartreeFock::Gradient::compute_rhf_gradient(
     }
 
     return grad;
+}
+
+// ─── RHF Gradient ─────────────────────────────────────────────────────────────
+//
+// g[A,x] = 2 Σ_{μ∈A,ν} P_μν (dT_μν/dA_x + dV_μν/dA_x)  [1e GTO-centre]
+//        + Σ_{μν}       P_μν dV_μν^{C=A}/dR_{A,x}         [nucleus-position V]
+//        + ½ Σ_{μνλσ}   Γ_μνλσ d(μν|λσ)/dA_x              [2e ERI]
+//        - 2 Σ_{μ∈A,ν}  W_μν dS_μν/dA_x                   [Pulay]
+//        + Σ_{B≠A}      Z_A Z_B (R_A-R_B)/|R_A-R_B|³      [nuclear repulsion]
+
+Eigen::MatrixXd HartreeFock::Gradient::compute_rhf_gradient(
+    const HartreeFock::Calculator& calc,
+    const std::vector<HartreeFock::ShellPair>& shell_pairs)
+{
+    const Eigen::MatrixXd& P = calc._info._scf.alpha.density;   // already has factor 2
+    int n_elec = 0;
+    for (std::size_t a = 0; a < calc._molecule.natoms; ++a) n_elec += calc._molecule.atomic_numbers[a];
+    n_elec -= calc._molecule.charge;
+    const int n_occ = n_elec / 2;
+
+    const Eigen::MatrixXd C_occ = calc._info._scf.alpha.mo_coefficients.leftCols(n_occ);
+    const Eigen::VectorXd eps   = calc._info._scf.alpha.mo_energies.head(n_occ);
+    const Eigen::MatrixXd W = 2.0 * C_occ * eps.asDiagonal() * C_occ.transpose();
+    auto gamma_fn = [&P](std::size_t ii, std::size_t jj, std::size_t kk, std::size_t ll) -> double {
+        return 2.0 * P(ii, jj) * P(kk, ll) - P(ii, kk) * P(jj, ll);
+    };
+    return compute_closed_shell_gradient_from_density(calc, shell_pairs, P, W, gamma_fn);
 }
 
 // ─── UHF Gradient ─────────────────────────────────────────────────────────────
@@ -387,6 +405,40 @@ Eigen::MatrixXd HartreeFock::Gradient::compute_uhf_gradient(
             grad(a, 0) -= Za * Zb * dx / r3;
             grad(a, 1) -= Za * Zb * dy / r3;
             grad(a, 2) -= Za * Zb * dz / r3;
+        }
+    }
+
+    return grad;
+}
+
+Eigen::MatrixXd HartreeFock::Gradient::compute_rmp2_gradient(
+    const HartreeFock::Calculator& calc)
+{
+    if (calc._correlation != HartreeFock::PostHF::RMP2)
+        throw std::runtime_error("RMP2 gradient requested without correlation = RMP2");
+    if (calc._scf._scf != HartreeFock::SCFType::RHF || calc._info._scf.is_uhf)
+        throw std::runtime_error("RMP2 gradient requires an RHF reference");
+
+    const std::size_t natoms = calc._molecule.natoms;
+    Eigen::MatrixXd grad = Eigen::MatrixXd::Zero(natoms, 3);
+
+    // Central-difference step in Bohr. Chosen smaller than the Hessian default
+    // because we are differentiating total energies directly.
+    constexpr double step = 1e-3;
+
+    for (std::size_t a = 0; a < natoms; ++a)
+    {
+        for (int q = 0; q < 3; ++q)
+        {
+            HartreeFock::Calculator calc_fwd = calc;
+            HartreeFock::Calculator calc_bck = calc;
+
+            calc_fwd._molecule._standard(a, q) += step;
+            calc_bck._molecule._standard(a, q) -= step;
+
+            const double e_fwd = run_sp_rmp2_energy(calc_fwd);
+            const double e_bck = run_sp_rmp2_energy(calc_bck);
+            grad(a, q) = (e_fwd - e_bck) / (2.0 * step);
         }
     }
 

--- a/src/gradient/gradient.h
+++ b/src/gradient/gradient.h
@@ -18,6 +18,11 @@ namespace HartreeFock
         // Returns natoms×3 matrix in Ha/Bohr.
         Eigen::MatrixXd compute_uhf_gradient(const HartreeFock::Calculator& calc,
                                              const std::vector<HartreeFock::ShellPair>& shell_pairs);
+
+        // RMP2 nuclear gradient via central differences of the total RMP2 energy.
+        // Returns natoms×3 matrix in Ha/Bohr.
+        // Requires a converged RHF reference and correlation = RMP2.
+        Eigen::MatrixXd compute_rmp2_gradient(const HartreeFock::Calculator& calc);
     }
 }
 

--- a/src/io/checkpoint.cpp
+++ b/src/io/checkpoint.cpp
@@ -145,7 +145,8 @@ std::expected<void, std::string> HartreeFock::Checkpoint::save(
     write_string(out, calc._basis._basis_name);
 
     // has_opt_coords: 1 if these coordinates came from a converged geometry optimization
-    const bool is_opt = (calc._calculation == HartreeFock::CalculationType::GeomOpt
+    const bool is_opt = ((calc._calculation == HartreeFock::CalculationType::GeomOpt ||
+                          calc._calculation == HartreeFock::CalculationType::GeomOptFrequency)
                          && calc._info._is_converged);
     write_pod<uint8_t>(out, static_cast<uint8_t>(is_opt ? 1 : 0));
 

--- a/src/io/io.cpp
+++ b/src/io/io.cpp
@@ -129,11 +129,17 @@ namespace HartreeFock::IO
             {"energy",      HartreeFock::CalculationType::SinglePoint},
             {"geomopt",     HartreeFock::CalculationType::GeomOpt},
             {"freq",        HartreeFock::CalculationType::Frequency},
+            {"optfreq",     HartreeFock::CalculationType::GeomOptFrequency},
+            {"geomoptfreq", HartreeFock::CalculationType::GeomOptFrequency},
+            {"geomopt+freq",HartreeFock::CalculationType::GeomOptFrequency},
+            {"geomopt_freq",HartreeFock::CalculationType::GeomOptFrequency},
             {"gradient",    HartreeFock::CalculationType::Gradient},
 
             {"sp",          HartreeFock::CalculationType::SinglePoint},
             {"opt",         HartreeFock::CalculationType::GeomOpt},
             {"frequency",   HartreeFock::CalculationType::Frequency},
+            {"opt+freq",    HartreeFock::CalculationType::GeomOptFrequency},
+            {"opt_freq",    HartreeFock::CalculationType::GeomOptFrequency},
             {"grad",        HartreeFock::CalculationType::Gradient}
         };
         

--- a/src/io/logging.h
+++ b/src/io/logging.h
@@ -313,6 +313,8 @@ const inline std::string map_enum<HartreeFock::CalculationType>(HartreeFock::Cal
         return "Geometry Optimization";
     case HartreeFock::CalculationType::Frequency:
         return "Frequency Calculation";
+    case HartreeFock::CalculationType::GeomOptFrequency:
+        return "Geometry Optimization + Frequency";
     }
     return "Unknown";
 }

--- a/src/opt/geomopt.cpp
+++ b/src/opt/geomopt.cpp
@@ -12,6 +12,7 @@
 #include "integrals/base.h"
 #include "scf/scf.h"
 #include "gradient/gradient.h"
+#include "post_hf/mp2.h"
 #include "base/tables.h"
 
 // ─── Single-point helper ─────────────────────────────────────────────────────
@@ -64,9 +65,20 @@ static Eigen::VectorXd _run_sp_gradient(HartreeFock::Calculator& calc)
     if (!scf_res)
         throw std::runtime_error("GeomOpt SCF failed: " + scf_res.error());
 
-    // Analytic gradient
+    // Post-HF correction / gradient
     Eigen::MatrixXd grad_mat;
-    if (calc._scf._scf == HartreeFock::SCFType::UHF)
+    if (calc._correlation == HartreeFock::PostHF::RMP2)
+    {
+        if (auto corr_res = HartreeFock::Correlation::run_rmp2(calc, shell_pairs); !corr_res)
+            throw std::runtime_error("GeomOpt RMP2 failed: " + corr_res.error());
+        calc._total_energy += calc._correlation_energy;
+        grad_mat = HartreeFock::Gradient::compute_rmp2_gradient(calc);
+    }
+    else if (calc._correlation == HartreeFock::PostHF::UMP2)
+    {
+        throw std::runtime_error("GeomOpt UMP2 gradient is not implemented");
+    }
+    else if (calc._scf._scf == HartreeFock::SCFType::UHF)
         grad_mat = HartreeFock::Gradient::compute_uhf_gradient(calc, shell_pairs);
     else
         grad_mat = HartreeFock::Gradient::compute_rhf_gradient(calc, shell_pairs);

--- a/src/opt/intcoords.cpp
+++ b/src/opt/intcoords.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <stdexcept>
 #include <Eigen/SVD>
+#include <Eigen/Geometry>
 
 // ── Covalent radii (Angstrom) from Alvarez (2008) ────────────────────────────
 // Indexed by atomic number Z (1-based; index 0 unused).

--- a/src/post_hf/mp2.cpp
+++ b/src/post_hf/mp2.cpp
@@ -1,101 +1,6 @@
-#include <format>
-
 #include "mp2.h"
-#include "integrals/os.h"
-#include "io/logging.h"
-
-// ─── Shared helper ────────────────────────────────────────────────────────────
-
-// Perform a 4-index AO→MO transformation using successive quarter transforms.
-//
-// Returns the (i,a,j,b) tensor — shape n_occ1 × n_virt1 × n_occ2 × n_virt2 —
-// where the mapping is:
-//   (ia|jb) = Σ_{μνλσ} C1_occ(μ,i) C1_virt(ν,a) eri[μνλσ] C2_occ(λ,j) C2_virt(σ,b)
-//
-// Indices 1 transform μ,ν and indices 2 transform λ,σ. This allows mixed-spin
-// blocks (α-β) by passing different coefficient matrices for the two index pairs.
-static std::vector<double> _transform_eri(
-    const std::vector<double>& eri,
-    std::size_t nb,
-    const Eigen::MatrixXd& C1_occ,   // nbasis × n_occ1
-    const Eigen::MatrixXd& C1_virt,  // nbasis × n_virt1
-    const Eigen::MatrixXd& C2_occ,   // nbasis × n_occ2
-    const Eigen::MatrixXd& C2_virt)  // nbasis × n_virt2
-{
-    const std::size_t no1 = static_cast<std::size_t>(C1_occ.cols());
-    const std::size_t nv1 = static_cast<std::size_t>(C1_virt.cols());
-    const std::size_t no2 = static_cast<std::size_t>(C2_occ.cols());
-    const std::size_t nv2 = static_cast<std::size_t>(C2_virt.cols());
-
-    const std::size_t nb2 = nb * nb;
-    const std::size_t nb3 = nb * nb2;
-
-    // T1[i,ν,λ,σ] = Σ_μ C1_occ(μ,i) eri[μνλσ]   shape: no1 × nb × nb × nb
-    std::vector<double> T1(no1 * nb * nb * nb, 0.0);
-    for (std::size_t i = 0; i < no1; ++i)
-        for (std::size_t nu = 0; nu < nb; ++nu)
-            for (std::size_t lam = 0; lam < nb; ++lam)
-                for (std::size_t sig = 0; sig < nb; ++sig)
-                    for (std::size_t mu = 0; mu < nb; ++mu)
-                        T1[i*nb3 + nu*nb2 + lam*nb + sig] +=
-                            C1_occ(mu, i) * eri[mu*nb3 + nu*nb2 + lam*nb + sig];
-
-    // T2[i,a,λ,σ] = Σ_ν C1_virt(ν,a) T1[i,ν,λ,σ]   shape: no1 × nv1 × nb × nb
-    std::vector<double> T2(no1 * nv1 * nb * nb, 0.0);
-    for (std::size_t i = 0; i < no1; ++i)
-        for (std::size_t a = 0; a < nv1; ++a)
-            for (std::size_t lam = 0; lam < nb; ++lam)
-                for (std::size_t sig = 0; sig < nb; ++sig)
-                    for (std::size_t nu = 0; nu < nb; ++nu)
-                        T2[i*nv1*nb*nb + a*nb*nb + lam*nb + sig] +=
-                            C1_virt(nu, a) * T1[i*nb3 + nu*nb2 + lam*nb + sig];
-
-    T1.clear();
-    T1.shrink_to_fit();
-
-    // T3[i,a,j,σ] = Σ_λ C2_occ(λ,j) T2[i,a,λ,σ]   shape: no1 × nv1 × no2 × nb
-    std::vector<double> T3(no1 * nv1 * no2 * nb, 0.0);
-    for (std::size_t i = 0; i < no1; ++i)
-        for (std::size_t a = 0; a < nv1; ++a)
-            for (std::size_t j = 0; j < no2; ++j)
-                for (std::size_t sig = 0; sig < nb; ++sig)
-                    for (std::size_t lam = 0; lam < nb; ++lam)
-                        T3[i*nv1*no2*nb + a*no2*nb + j*nb + sig] +=
-                            C2_occ(lam, j) * T2[i*nv1*nb*nb + a*nb*nb + lam*nb + sig];
-
-    T2.clear();
-    T2.shrink_to_fit();
-
-    // T4[i,a,j,b] = Σ_σ C2_virt(σ,b) T3[i,a,j,σ]   shape: no1 × nv1 × no2 × nv2
-    std::vector<double> mo_eri(no1 * nv1 * no2 * nv2, 0.0);
-    for (std::size_t i = 0; i < no1; ++i)
-        for (std::size_t a = 0; a < nv1; ++a)
-            for (std::size_t j = 0; j < no2; ++j)
-                for (std::size_t b = 0; b < nv2; ++b)
-                    for (std::size_t sig = 0; sig < nb; ++sig)
-                        mo_eri[i*nv1*no2*nv2 + a*no2*nv2 + j*nv2 + b] +=
-                            C2_virt(sig, b) * T3[i*nv1*no2*nb + a*no2*nb + j*nb + sig];
-
-    return mo_eri;
-}
-
-// ─── Helper: ensure AO ERI is available ──────────────────────────────────────
-
-static const std::vector<double>& _ensure_eri(
-    HartreeFock::Calculator& calculator,
-    const std::vector<HartreeFock::ShellPair>& shell_pairs,
-    std::vector<double>& eri_local,
-    const std::string& tag)
-{
-    if (!calculator._eri.empty())
-        return calculator._eri;
-
-    const std::size_t nb = calculator._shells.nbasis();
-    HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, tag,
-        std::format("Building AO ERI tensor ({:.1f} MB)", nb * nb * nb * nb * 8.0 / 1e6));
-    eri_local = HartreeFock::ObaraSaika::_compute_2e(shell_pairs, nb);
-    return eri_local;
-}
+#include "integrals.h"
+#include "mp2_gradient.h"
 
 // ─── RMP2 ────────────────────────────────────────────────────────────────────
 
@@ -109,44 +14,22 @@ HartreeFock::Correlation::run_rmp2(
     if (!calculator._info._is_converged)
         return std::unexpected("run_rmp2: SCF not converged.");
 
-    const std::size_t nb  = calculator._shells.nbasis();
-    const Eigen::MatrixXd& C   = calculator._info._scf.alpha.mo_coefficients;
-    const Eigen::VectorXd& eps = calculator._info._scf.alpha.mo_energies;
-
-    int n_electrons = 0;
-    for (auto Z : calculator._molecule.atomic_numbers)
-        n_electrons += static_cast<int>(Z);
-    n_electrons -= calculator._molecule.charge;
-
-    if (n_electrons % 2 != 0)
-        return std::unexpected("run_rmp2: odd electron count; RMP2 requires closed-shell RHF.");
-
-    const std::size_t n_occ  = static_cast<std::size_t>(n_electrons / 2);
-    const std::size_t n_virt = nb - n_occ;
-
-    if (n_occ == 0 || n_virt == 0)
-        return std::unexpected("run_rmp2: no occupied or virtual orbitals.");
-
-    std::vector<double> eri_local;
-    const std::vector<double>& eri = _ensure_eri(calculator, shell_pairs, eri_local, "RMP2 :");
-
-    const Eigen::MatrixXd C_occ  = C.leftCols(n_occ);
-    const Eigen::MatrixXd C_virt = C.middleCols(n_occ, n_virt);
-
-    const auto mo_eri = _transform_eri(eri, nb, C_occ, C_virt, C_occ, C_virt);
+    auto amp_res = HartreeFock::Correlation::build_rmp2_amplitudes(calculator, shell_pairs);
+    if (!amp_res)
+        return std::unexpected("run_rmp2: " + amp_res.error());
+    const auto& amp = *amp_res;
 
     // E_MP2 = Σ_{i,j ∈ occ, a,b ∈ virt}
     //         (ia|jb) * [2*(ia|jb) - (ib|ja)] / (ε_i + ε_j - ε_a - ε_b)
     double E_mp2 = 0.0;
-    for (std::size_t i = 0; i < n_occ; ++i)
-        for (std::size_t j = 0; j < n_occ; ++j)
-            for (std::size_t a = 0; a < n_virt; ++a)
-                for (std::size_t b = 0; b < n_virt; ++b)
+    for (int i = 0; i < amp.n_occ; ++i)
+        for (int j = 0; j < amp.n_occ; ++j)
+            for (int a = 0; a < amp.n_virt; ++a)
+                for (int b = 0; b < amp.n_virt; ++b)
                 {
-                    const double iajb = mo_eri[i*n_virt*n_occ*n_virt + a*n_occ*n_virt + j*n_virt + b];
-                    const double ibja = mo_eri[i*n_virt*n_occ*n_virt + b*n_occ*n_virt + j*n_virt + a];
-                    const double denom = eps(i) + eps(j) - eps(n_occ + a) - eps(n_occ + b);
-                    E_mp2 += iajb * (2.0 * iajb - ibja) / denom;
+                    const std::size_t ijab = ((static_cast<std::size_t>(i) * amp.n_virt + a)
+                                            * amp.n_occ + j) * amp.n_virt + b;
+                    E_mp2 += amp.iajb[ijab] * amp.tau[ijab];
                 }
 
     calculator._correlation_energy = E_mp2;
@@ -190,7 +73,7 @@ HartreeFock::Correlation::run_ump2(
         return std::unexpected("run_ump2: no beta occupied or virtual orbitals.");
 
     std::vector<double> eri_local;
-    const std::vector<double>& eri = _ensure_eri(calculator, shell_pairs, eri_local, "UMP2 :");
+    const std::vector<double>& eri = HartreeFock::Correlation::ensure_eri(calculator, shell_pairs, eri_local, "UMP2 :");
 
     const Eigen::MatrixXd Ca_occ  = Ca.leftCols(n_alpha);
     const Eigen::MatrixXd Ca_virt = Ca.middleCols(n_alpha, nva);
@@ -201,9 +84,9 @@ HartreeFock::Correlation::run_ump2(
     // mo_aa[i,a,j,b]: α occupied × α virtual × α occupied × α virtual
     // mo_bb[i,a,j,b]: β occupied × β virtual × β occupied × β virtual
     // mo_ab[i,a,j,b]: α occupied × α virtual × β occupied × β virtual
-    const auto mo_aa = _transform_eri(eri, nb, Ca_occ, Ca_virt, Ca_occ, Ca_virt);
-    const auto mo_bb = _transform_eri(eri, nb, Cb_occ, Cb_virt, Cb_occ, Cb_virt);
-    const auto mo_ab = _transform_eri(eri, nb, Ca_occ, Ca_virt, Cb_occ, Cb_virt);
+    const auto mo_aa = HartreeFock::Correlation::transform_eri(eri, nb, Ca_occ, Ca_virt, Ca_occ, Ca_virt);
+    const auto mo_bb = HartreeFock::Correlation::transform_eri(eri, nb, Cb_occ, Cb_virt, Cb_occ, Cb_virt);
+    const auto mo_ab = HartreeFock::Correlation::transform_eri(eri, nb, Ca_occ, Ca_virt, Cb_occ, Cb_virt);
 
     // ── Same-spin α-α term ────────────────────────────────────────────────────
     // E_αα = (1/4) Σ_{i,j,a,b} [(ia|jb) - (ib|ja)]² / (εᵢᵅ + εⱼᵅ - εₐᵅ - εᵦᵅ)

--- a/src/post_hf/mp2_gradient.cpp
+++ b/src/post_hf/mp2_gradient.cpp
@@ -1,0 +1,259 @@
+#include "mp2_gradient.h"
+
+#include <format>
+
+#include "post_hf/integrals.h"
+#include "post_hf/rhf_response.h"
+
+namespace
+{
+inline std::size_t idx_iajb(int i, int a, int j, int b, int n_occ, int n_virt)
+{
+    return ((static_cast<std::size_t>(i) * n_virt + a) * n_occ + j) * n_virt + b;
+}
+
+inline std::size_t idx_pqrs(int p, int q, int r, int s, int nq, int nr, int ns)
+{
+    return ((static_cast<std::size_t>(p) * nq + q) * nr + r) * ns + s;
+}
+}
+
+namespace HartreeFock::Correlation
+{
+
+std::expected<RMP2AmplitudeData, std::string> build_rmp2_amplitudes(
+    HartreeFock::Calculator& calculator,
+    const std::vector<HartreeFock::ShellPair>& shell_pairs)
+{
+    if (calculator._info._scf.is_uhf || calculator._scf._scf != HartreeFock::SCFType::RHF)
+        return std::unexpected("build_rmp2_amplitudes: RHF reference required.");
+    if (!calculator._info._is_converged)
+        return std::unexpected("build_rmp2_amplitudes: SCF not converged.");
+
+    const std::size_t nb = calculator._shells.nbasis();
+    const Eigen::MatrixXd& C   = calculator._info._scf.alpha.mo_coefficients;
+    const Eigen::VectorXd& eps = calculator._info._scf.alpha.mo_energies;
+
+    int n_electrons = 0;
+    for (auto Z : calculator._molecule.atomic_numbers)
+        n_electrons += static_cast<int>(Z);
+    n_electrons -= calculator._molecule.charge;
+
+    if (n_electrons % 2 != 0)
+        return std::unexpected("build_rmp2_amplitudes: closed-shell RHF reference required.");
+
+    RMP2AmplitudeData data;
+    data.n_occ  = n_electrons / 2;
+    data.n_virt = static_cast<int>(nb) - data.n_occ;
+
+    if (data.n_occ <= 0 || data.n_virt <= 0)
+        return std::unexpected("build_rmp2_amplitudes: no occupied or virtual orbitals.");
+
+    data.C_occ   = C.leftCols(data.n_occ);
+    data.C_virt  = C.middleCols(data.n_occ, data.n_virt);
+    data.eps_occ = eps.head(data.n_occ);
+    data.eps_virt= eps.tail(data.n_virt);
+
+    std::vector<double> eri_local;
+    const std::vector<double>& eri = ensure_eri(
+        calculator, shell_pairs, eri_local, "RMP2 Gradient :");
+
+    data.iajb = transform_eri(eri, nb, data.C_occ, data.C_virt, data.C_occ, data.C_virt);
+    data.ibja.resize(data.iajb.size());
+    data.t2.resize(data.iajb.size());
+    data.tau.resize(data.iajb.size());
+
+    for (int i = 0; i < data.n_occ; ++i)
+    for (int a = 0; a < data.n_virt; ++a)
+    for (int j = 0; j < data.n_occ; ++j)
+    for (int b = 0; b < data.n_virt; ++b)
+    {
+        const std::size_t ijab = idx_iajb(i, a, j, b, data.n_occ, data.n_virt);
+        const std::size_t ibja = idx_iajb(i, b, j, a, data.n_occ, data.n_virt);
+
+        data.ibja[ijab] = data.iajb[ibja];
+
+        const double denom = data.eps_occ(i) + data.eps_occ(j)
+                           - data.eps_virt(a) - data.eps_virt(b);
+
+        data.t2[ijab]  = data.iajb[ijab] / denom;
+        data.tau[ijab] = (2.0 * data.iajb[ijab] - data.ibja[ijab]) / denom;
+    }
+
+    return data;
+}
+
+std::expected<RMP2UnrelaxedDensity, std::string> build_rmp2_unrelaxed_density(
+    HartreeFock::Calculator& calculator,
+    const std::vector<HartreeFock::ShellPair>& shell_pairs)
+{
+    auto amp_res = build_rmp2_amplitudes(calculator, shell_pairs);
+    if (!amp_res) return std::unexpected(amp_res.error());
+    const auto& amp = *amp_res;
+
+    RMP2UnrelaxedDensity dens;
+    dens.P_occ  = Eigen::MatrixXd::Zero(amp.n_occ, amp.n_occ);
+    dens.P_virt = Eigen::MatrixXd::Zero(amp.n_virt, amp.n_virt);
+
+    // Closed-shell MP2 unrelaxed density in spin-summed spatial-orbital form.
+    // These blocks are the standard second-order occupancy corrections and are
+    // one of the ingredients of the final relaxed MP2 density.
+    for (int i = 0; i < amp.n_occ; ++i)
+    for (int j = 0; j < amp.n_occ; ++j)
+    {
+        double val = 0.0;
+        for (int m = 0; m < amp.n_occ; ++m)
+        for (int a = 0; a < amp.n_virt; ++a)
+        for (int b = 0; b < amp.n_virt; ++b)
+        {
+            const double tau_imab = amp.tau[idx_iajb(i, a, m, b, amp.n_occ, amp.n_virt)];
+            const double t_jmab   = amp.t2 [idx_iajb(j, a, m, b, amp.n_occ, amp.n_virt)];
+            val -= tau_imab * t_jmab;
+        }
+        dens.P_occ(i, j) = val;
+    }
+
+    for (int a = 0; a < amp.n_virt; ++a)
+    for (int b = 0; b < amp.n_virt; ++b)
+    {
+        double val = 0.0;
+        for (int i = 0; i < amp.n_occ; ++i)
+        for (int j = 0; j < amp.n_occ; ++j)
+        for (int c = 0; c < amp.n_virt; ++c)
+        {
+            const double tau_ijac = amp.tau[idx_iajb(i, a, j, c, amp.n_occ, amp.n_virt)];
+            const double t_ijbc   = amp.t2 [idx_iajb(i, b, j, c, amp.n_occ, amp.n_virt)];
+            val += tau_ijac * t_ijbc;
+        }
+        dens.P_virt(a, b) = val;
+    }
+
+    return dens;
+}
+
+std::expected<Eigen::MatrixXd, std::string> build_rmp2_unrelaxed_density_ao(
+    HartreeFock::Calculator& calculator,
+    const std::vector<HartreeFock::ShellPair>& shell_pairs)
+{
+    auto amp_res = build_rmp2_amplitudes(calculator, shell_pairs);
+    if (!amp_res) return std::unexpected(amp_res.error());
+    auto dens_res = build_rmp2_unrelaxed_density(calculator, shell_pairs);
+    if (!dens_res) return std::unexpected(dens_res.error());
+
+    const auto& amp  = *amp_res;
+    const auto& dens = *dens_res;
+
+    Eigen::MatrixXd P2 =
+        amp.C_occ  * dens.P_occ  * amp.C_occ.transpose() +
+        amp.C_virt * dens.P_virt * amp.C_virt.transpose();
+    return P2;
+}
+
+std::expected<Eigen::MatrixXd, std::string> build_rmp2_zvector_rhs(
+    HartreeFock::Calculator& calculator,
+    const std::vector<HartreeFock::ShellPair>& shell_pairs)
+{
+    auto amp_res = build_rmp2_amplitudes(calculator, shell_pairs);
+    if (!amp_res) return std::unexpected(amp_res.error());
+    const auto& amp = *amp_res;
+
+    std::vector<double> eri_local;
+    const std::vector<double>& eri = ensure_eri(
+        calculator, shell_pairs, eri_local, "RMP2 Z-Vector :");
+
+    const std::size_t nb = calculator._shells.nbasis();
+
+    // These mixed MO-ERI blocks are the ingredients needed to differentiate
+    // the MP2 energy with respect to occupied-virtual orbital rotations.
+    const auto vvov = transform_eri(eri, nb, amp.C_virt, amp.C_virt, amp.C_occ, amp.C_virt);
+    const auto ooov = transform_eri(eri, nb, amp.C_occ,  amp.C_occ,  amp.C_occ, amp.C_virt);
+    const auto ovvv = transform_eri(eri, nb, amp.C_occ,  amp.C_virt, amp.C_virt, amp.C_virt);
+    const auto ovoo = transform_eri(eri, nb, amp.C_occ,  amp.C_virt, amp.C_occ, amp.C_occ);
+
+    Eigen::MatrixXd rhs = Eigen::MatrixXd::Zero(amp.n_virt, amp.n_occ);
+
+    for (int i = 0; i < amp.n_occ; ++i)
+    for (int a = 0; a < amp.n_virt; ++a)
+    for (int j = 0; j < amp.n_occ; ++j)
+    for (int b = 0; b < amp.n_virt; ++b)
+    {
+        const std::size_t ijab = idx_iajb(i, a, j, b, amp.n_occ, amp.n_virt);
+        const double denom = amp.eps_occ(i) + amp.eps_occ(j)
+                           - amp.eps_virt(a) - amp.eps_virt(b);
+
+        const double coeff_main = (4.0 * amp.iajb[ijab] - amp.ibja[ijab]) / denom;
+        const double coeff_exch = -amp.iajb[ijab] / denom;
+
+        for (int c = 0; c < amp.n_virt; ++c)
+        {
+            rhs(c, i) += coeff_main * vvov[idx_pqrs(c, a, j, b, amp.n_virt, amp.n_occ, amp.n_virt)];
+            rhs(c, j) += coeff_main * ovvv[idx_pqrs(i, a, c, b, amp.n_virt, amp.n_virt, amp.n_virt)];
+
+            rhs(c, i) += coeff_exch * vvov[idx_pqrs(c, b, j, a, amp.n_virt, amp.n_occ, amp.n_virt)];
+            rhs(c, j) += coeff_exch * ovvv[idx_pqrs(i, b, c, a, amp.n_virt, amp.n_virt, amp.n_virt)];
+        }
+
+        for (int k = 0; k < amp.n_occ; ++k)
+        {
+            rhs(a, k) -= coeff_main * ooov[idx_pqrs(i, k, j, b, amp.n_occ, amp.n_occ, amp.n_virt)];
+            rhs(b, k) -= coeff_main * ovoo[idx_pqrs(i, a, j, k, amp.n_virt, amp.n_occ, amp.n_occ)];
+
+            rhs(b, k) -= coeff_exch * ooov[idx_pqrs(i, k, j, a, amp.n_occ, amp.n_occ, amp.n_virt)];
+            rhs(a, k) -= coeff_exch * ovoo[idx_pqrs(i, b, j, k, amp.n_virt, amp.n_occ, amp.n_occ)];
+        }
+    }
+
+    return rhs;
+}
+
+std::expected<Eigen::MatrixXd, std::string> solve_rmp2_zvector(
+    HartreeFock::Calculator& calculator,
+    const std::vector<HartreeFock::ShellPair>& shell_pairs)
+{
+    auto rhs_res = build_rmp2_zvector_rhs(calculator, shell_pairs);
+    if (!rhs_res) return std::unexpected(rhs_res.error());
+
+    return solve_rhf_cphf(calculator, shell_pairs, -(*rhs_res));
+}
+
+std::expected<RMP2RelaxedDensity, std::string> build_rmp2_relaxed_density(
+    HartreeFock::Calculator& calculator,
+    const std::vector<HartreeFock::ShellPair>& shell_pairs)
+{
+    auto amp_res = build_rmp2_amplitudes(calculator, shell_pairs);
+    if (!amp_res) return std::unexpected(amp_res.error());
+    auto dens_res = build_rmp2_unrelaxed_density(calculator, shell_pairs);
+    if (!dens_res) return std::unexpected(dens_res.error());
+    auto z_res = solve_rmp2_zvector(calculator, shell_pairs);
+    if (!z_res) return std::unexpected(z_res.error());
+
+    const auto& amp  = *amp_res;
+    const auto& dens = *dens_res;
+    const auto& z    = *z_res;
+
+    const int nb = amp.n_occ + amp.n_virt;
+    Eigen::MatrixXd P_mo = Eigen::MatrixXd::Zero(nb, nb);
+
+    // RHF reference occupations.
+    P_mo.topLeftCorner(amp.n_occ, amp.n_occ) = 2.0 * Eigen::MatrixXd::Identity(amp.n_occ, amp.n_occ);
+
+    // Add the MP2 oo/vv corrections and the ov response block.
+    P_mo.topLeftCorner(amp.n_occ, amp.n_occ) += dens.P_occ;
+    P_mo.bottomRightCorner(amp.n_virt, amp.n_virt) = dens.P_virt;
+
+    // The Z-vector lives in the virtual-occupied space. In the spin-summed
+    // spatial density this enters as a symmetric occupied-virtual correction.
+    P_mo.bottomLeftCorner(amp.n_virt, amp.n_occ) = 2.0 * z;
+    P_mo.topRightCorner(amp.n_occ, amp.n_virt) = 2.0 * z.transpose();
+
+    Eigen::MatrixXd C(nb, nb);
+    C.leftCols(amp.n_occ) = amp.C_occ;
+    C.rightCols(amp.n_virt) = amp.C_virt;
+
+    RMP2RelaxedDensity relaxed;
+    relaxed.P_mo = P_mo;
+    relaxed.P_ao = C * P_mo * C.transpose();
+    return relaxed;
+}
+
+} // namespace HartreeFock::Correlation

--- a/src/post_hf/mp2_gradient.h
+++ b/src/post_hf/mp2_gradient.h
@@ -1,0 +1,81 @@
+#ifndef HF_POSTHF_MP2_GRADIENT_H
+#define HF_POSTHF_MP2_GRADIENT_H
+
+#include <Eigen/Core>
+#include <expected>
+#include <string>
+#include <vector>
+
+#include "base/types.h"
+#include "integrals/shellpair.h"
+
+namespace HartreeFock::Correlation
+{
+    struct RMP2AmplitudeData
+    {
+        int n_occ  = 0;
+        int n_virt = 0;
+
+        Eigen::MatrixXd C_occ;
+        Eigen::MatrixXd C_virt;
+        Eigen::VectorXd eps_occ;
+        Eigen::VectorXd eps_virt;
+
+        // Stored in row-major [i,a,j,b] order.
+        std::vector<double> iajb;
+        std::vector<double> ibja;
+        std::vector<double> t2;
+        std::vector<double> tau;
+    };
+
+    struct RMP2UnrelaxedDensity
+    {
+        Eigen::MatrixXd P_occ;   // occupied-occupied block correction
+        Eigen::MatrixXd P_virt;  // virtual-virtual block correction
+    };
+
+    struct RMP2RelaxedDensity
+    {
+        Eigen::MatrixXd P_mo;  // full spin-summed MO-space density
+        Eigen::MatrixXd P_ao;  // full AO-space density
+    };
+
+    std::expected<RMP2AmplitudeData, std::string> build_rmp2_amplitudes(
+        HartreeFock::Calculator& calculator,
+        const std::vector<HartreeFock::ShellPair>& shell_pairs);
+
+    // Build the unrelaxed MP2 one-particle density in MO block form.
+    // This is one of the core ingredients of the final analytic gradient.
+    std::expected<RMP2UnrelaxedDensity, std::string> build_rmp2_unrelaxed_density(
+        HartreeFock::Calculator& calculator,
+        const std::vector<HartreeFock::ShellPair>& shell_pairs);
+
+    // Build the AO-space unrelaxed density contribution:
+    //   P^(2)_AO = C_occ P_occ C_occ^T + C_virt P_virt C_virt^T
+    std::expected<Eigen::MatrixXd, std::string> build_rmp2_unrelaxed_density_ao(
+        HartreeFock::Calculator& calculator,
+        const std::vector<HartreeFock::ShellPair>& shell_pairs);
+
+    // Build the closed-shell MP2 orbital-gradient RHS in the RHF occupied-
+    // virtual response space. The result is shaped [nvirt x nocc] and can be
+    // used as the source term for the RHF CPHF/Z-vector equation.
+    std::expected<Eigen::MatrixXd, std::string> build_rmp2_zvector_rhs(
+        HartreeFock::Calculator& calculator,
+        const std::vector<HartreeFock::ShellPair>& shell_pairs);
+
+    // Solve the RHF response equation for the MP2 Z-vector:
+    //   A * Z = -RHS_MP2
+    // returning Z in [nvirt x nocc] shape.
+    std::expected<Eigen::MatrixXd, std::string> solve_rmp2_zvector(
+        HartreeFock::Calculator& calculator,
+        const std::vector<HartreeFock::ShellPair>& shell_pairs);
+
+    // Build the first-order relaxed MP2 one-particle density using the RHF
+    // reference occupations, the MP2 unrelaxed oo/vv corrections, and the
+    // occupied-virtual Z-vector response block.
+    std::expected<RMP2RelaxedDensity, std::string> build_rmp2_relaxed_density(
+        HartreeFock::Calculator& calculator,
+        const std::vector<HartreeFock::ShellPair>& shell_pairs);
+}
+
+#endif

--- a/src/post_hf/rhf_response.cpp
+++ b/src/post_hf/rhf_response.cpp
@@ -1,0 +1,116 @@
+#include "rhf_response.h"
+
+#include <format>
+
+#include "post_hf/integrals.h"
+
+namespace HartreeFock::Correlation
+{
+
+std::expected<Eigen::MatrixXd, std::string> build_rhf_cphf_matrix(
+    HartreeFock::Calculator& calculator,
+    const std::vector<HartreeFock::ShellPair>& shell_pairs)
+{
+    if (!calculator._info._is_converged)
+        return std::unexpected("build_rhf_cphf_matrix: SCF not converged.");
+    if (calculator._scf._scf != HartreeFock::SCFType::RHF ||
+        calculator._info._scf.is_uhf)
+        return std::unexpected("build_rhf_cphf_matrix: RHF reference required.");
+
+    const std::size_t nb = calculator._shells.nbasis();
+    const Eigen::MatrixXd& C   = calculator._info._scf.alpha.mo_coefficients;
+    const Eigen::VectorXd& eps = calculator._info._scf.alpha.mo_energies;
+
+    int n_electrons = 0;
+    for (auto Z : calculator._molecule.atomic_numbers)
+        n_electrons += static_cast<int>(Z);
+    n_electrons -= calculator._molecule.charge;
+    if (n_electrons % 2 != 0)
+        return std::unexpected("build_rhf_cphf_matrix: closed-shell RHF reference required.");
+
+    const int n_occ  = n_electrons / 2;
+    const int n_virt = static_cast<int>(nb) - n_occ;
+    if (n_occ <= 0 || n_virt <= 0)
+        return std::unexpected("build_rhf_cphf_matrix: no occupied or virtual orbitals.");
+
+    std::vector<double> eri_local;
+    const std::vector<double>& eri = ensure_eri(
+        calculator, shell_pairs, eri_local, "RHF Response :");
+
+    const Eigen::MatrixXd C_occ  = C.leftCols(n_occ);
+    const Eigen::MatrixXd C_virt = C.middleCols(n_occ, n_virt);
+
+    // (a i | b j)
+    const auto mo_ai_bj = transform_eri(eri, nb, C_virt, C_occ, C_virt, C_occ);
+    // (a b | i j)
+    const auto mo_ab_ij = transform_eri(eri, nb, C_virt, C_virt, C_occ, C_occ);
+
+    const int nov = n_occ * n_virt;
+    Eigen::MatrixXd A = Eigen::MatrixXd::Zero(nov, nov);
+
+    auto idx_ai = [n_occ](int a, int i) -> int {
+        return a * n_occ + i;
+    };
+    auto idx_ai_bj = [n_occ, n_virt](int a, int i, int b, int j) -> std::size_t {
+        return ((static_cast<std::size_t>(a) * n_occ + i) * n_virt + b) * n_occ + j;
+    };
+    auto idx_ab_ij = [n_virt, n_occ](int a, int b, int i, int j) -> std::size_t {
+        return ((static_cast<std::size_t>(a) * n_virt + b) * n_occ + i) * n_occ + j;
+    };
+
+    for (int a = 0; a < n_virt; ++a)
+    for (int i = 0; i < n_occ;  ++i)
+    {
+        const int ai = idx_ai(a, i);
+        for (int b = 0; b < n_virt; ++b)
+        for (int j = 0; j < n_occ;  ++j)
+        {
+            const int bj = idx_ai(b, j);
+            double val = 0.0;
+            if (a == b && i == j)
+                val += eps(n_occ + a) - eps(i);
+
+            const double ai_bj = mo_ai_bj[idx_ai_bj(a, i, b, j)];
+            const double ab_ij = mo_ab_ij[idx_ab_ij(a, b, i, j)];
+            const double aj_bi = mo_ai_bj[idx_ai_bj(a, j, b, i)];
+
+            val += 4.0 * ai_bj - ab_ij - aj_bi;
+            A(ai, bj) = val;
+        }
+    }
+
+    return A;
+}
+
+std::expected<Eigen::MatrixXd, std::string> solve_rhf_cphf(
+    HartreeFock::Calculator& calculator,
+    const std::vector<HartreeFock::ShellPair>& shell_pairs,
+    const Eigen::MatrixXd& rhs)
+{
+    auto A_res = build_rhf_cphf_matrix(calculator, shell_pairs);
+    if (!A_res) return std::unexpected(A_res.error());
+
+    const Eigen::MatrixXd& A = *A_res;
+
+    int n_electrons = 0;
+    for (auto Z : calculator._molecule.atomic_numbers)
+        n_electrons += static_cast<int>(Z);
+    n_electrons -= calculator._molecule.charge;
+
+    const int n_occ  = n_electrons / 2;
+    const int n_virt = static_cast<int>(calculator._shells.nbasis()) - n_occ;
+    if (rhs.rows() != n_virt || rhs.cols() != n_occ)
+    {
+        return std::unexpected(std::format(
+            "solve_rhf_cphf: RHS shape mismatch; expected {}x{}, got {}x{}.",
+            n_virt, n_occ, rhs.rows(), rhs.cols()));
+    }
+
+    Eigen::VectorXd rhs_vec(Eigen::Map<const Eigen::VectorXd>(rhs.data(), rhs.size()));
+    Eigen::VectorXd z_vec = A.colPivHouseholderQr().solve(rhs_vec);
+
+    Eigen::MatrixXd z = Eigen::Map<const Eigen::MatrixXd>(z_vec.data(), n_virt, n_occ);
+    return z;
+}
+
+} // namespace HartreeFock::Correlation

--- a/src/post_hf/rhf_response.h
+++ b/src/post_hf/rhf_response.h
@@ -1,0 +1,37 @@
+#ifndef HF_POSTHF_RHF_RESPONSE_H
+#define HF_POSTHF_RHF_RESPONSE_H
+
+#include <Eigen/Core>
+#include <expected>
+#include <string>
+#include <vector>
+
+#include "base/types.h"
+#include "integrals/shellpair.h"
+
+namespace HartreeFock::Correlation
+{
+    // Build the full RHF CPHF/Z-vector matrix in the occupied-virtual space.
+    //
+    // The matrix is indexed in (a,i) compound order with a in virtual orbitals
+    // and i in occupied orbitals:
+    //
+    //   A_ai,bj = (eps_a - eps_i) delta_ab delta_ij
+    //           + 4 (ai|bj) - (ab|ij) - (aj|bi)
+    //
+    // This is the canonical RHF response matrix used by the MP2 Z-vector
+    // equations and other relaxed-property solvers.
+    std::expected<Eigen::MatrixXd, std::string> build_rhf_cphf_matrix(
+        HartreeFock::Calculator& calculator,
+        const std::vector<HartreeFock::ShellPair>& shell_pairs);
+
+    // Solve A * z = rhs for one or more right-hand sides in the occupied-virtual
+    // RHF response space. rhs is shaped [nvirt x nocc], and the solution has the
+    // same shape.
+    std::expected<Eigen::MatrixXd, std::string> solve_rhf_cphf(
+        HartreeFock::Calculator& calculator,
+        const std::vector<HartreeFock::ShellPair>& shell_pairs,
+        const Eigen::MatrixXd& rhs);
+}
+
+#endif

--- a/src/symmetry/vibrational_symmetry.cpp
+++ b/src/symmetry/vibrational_symmetry.cpp
@@ -1,0 +1,299 @@
+#include "vibrational_symmetry.h"
+
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+
+#include "wrapper.h"
+
+namespace
+{
+    static Eigen::Matrix3d sop_to_matrix(const msym_symmetry_operation_t& sop)
+    {
+        using M3d = Eigen::Matrix3d;
+        using V3d = Eigen::Vector3d;
+
+        switch (static_cast<int>(sop.type))
+        {
+            case 0:
+                return M3d::Identity();
+            case 4:
+                return -M3d::Identity();
+            case 3:
+            {
+                V3d n(sop.v[0], sop.v[1], sop.v[2]);
+                n.normalize();
+                return M3d::Identity() - 2.0 * n * n.transpose();
+            }
+            case 1:
+            {
+                V3d v(sop.v[0], sop.v[1], sop.v[2]);
+                v.normalize();
+                const double angle = 2.0 * M_PI * sop.power / sop.order;
+                const double c = std::cos(angle);
+                const double s = std::sin(angle);
+                M3d K;
+                K <<     0, -v.z(),  v.y(),
+                     v.z(),      0, -v.x(),
+                    -v.y(),  v.x(),      0;
+                return c * M3d::Identity() + (1.0 - c) * v * v.transpose() + s * K;
+            }
+            case 2:
+            {
+                V3d v(sop.v[0], sop.v[1], sop.v[2]);
+                v.normalize();
+                const double angle = 2.0 * M_PI * sop.power / sop.order;
+                const double c = std::cos(angle);
+                const double s = std::sin(angle);
+                M3d K;
+                K <<      0, -v.z(),  v.y(),
+                     v.z(),       0, -v.x(),
+                    -v.y(),  v.x(),       0;
+                const M3d Cn      = c * M3d::Identity() + (1.0 - c) * v * v.transpose() + s * K;
+                const M3d sigma_h = M3d::Identity() - 2.0 * v * v.transpose();
+                return sigma_h * Cn;
+            }
+            default:
+                return M3d::Identity();
+        }
+    }
+
+    static bool is_all_1d_irreps(msym_point_group_type_t t, int n)
+    {
+        switch (static_cast<int>(t))
+        {
+            case 2:
+            case 3:
+                return true;
+            case 4:
+            case 5:
+            case 6:
+            case 7:
+            case 8:
+                return n <= 2;
+            case 9:
+                return n <= 1;
+            case 10:
+                return false;
+            default:
+                return false;
+        }
+    }
+
+    static void normalize_e_labels(const msym_character_table_t* ct,
+                                   std::vector<std::string>& labels)
+    {
+        const int nc = ct->d;
+        for (int g = 0; g < nc; ++g)
+        {
+            const std::string name = ct->s[g].name;
+            if (name.size() >= 2 && name[0] == 'E' && name[1] >= '2' && name[1] <= '9')
+                return;
+        }
+        for (auto& lbl : labels)
+            if (lbl.size() >= 2 && lbl[0] == 'E' && lbl[1] == '1')
+                lbl = "E" + lbl.substr(2);
+    }
+
+    static void fix_b1b2_convention(const msym_character_table_t* ct,
+                                    std::vector<std::string>& labels)
+    {
+        const int nc = ct->d;
+        const double* table = static_cast<const double*>(ct->table);
+
+        int b1_idx = -1;
+        int b2_idx = -1;
+        for (int g = 0; g < nc; ++g)
+        {
+            const std::string name = ct->s[g].name;
+            if (name == "B1") b1_idx = g;
+            if (name == "B2") b2_idx = g;
+        }
+        if (b1_idx < 0 || b2_idx < 0) return;
+
+        for (int c = 0; c < nc; ++c)
+        {
+            const msym_symmetry_operation_t* sop = ct->sops[c];
+            if (static_cast<int>(sop->type) != 3) continue;
+
+            Eigen::Vector3d n(sop->v[0], sop->v[1], sop->v[2]);
+            n.normalize();
+            if (std::abs(std::abs(n[1]) - 1.0) > 0.1) continue;
+
+            if (table[b2_idx * nc + c] > 0.5)
+            {
+                for (auto& lbl : labels)
+                {
+                    if (lbl == "B1") lbl = "B2";
+                    else if (lbl == "B2") lbl = "B1";
+                }
+            }
+            break;
+        }
+    }
+
+    static int find_mapped_atom(const HartreeFock::Molecule& mol,
+                                const Eigen::Vector3d& transformed,
+                                int atomic_number,
+                                std::vector<bool>& used)
+    {
+        int best = -1;
+        double best_dist2 = std::numeric_limits<double>::max();
+        for (std::size_t b = 0; b < mol.natoms; ++b)
+        {
+            if (used[b]) continue;
+            if (static_cast<int>(mol.atomic_numbers[b]) != atomic_number) continue;
+
+            const Eigen::Vector3d rb = mol.standard.row(static_cast<int>(b)).transpose();
+            const double dist2 = (rb - transformed).squaredNorm();
+            if (dist2 < best_dist2)
+            {
+                best_dist2 = dist2;
+                best = static_cast<int>(b);
+            }
+        }
+
+        if (best >= 0 && best_dist2 < 1.0e-8)
+        {
+            used[static_cast<std::size_t>(best)] = true;
+            return best;
+        }
+        return -1;
+    }
+
+    static Eigen::MatrixXd build_cartesian_representation(
+        const HartreeFock::Molecule& mol,
+        const msym_symmetry_operation_t& sop)
+    {
+        const int n3 = static_cast<int>(3 * mol.natoms);
+        Eigen::MatrixXd rep = Eigen::MatrixXd::Zero(n3, n3);
+        const Eigen::Matrix3d M = sop_to_matrix(sop);
+        std::vector<bool> used(mol.natoms, false);
+
+        for (std::size_t a = 0; a < mol.natoms; ++a)
+        {
+            const Eigen::Vector3d ra = mol.standard.row(static_cast<int>(a)).transpose();
+            const Eigen::Vector3d transformed = M * ra;
+            const int b = find_mapped_atom(
+                mol,
+                transformed,
+                static_cast<int>(mol.atomic_numbers[a]),
+                used);
+            if (b < 0)
+                throw std::runtime_error("vibrational symmetry: failed to map transformed atom");
+
+            rep.block<3, 3>(3 * b, 3 * static_cast<int>(a)) = M;
+        }
+
+        return rep;
+    }
+}
+
+std::vector<std::string> HartreeFock::Symmetry::assign_vibrational_symmetry(
+    const HartreeFock::Calculator& calc,
+    const Eigen::MatrixXd& normal_modes)
+{
+    if (!calc._molecule._symmetry) return {};
+    if (normal_modes.cols() == 0) return {};
+
+    const std::string& pg = calc._molecule._point_group;
+    if (pg.find("inf") != std::string::npos) return {};
+
+    HartreeFock::Symmetry::SymmetryContext ctx;
+    HartreeFock::Symmetry::SymmetryElements atoms(calc._molecule.natoms);
+
+    for (std::size_t i = 0; i < calc._molecule.natoms; ++i)
+    {
+        atoms.data()[i].m    = calc._molecule.atomic_masses[i];
+        atoms.data()[i].n    = calc._molecule.atomic_numbers[i];
+        atoms.data()[i].v[0] = calc._molecule.standard(i, 0);
+        atoms.data()[i].v[1] = calc._molecule.standard(i, 1);
+        atoms.data()[i].v[2] = calc._molecule.standard(i, 2);
+    }
+
+    if (MSYM_SUCCESS != msymSetElements(ctx.get(), atoms.size(), atoms.data()))
+        return {};
+    if (MSYM_SUCCESS != msymFindSymmetry(ctx.get()))
+        return {};
+
+    msym_point_group_type_t pg_type;
+    int pg_n = 0;
+    if (MSYM_SUCCESS != msymGetPointGroupType(ctx.get(), &pg_type, &pg_n))
+        return {};
+
+    if (!is_all_1d_irreps(pg_type, pg_n))
+    {
+        int nsg = 0;
+        const msym_subgroup_t* sgs = nullptr;
+        if (MSYM_SUCCESS != msymGetSubgroups(ctx.get(), &nsg, &sgs))
+            return {};
+
+        const msym_subgroup_t* best = nullptr;
+        int best_order = 0;
+        for (int k = 0; k < nsg; ++k)
+        {
+            if (is_all_1d_irreps(sgs[k].type, sgs[k].n) && sgs[k].order > best_order)
+            {
+                best_order = sgs[k].order;
+                best = &sgs[k];
+            }
+        }
+
+        if (best == nullptr) return {};
+        if (MSYM_SUCCESS != msymSelectSubgroup(ctx.get(), best))
+            return {};
+    }
+
+    const msym_character_table_t* ct = nullptr;
+    if (MSYM_SUCCESS != msymGetCharacterTable(ctx.get(), &ct))
+        return {};
+
+    const int nc = ct->d;
+    if (nc <= 0) return {};
+
+    std::vector<Eigen::MatrixXd> reps;
+    reps.reserve(static_cast<std::size_t>(nc));
+    for (int c = 0; c < nc; ++c)
+    {
+        reps.push_back(build_cartesian_representation(calc._molecule, *ct->sops[c]));
+    }
+
+    std::vector<std::string> labels(static_cast<std::size_t>(normal_modes.cols()));
+    std::vector<std::string> irrep_names(static_cast<std::size_t>(nc));
+    for (int g = 0; g < nc; ++g)
+        irrep_names[static_cast<std::size_t>(g)] = ct->s[g].name;
+    normalize_e_labels(ct, irrep_names);
+    fix_b1b2_convention(ct, irrep_names);
+
+    const double* table = static_cast<const double*>(ct->table);
+    for (int mode = 0; mode < normal_modes.cols(); ++mode)
+    {
+        const Eigen::VectorXd v = normal_modes.col(mode).normalized();
+        int best_irrep = -1;
+        double best_err = std::numeric_limits<double>::max();
+
+        for (int g = 0; g < nc; ++g)
+        {
+            double err = 0.0;
+            for (int c = 0; c < nc; ++c)
+            {
+                const double observed = v.dot(reps[static_cast<std::size_t>(c)] * v);
+                const double expected = table[g * nc + c];
+                const double diff = observed - expected;
+                err += diff * diff;
+            }
+            if (err < best_err)
+            {
+                best_err = err;
+                best_irrep = g;
+            }
+        }
+
+        labels[static_cast<std::size_t>(mode)] =
+            (best_irrep >= 0 && best_err < 0.25 * nc)
+                ? irrep_names[static_cast<std::size_t>(best_irrep)]
+                : "?";
+    }
+
+    return labels;
+}

--- a/src/symmetry/vibrational_symmetry.h
+++ b/src/symmetry/vibrational_symmetry.h
@@ -1,0 +1,23 @@
+#ifndef HF_VIBRATIONAL_SYMMETRY_H
+#define HF_VIBRATIONAL_SYMMETRY_H
+
+#include <vector>
+#include <string>
+#include <Eigen/Dense>
+
+#include "base/types.h"
+
+namespace HartreeFock
+{
+    namespace Symmetry
+    {
+        // Assign Mulliken irrep labels to vibrational normal modes.
+        // Returns one label per column of normal_modes, or an empty vector when
+        // symmetry analysis is unavailable/unsupported for the current molecule.
+        std::vector<std::string> assign_vibrational_symmetry(
+            const HartreeFock::Calculator& calc,
+            const Eigen::MatrixXd& normal_modes);
+    }
+}
+
+#endif // HF_VIBRATIONAL_SYMMETRY_H

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,101 @@
+# Regression Test Infrastructure
+
+This directory contains a manifest-driven regression suite for the current
+Planck executable. The goal is to test user-visible chemistry workflows at the
+program boundary, not just individual helper functions.
+
+## What it covers
+
+- RHF + RMP2 single-point validation cases
+- expected-failure behavior for unsupported edge cases
+- CASSCF regression cases tied to the recent active-space fixes
+- gradient smoke tests for the current RHF and RMP2 gradient paths
+
+## Files
+
+- `run_regressions.py`
+  - Python runner that executes `hartree-fock`, parses the textual output, and
+    enforces manifest-defined checks.
+- `regression_cases.json`
+  - Source of truth for test cases, tolerances, tags, and expected failures.
+- `inputs/`
+  - Dedicated test-only inputs that exercise workflows not already present in
+    the project input corpus.
+
+## Supported checks
+
+The runner currently supports:
+
+- required / forbidden output substrings
+- expected process exit code
+- exact-ish numerical checks with absolute tolerances
+- inequality checks between extracted metrics
+- expected string metrics such as point group
+- expected counts such as the number of printed gradient atom lines
+
+Extracted metrics currently include:
+
+- `rhf_total_energy`
+- `mp2_corr_energy`
+- `mp2_total_energy`
+- `casscf_corr_energy`
+- `casscf_total_energy`
+- `gradient_max`
+- `gradient_rms`
+- `point_group`
+- `gradient_atom_lines`
+- `scf_converged_iterations`
+
+## Running the suite
+
+From the repository root:
+
+```bash
+cmake -S . -B build
+cmake --build build --target hartree-fock -j4
+python3 tests/run_regressions.py --build-dir build --suite smoke
+python3 tests/run_regressions.py --build-dir build --suite core
+python3 tests/run_regressions.py --build-dir build --suite extended
+```
+
+You can also use the CMake targets:
+
+```bash
+cmake --build build --target regression-smoke
+cmake --build build --target regression-core
+cmake --build build --target regression-extended
+```
+
+Or via CTest:
+
+```bash
+ctest --test-dir build --output-on-failure
+ctest --test-dir build -R planck-regression-core --output-on-failure
+```
+
+## Adding a new regression case
+
+1. Add or reuse an input file.
+2. Run the executable manually and capture the stable quantities worth checking.
+3. Add a new object to `regression_cases.json` with:
+   - a unique `id`
+   - an `input`
+   - one or more `tags`
+   - the expected exit code
+   - required strings and numerical checks
+4. Prefer checking physically meaningful invariants in addition to exact totals.
+   Examples:
+   - `mp2_total_energy < rhf_total_energy`
+   - `casscf_total_energy <= rhf_total_energy`
+   - expected gradient lines count matches atom count
+
+## Design notes
+
+- This suite intentionally tests the compiled binary end-to-end, including
+  parsing, symmetry handling, SCF, post-HF drivers, logging, and checkpoint
+  interactions.
+- The `he_rmp2_no_virtual_expected_failure` case is intentionally kept as a
+  regression test for current behavior: RHF succeeds, then RMP2 exits with a
+  clear diagnostic because there are no occupied/virtual excitations.
+- Gradient tests are smoke tests rather than high-precision references because
+  the current `RMP2` gradient path is still central-difference based.

--- a/tests/inputs/h2_optfreq.hfinp
+++ b/tests/inputs/h2_optfreq.hfinp
@@ -1,0 +1,27 @@
+%begin_control
+    basis       sto-3g
+    calculation optfreq
+    verbosity   normal
+    basis_type  cartesian
+%end_control
+
+%begin_scf
+    scf_type    rhf
+    use_diis    .true.
+    diis_dim    8
+    engine      os
+    guess       hcore
+%end_scf
+
+%begin_geom
+    coord_type  cartesian
+    coord_units angstrom
+    use_symm    .false.
+%end_geom
+
+%begin_coords
+2
+0   1
+H    0.000000    0.000000     0.000000
+H    0.000000    0.000000     0.750000
+%end_coords

--- a/tests/inputs/h2_rmp2_gradient.hfinp
+++ b/tests/inputs/h2_rmp2_gradient.hfinp
@@ -1,0 +1,28 @@
+%begin_control
+    basis       sto-3g
+    calculation gradient
+    verbosity   normal
+    basis_type  cartesian
+%end_control
+
+%begin_scf
+    scf_type    rhf
+    correlation rmp2
+    use_diis    .true.
+    diis_dim    8
+    engine      os
+    guess       hcore
+%end_scf
+
+%begin_geom
+    coord_type  cartesian
+    coord_units angstrom
+    use_symm    .false.
+%end_geom
+
+%begin_coords
+2
+0   1
+H     0.000000     0.000000    -0.370500
+H     0.000000     0.000000     0.370500
+%end_coords

--- a/tests/inputs/water_freq_symmetry.hfinp
+++ b/tests/inputs/water_freq_symmetry.hfinp
@@ -1,0 +1,28 @@
+%begin_control
+    basis       sto-3g
+    calculation frequency
+    verbosity   normal
+    basis_type  cartesian
+%end_control
+
+%begin_scf
+    scf_type    rhf
+    use_diis    .true.
+    diis_dim    8
+    engine      os
+    guess       hcore
+%end_scf
+
+%begin_geom
+    coord_type  cartesian
+    coord_units angstrom
+    use_symm    .true.
+%end_geom
+
+%begin_coords
+3
+0   1
+O      0.000000     0.000000     0.000000
+H      0.758602     0.000000     0.504284
+H     -0.758602     0.000000     0.504284
+%end_coords

--- a/tests/inputs/water_rhf_gradient.hfinp
+++ b/tests/inputs/water_rhf_gradient.hfinp
@@ -1,0 +1,28 @@
+%begin_control
+    basis       sto-3g
+    calculation gradient
+    verbosity   normal
+    basis_type  cartesian
+%end_control
+
+%begin_scf
+    scf_type    rhf
+    use_diis    .true.
+    diis_dim    8
+    engine      os
+    guess       hcore
+%end_scf
+
+%begin_geom
+    coord_type  cartesian
+    coord_units angstrom
+    use_symm    .false.
+%end_geom
+
+%begin_coords
+3
+0   1
+O     0.000000     0.000000     0.000000
+H     0.758602     0.000000     0.504284
+H    -0.758602     0.000000     0.504284
+%end_coords

--- a/tests/regression_cases.json
+++ b/tests/regression_cases.json
@@ -1,0 +1,195 @@
+{
+  "cases": [
+    {
+      "id": "h2_rmp2_sto3g",
+      "input": "inputs/val_h2.hfinp",
+      "tags": ["smoke", "core"],
+      "expected_exit_code": 0,
+      "contains": ["SCF Converged after", "Total MP2 Energy"],
+      "checks": [
+        {"type": "metric_close", "metric": "rhf_total_energy", "expected": -1.1167593103, "atol": 1e-9},
+        {"type": "metric_close", "metric": "mp2_total_energy", "expected": -1.1298973826, "atol": 1e-9},
+        {"type": "metric_lt_metric", "left": "mp2_total_energy", "right": "rhf_total_energy"}
+      ]
+    },
+    {
+      "id": "lih_rmp2_sto3g",
+      "input": "inputs/val_lih.hfinp",
+      "tags": ["core"],
+      "expected_exit_code": 0,
+      "contains": ["SCF Converged after", "Total MP2 Energy"],
+      "checks": [
+        {"type": "metric_close", "metric": "rhf_total_energy", "expected": -7.8620238776, "atol": 1e-9},
+        {"type": "metric_close", "metric": "mp2_total_energy", "expected": -7.8748885147, "atol": 1e-9},
+        {"type": "metric_lt_metric", "left": "mp2_total_energy", "right": "rhf_total_energy"}
+      ]
+    },
+    {
+      "id": "hf_rmp2_sto3g",
+      "input": "inputs/val_hf.hfinp",
+      "tags": ["core"],
+      "expected_exit_code": 0,
+      "contains": ["SCF Converged after", "Total MP2 Energy"],
+      "checks": [
+        {"type": "metric_close", "metric": "rhf_total_energy", "expected": -98.5707800505, "atol": 1e-9},
+        {"type": "metric_close", "metric": "mp2_total_energy", "expected": -98.5881243665, "atol": 1e-9},
+        {"type": "metric_lt_metric", "left": "mp2_total_energy", "right": "rhf_total_energy"}
+      ]
+    },
+    {
+      "id": "water_rmp2_sto3g",
+      "input": "inputs/val_water.hfinp",
+      "tags": ["smoke", "core"],
+      "expected_exit_code": 0,
+      "contains": ["SCF Converged after", "Total MP2 Energy"],
+      "checks": [
+        {"type": "metric_close", "metric": "rhf_total_energy", "expected": -74.9458807581, "atol": 1e-9},
+        {"type": "metric_close", "metric": "mp2_total_energy", "expected": -74.9767773220, "atol": 1e-9},
+        {"type": "metric_lt_metric", "left": "mp2_total_energy", "right": "rhf_total_energy"}
+      ]
+    },
+    {
+      "id": "nh3_rmp2_sto3g",
+      "input": "inputs/val_nh3.hfinp",
+      "tags": ["core"],
+      "expected_exit_code": 0,
+      "contains": ["SCF Converged after", "Total MP2 Energy"],
+      "checks": [
+        {"type": "metric_close", "metric": "rhf_total_energy", "expected": -55.4363868783, "atol": 1e-9},
+        {"type": "metric_close", "metric": "mp2_total_energy", "expected": -55.4996670673, "atol": 1e-9},
+        {"type": "metric_lt_metric", "left": "mp2_total_energy", "right": "rhf_total_energy"}
+      ]
+    },
+    {
+      "id": "ch4_rmp2_sto3g",
+      "input": "inputs/val_ch4.hfinp",
+      "tags": ["core"],
+      "expected_exit_code": 0,
+      "contains": ["SCF Converged after", "Total MP2 Energy"],
+      "checks": [
+        {"type": "metric_close", "metric": "rhf_total_energy", "expected": -39.7267433254, "atol": 1e-9},
+        {"type": "metric_close", "metric": "mp2_total_energy", "expected": -39.7832030740, "atol": 1e-9},
+        {"type": "metric_lt_metric", "left": "mp2_total_energy", "right": "rhf_total_energy"}
+      ]
+    },
+    {
+      "id": "dihydrogen_rmp2_ccpvdz",
+      "input": "inputs/dihydrogen.hfinp",
+      "tags": ["smoke", "core"],
+      "expected_exit_code": 0,
+      "contains": ["Point Group :", "Total MP2 Energy"],
+      "checks": [
+        {"type": "metric_eq", "metric": "point_group", "expected": "Dinfh"},
+        {"type": "metric_close", "metric": "rhf_total_energy", "expected": -1.1310536239, "atol": 1e-9},
+        {"type": "metric_close", "metric": "mp2_total_energy", "expected": -1.1589651592, "atol": 1e-9},
+        {"type": "metric_lt_metric", "left": "mp2_total_energy", "right": "rhf_total_energy"}
+      ]
+    },
+    {
+      "id": "he_rmp2_no_virtual_expected_failure",
+      "input": "inputs/val_he.hfinp",
+      "tags": ["smoke", "core"],
+      "expected_exit_code": 1,
+      "contains": ["RMP2 : Failed :", "no occupied or virtual orbitals"],
+      "checks": [
+        {"type": "metric_close", "metric": "rhf_total_energy", "expected": -2.8077839566, "atol": 1e-9}
+      ]
+    },
+    {
+      "id": "h2_casscf_22",
+      "input": "inputs/h2_cas22.hfinp",
+      "tags": ["smoke", "core"],
+      "expected_exit_code": 0,
+      "contains": ["CASSCF :", "CASSCF Total Energy"],
+      "checks": [
+        {"type": "metric_close", "metric": "rhf_total_energy", "expected": -1.1167061402, "atol": 1e-9},
+        {"type": "metric_close", "metric": "casscf_total_energy", "expected": -1.1372744062, "atol": 1e-9},
+        {"type": "metric_le_metric", "left": "casscf_total_energy", "right": "rhf_total_energy"}
+      ]
+    },
+    {
+      "id": "water_casscf_22",
+      "input": "inputs/water_cas22.hfinp",
+      "tags": ["smoke", "core"],
+      "expected_exit_code": 0,
+      "contains": ["CASSCF :", "CASSCF Total Energy"],
+      "checks": [
+        {"type": "metric_close", "metric": "rhf_total_energy", "expected": -74.9629329919, "atol": 1e-9},
+        {"type": "metric_close", "metric": "casscf_total_energy", "expected": -74.9641865744, "atol": 1e-9},
+        {"type": "metric_le_metric", "left": "casscf_total_energy", "right": "rhf_total_energy"}
+      ]
+    },
+    {
+      "id": "water_casscf_44",
+      "input": "inputs/water_cas44_symm.hfinp",
+      "tags": ["smoke", "core"],
+      "expected_exit_code": 0,
+      "contains": ["CASSCF :", "CASSCF Total Energy"],
+      "checks": [
+        {"type": "metric_close", "metric": "rhf_total_energy", "expected": -75.9839985679, "atol": 1e-9},
+        {"type": "metric_close", "metric": "casscf_total_energy", "expected": -75.9851092026, "atol": 1e-9},
+        {"type": "metric_le_metric", "left": "casscf_total_energy", "right": "rhf_total_energy"}
+      ]
+    },
+    {
+      "id": "water_rhf_gradient_smoke",
+      "input": "tests/inputs/water_rhf_gradient.hfinp",
+      "tags": ["smoke", "extended"],
+      "expected_exit_code": 0,
+      "contains": ["Gradient :", "Nuclear Gradient (Ha/Bohr) :"],
+      "checks": [
+        {"type": "metric_present", "metric": "gradient_max"},
+        {"type": "metric_present", "metric": "gradient_rms"},
+        {"type": "metric_eq", "metric": "gradient_atom_lines", "expected": 3},
+        {"type": "metric_le", "metric": "gradient_max", "value": 0.2}
+      ]
+    },
+    {
+      "id": "h2_rmp2_gradient_smoke",
+      "input": "tests/inputs/h2_rmp2_gradient.hfinp",
+      "tags": ["extended"],
+      "expected_exit_code": 0,
+      "contains": [
+        "Using central-difference RMP2 total-energy gradient",
+        "Nuclear Gradient (Ha/Bohr) :"
+      ],
+      "checks": [
+        {"type": "metric_present", "metric": "gradient_max"},
+        {"type": "metric_present", "metric": "gradient_rms"},
+        {"type": "metric_eq", "metric": "gradient_atom_lines", "expected": 2},
+        {"type": "metric_le", "metric": "gradient_max", "value": 0.1}
+      ]
+    },
+    {
+      "id": "h2_optfreq_smoke",
+      "input": "tests/inputs/h2_optfreq.hfinp",
+      "tags": ["extended"],
+      "expected_exit_code": 0,
+      "contains": [
+        "Calculation Type :            Geometry Optimization + Frequency",
+        "Geometry Optimization :       Converged",
+        "Frequency :                   Computing semi-numerical Hessian",
+        "Vibrational Frequencies :",
+        "Zero-point energy :"
+      ]
+    },
+    {
+      "id": "water_freq_symmetry",
+      "input": "tests/inputs/water_freq_symmetry.hfinp",
+      "tags": ["extended"],
+      "expected_exit_code": 0,
+      "contains": [
+        "Point Group :                 C2v",
+        "Vibrational Frequencies :",
+        "Mode    Symmetry    Frequency (cm⁻¹)",
+        "1  A1",
+        "2  A1",
+        "3  B2",
+        "Zero-point energy :"
+      ],
+      "checks": [
+        {"type": "metric_eq", "metric": "point_group", "expected": "C2v"}
+      ]
+    }
+  ]
+}

--- a/tests/run_regressions.py
+++ b/tests/run_regressions.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+METRIC_PATTERNS: dict[str, re.Pattern[str]] = {
+    "rhf_total_energy": re.compile(r"^\s*Total Energy\s+([-+0-9Ee\.]+)", re.MULTILINE),
+    "mp2_corr_energy": re.compile(r"^\s*Correlation Energy\s+([-+0-9Ee\.]+)", re.MULTILINE),
+    "mp2_total_energy": re.compile(r"^\s*Total MP2 Energy\s+([-+0-9Ee\.]+)", re.MULTILINE),
+    "casscf_corr_energy": re.compile(r"^\s*CASSCF Correlation Energy\s+([-+0-9Ee\.]+)", re.MULTILINE),
+    "casscf_total_energy": re.compile(r"^\s*CASSCF Total Energy\s+([-+0-9Ee\.]+)", re.MULTILINE),
+    "gradient_max": re.compile(r"Gradient max\|g\|\s*:\s*([-+0-9Ee\.]+)\s+Ha/Bohr"),
+    "gradient_rms": re.compile(r"Gradient rms\|g\|\s*:\s*([-+0-9Ee\.]+)\s+Ha/Bohr"),
+    "point_group": re.compile(r"Point Group\s*:\s*([A-Za-z0-9_+\-]+)"),
+}
+
+COUNT_PATTERNS: dict[str, re.Pattern[str]] = {
+    "gradient_atom_lines": re.compile(r"Atom\s+\d+\s*:\s+[-+0-9Ee\.]+\s+[-+0-9Ee\.]+\s+[-+0-9Ee\.]+"),
+}
+
+ITER_PATTERNS: dict[str, re.Pattern[str]] = {
+    "scf_converged_iterations": re.compile(r"SCF Converged after\s+(\d+)\s+iterations"),
+}
+
+
+@dataclass
+class CaseResult:
+    case_id: str
+    passed: bool
+    duration_s: float
+    details: list[str]
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def extract_metrics(output: str) -> dict[str, Any]:
+    metrics: dict[str, Any] = {}
+    for key, pattern in METRIC_PATTERNS.items():
+        matches = pattern.findall(output)
+        if not matches:
+            continue
+        value = matches[-1]
+        if key == "point_group":
+            metrics[key] = value.strip()
+        else:
+            metrics[key] = float(value)
+
+    for key, pattern in COUNT_PATTERNS.items():
+        metrics[key] = len(pattern.findall(output))
+
+    for key, pattern in ITER_PATTERNS.items():
+        matches = pattern.findall(output)
+        if matches:
+            metrics[key] = int(matches[-1])
+
+    return metrics
+
+
+def approx_equal(a: float, b: float, atol: float) -> bool:
+    return math.isfinite(a) and math.isfinite(b) and abs(a - b) <= atol
+
+
+def run_case(case: dict[str, Any], repo_root: Path, executable: Path) -> CaseResult:
+    case_id = case["id"]
+    input_path = repo_root / case["input"]
+    timeout_s = int(case.get("timeout_s", 120))
+
+    start = time.perf_counter()
+    proc = subprocess.run(
+        [str(executable), str(input_path)],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        timeout=timeout_s,
+    )
+    duration_s = time.perf_counter() - start
+
+    output = proc.stdout + proc.stderr
+    metrics = extract_metrics(output)
+    details: list[str] = []
+    passed = True
+
+    expected_exit = int(case.get("expected_exit_code", 0))
+    if proc.returncode != expected_exit:
+        passed = False
+        details.append(
+            f"exit code mismatch: expected {expected_exit}, got {proc.returncode}"
+        )
+
+    for needle in case.get("contains", []):
+        if needle not in output:
+            passed = False
+            details.append(f"missing required text: {needle!r}")
+
+    for needle in case.get("not_contains", []):
+        if needle in output:
+            passed = False
+            details.append(f"found forbidden text: {needle!r}")
+
+    for check in case.get("checks", []):
+        ctype = check["type"]
+
+        if ctype == "metric_present":
+            metric = check["metric"]
+            if metric not in metrics:
+                passed = False
+                details.append(f"missing metric: {metric}")
+
+        elif ctype == "metric_close":
+            metric = check["metric"]
+            expected = float(check["expected"])
+            atol = float(check.get("atol", 1e-9))
+            actual = metrics.get(metric)
+            if actual is None or not approx_equal(float(actual), expected, atol):
+                passed = False
+                details.append(
+                    f"{metric} mismatch: expected {expected:.10f} +/- {atol:.2e}, got {actual}"
+                )
+
+        elif ctype == "metric_le":
+            metric = check["metric"]
+            threshold = float(check["value"])
+            actual = metrics.get(metric)
+            if actual is None or not float(actual) <= threshold:
+                passed = False
+                details.append(f"{metric} expected <= {threshold}, got {actual}")
+
+        elif ctype == "metric_ge":
+            metric = check["metric"]
+            threshold = float(check["value"])
+            actual = metrics.get(metric)
+            if actual is None or not float(actual) >= threshold:
+                passed = False
+                details.append(f"{metric} expected >= {threshold}, got {actual}")
+
+        elif ctype == "metric_lt_metric":
+            left = check["left"]
+            right = check["right"]
+            lv = metrics.get(left)
+            rv = metrics.get(right)
+            if lv is None or rv is None or not float(lv) < float(rv):
+                passed = False
+                details.append(f"expected {left} < {right}, got {lv} vs {rv}")
+
+        elif ctype == "metric_le_metric":
+            left = check["left"]
+            right = check["right"]
+            lv = metrics.get(left)
+            rv = metrics.get(right)
+            if lv is None or rv is None or not float(lv) <= float(rv):
+                passed = False
+                details.append(f"expected {left} <= {right}, got {lv} vs {rv}")
+
+        elif ctype == "metric_eq":
+            metric = check["metric"]
+            expected = check["expected"]
+            actual = metrics.get(metric)
+            if actual != expected:
+                passed = False
+                details.append(f"{metric} mismatch: expected {expected}, got {actual}")
+
+        else:
+            passed = False
+            details.append(f"unknown check type: {ctype}")
+
+    if not passed:
+        details.append("---- captured output ----")
+        details.extend(output.strip().splitlines()[-40:])
+
+    return CaseResult(case_id=case_id, passed=passed, duration_s=duration_s, details=details)
+
+
+def should_run(case: dict[str, Any], suite: str, selected_cases: set[str]) -> bool:
+    if selected_cases and case["id"] not in selected_cases:
+        return False
+    if suite == "all":
+        return True
+    return suite in set(case.get("tags", []))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run Planck regression tests")
+    parser.add_argument("--manifest", default="tests/regression_cases.json")
+    parser.add_argument("--build-dir", default="build")
+    parser.add_argument("--executable", default=None)
+    parser.add_argument("--suite", default="core", choices=["smoke", "core", "extended", "all"])
+    parser.add_argument("--case", action="append", default=[])
+    parser.add_argument("--list", action="store_true")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[1]
+    manifest_path = repo_root / args.manifest
+    manifest = load_manifest(manifest_path)
+    cases = manifest["cases"]
+
+    if args.list:
+        for case in cases:
+            tags = ",".join(case.get("tags", []))
+            print(f"{case['id']}: {case['input']} [{tags}]")
+        return 0
+
+    executable = Path(args.executable) if args.executable else repo_root / args.build_dir / "hartree-fock"
+    if not executable.exists():
+        print(f"executable not found: {executable}", file=sys.stderr)
+        return 2
+
+    selected_cases = set(args.case)
+    chosen = [case for case in cases if should_run(case, args.suite, selected_cases)]
+    if not chosen:
+        print("no cases selected", file=sys.stderr)
+        return 2
+
+    print(f"Running {len(chosen)} regression case(s) from {manifest_path}")
+    failures = 0
+    total_start = time.perf_counter()
+
+    for case in chosen:
+        result = run_case(case, repo_root, executable)
+        status = "PASS" if result.passed else "FAIL"
+        print(f"[{status}] {result.case_id} ({result.duration_s:.2f}s)")
+        for line in result.details:
+            print(f"    {line}")
+        if not result.passed:
+            failures += 1
+
+    total_duration = time.perf_counter() - total_start
+    print(
+        f"Completed {len(chosen)} case(s) in {total_duration:.2f}s: "
+        f"{len(chosen) - failures} passed, {failures} failed"
+    )
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/chkdump.cpp
+++ b/tools/chkdump.cpp
@@ -1,22 +1,26 @@
-// chkdump — convert a Planck binary checkpoint (.hfchk) to formatted text
+// chkdump -- export a Planck binary checkpoint (.hfchk) as a Gaussian-style
+// formatted checkpoint text file (.fchk-like).
 //
-// Usage:  chkdump <file.hfchk> [output.txt]
+// Usage:
+//   chkdump <file.hfchk> [output.fchk]
 //
-// When no output file is given, the formatted text is written to stdout.
-// The tool is self-contained and requires no link dependencies beyond the
-// C++ standard library.
+// Notes:
+// - The Planck checkpoint does not store the full Gaussian basis metadata that a
+//   canonical Gaussian .fchk would contain, so this exporter writes the common
+//   scalar, vector, and matrix sections that can be reconstructed exactly from
+//   the checkpoint contents.
+// - Symmetric matrices are emitted in packed lower-triangular form, matching
+//   the usual formatted-checkpoint convention.
 
+#include <algorithm>
 #include <cstdint>
 #include <cstring>
-#include <cmath>
 #include <fstream>
-#include <iostream>
 #include <iomanip>
+#include <iostream>
 #include <sstream>
 #include <string>
 #include <vector>
-
-// ─── Binary helpers ───────────────────────────────────────────────────────────
 
 template<typename T>
 static T read_pod(std::istream& in)
@@ -34,11 +38,16 @@ static std::string read_string(std::istream& in)
     return s;
 }
 
-// Read an int64 × int64 matrix stored column-major
-struct Matrix {
-    int64_t rows = 0, cols = 0;
-    std::vector<double> data;   // column-major
-    double operator()(int r, int c) const { return data[c * rows + r]; }
+struct Matrix
+{
+    int64_t rows = 0;
+    int64_t cols = 0;
+    std::vector<double> data; // column-major
+
+    double operator()(int64_t r, int64_t c) const
+    {
+        return data[static_cast<std::size_t>(c * rows + r)];
+    }
 };
 
 static Matrix read_matrix(std::istream& in)
@@ -48,108 +57,111 @@ static Matrix read_matrix(std::istream& in)
     in.read(reinterpret_cast<char*>(&m.cols), 8);
     m.data.resize(static_cast<std::size_t>(m.rows * m.cols));
     in.read(reinterpret_cast<char*>(m.data.data()),
-            m.rows * m.cols * static_cast<int64_t>(sizeof(double)));
+            static_cast<std::streamsize>(m.rows * m.cols * static_cast<int64_t>(sizeof(double))));
     return m;
 }
 
 static Matrix read_vector_as_matrix(std::istream& in)
 {
-    return read_matrix(in);   // stored as n × 1
+    return read_matrix(in);
 }
 
-// ─── Element symbol lookup (Z = 1 … 118) ─────────────────────────────────────
-
-static const char* element_symbol(int Z)
+static std::string uppercase(std::string s)
 {
-    static constexpr const char* sym[] = {
-        "?",
-        "H",  "He", "Li", "Be", "B",  "C",  "N",  "O",  "F",  "Ne",
-        "Na", "Mg", "Al", "Si", "P",  "S",  "Cl", "Ar", "K",  "Ca",
-        "Sc", "Ti", "V",  "Cr", "Mn", "Fe", "Co", "Ni", "Cu", "Zn",
-        "Ga", "Ge", "As", "Se", "Br", "Kr", "Rb", "Sr", "Y",  "Zr",
-        "Nb", "Mo", "Tc", "Ru", "Rh", "Pd", "Ag", "Cd", "In", "Sn",
-        "Sb", "Te", "I",  "Xe", "Cs", "Ba", "La", "Ce", "Pr", "Nd",
-        "Pm", "Sm", "Eu", "Gd", "Tb", "Dy", "Ho", "Er", "Tm", "Yb",
-        "Lu", "Hf", "Ta", "W",  "Re", "Os", "Ir", "Pt", "Au", "Hg",
-        "Tl", "Pb", "Bi", "Po", "At", "Rn", "Fr", "Ra", "Ac", "Th",
-        "Pa", "U",  "Np", "Pu", "Am", "Cm", "Bk", "Cf", "Es", "Fm",
-        "Md", "No", "Lr", "Rf", "Db", "Sg", "Bh", "Hs", "Mt", "Ds",
-        "Rg", "Cn", "Nh", "Fl", "Mc", "Lv", "Ts", "Og"
-    };
-    if (Z < 1 || Z > 118) return sym[0];
-    return sym[Z];
+    std::transform(s.begin(), s.end(), s.begin(), [](unsigned char ch) {
+        return static_cast<char>(std::toupper(ch));
+    });
+    return s;
 }
 
-// ─── Formatting helpers ───────────────────────────────────────────────────────
-
-static const int LINE_WIDTH = 78;
-
-static void rule(std::ostream& out)
+static std::vector<double> packed_lower_triangle(const Matrix& m)
 {
-    out << std::string(LINE_WIDTH, '=') << "\n";
+    std::vector<double> packed;
+    const int64_t n = std::min(m.rows, m.cols);
+    packed.reserve(static_cast<std::size_t>(n * (n + 1) / 2));
+    for (int64_t i = 0; i < n; ++i)
+        for (int64_t j = 0; j <= i; ++j)
+            packed.push_back(m(i, j));
+    return packed;
 }
 
-static void section(std::ostream& out, const std::string& title)
+static std::vector<double> flatten_matrix(const Matrix& m)
 {
-    out << "\n";
-    rule(out);
-    out << "  " << title << "\n";
-    rule(out);
+    return m.data;
 }
 
-static void kv(std::ostream& out, const std::string& key, const std::string& val)
+static std::vector<int32_t> to_int32_vector(const std::vector<int32_t>& values)
 {
-    out << "  " << std::setw(22) << std::left << key << ": " << val << "\n";
+    return values;
 }
 
-static void print_matrix(std::ostream& out, const Matrix& m, int max_cols = 8)
+static std::vector<double> to_double_vector(const std::vector<int32_t>& values)
 {
-    // Print at most max_cols columns per pass to keep lines manageable.
-    // Column header
-    const int w = 14;
-    const int label_w = 8;
+    std::vector<double> out;
+    out.reserve(values.size());
+    for (int32_t v : values)
+        out.push_back(static_cast<double>(v));
+    return out;
+}
 
-    for (int64_t col_start = 0; col_start < m.cols; col_start += max_cols)
+static void write_scalar_int(std::ostream& out, const std::string& label, long long value)
+{
+    out << std::left << std::setw(43) << label
+        << "I"
+        << std::right << std::setw(12) << value << "\n";
+}
+
+static void write_scalar_real(std::ostream& out, const std::string& label, double value)
+{
+    out << std::left << std::setw(43) << label
+        << "R"
+        << std::right << std::setw(27) << std::uppercase << std::scientific
+        << std::setprecision(15) << value << "\n";
+}
+
+static void write_array_header(std::ostream& out, const std::string& label, char kind, std::size_t n)
+{
+    out << std::left << std::setw(43) << label
+        << kind
+        << "   N="
+        << std::right << std::setw(12) << n << "\n";
+}
+
+static void write_integer_array(std::ostream& out, const std::string& label,
+                                const std::vector<int32_t>& values)
+{
+    write_array_header(out, label, 'I', values.size());
+    for (std::size_t i = 0; i < values.size(); ++i)
     {
-        const int64_t col_end = std::min(col_start + max_cols, m.cols);
-
-        // Column indices
-        out << std::string(label_w, ' ');
-        for (int64_t c = col_start; c < col_end; ++c)
-            out << std::setw(w) << std::right << (c + 1);
-        out << "\n";
-
-        // Separator
-        out << std::string(label_w + (col_end - col_start) * w, '-') << "\n";
-
-        // Rows
-        for (int64_t r = 0; r < m.rows; ++r)
-        {
-            out << std::setw(label_w) << std::right << (r + 1);
-            for (int64_t c = col_start; c < col_end; ++c)
-            {
-                std::ostringstream oss;
-                oss << std::fixed << std::setprecision(7) << m(static_cast<int>(r), static_cast<int>(c));
-                out << std::setw(w) << std::right << oss.str();
-            }
+        out << std::setw(12) << values[i];
+        if ((i + 1) % 6 == 0 || i + 1 == values.size())
             out << "\n";
-        }
-        out << "\n";
     }
 }
 
-// ─── Main ─────────────────────────────────────────────────────────────────────
+static void write_real_array(std::ostream& out, const std::string& label,
+                             const std::vector<double>& values)
+{
+    write_array_header(out, label, 'R', values.size());
+    out << std::uppercase << std::scientific << std::setprecision(8);
+    for (std::size_t i = 0; i < values.size(); ++i)
+    {
+        out << std::setw(16) << values[i];
+        if ((i + 1) % 5 == 0 || i + 1 == values.size())
+            out << "\n";
+    }
+}
 
 int main(int argc, char* argv[])
 {
     if (argc < 2 || argc > 3)
     {
-        std::cerr << "Usage: chkdump <file.hfchk> [output.txt]\n";
+        std::cerr << "Usage: chkdump <file.hfchk> [output.fchk]\n";
         return EXIT_FAILURE;
     }
 
-    const std::string in_path  = argv[1];
-    const bool        to_file  = (argc == 3);
+    const std::string in_path = argv[1];
+    const bool to_file = (argc == 3);
     const std::string out_path = to_file ? argv[2] : "";
 
     std::ifstream in(in_path, std::ios::binary);
@@ -173,7 +185,6 @@ int main(int argc, char* argv[])
     }
     std::ostream& out = *outp;
 
-    // ── Header ────────────────────────────────────────────────────────────────
     char magic[8] = {};
     in.read(magic, 8);
     if (std::memcmp(magic, "PLNKCHK\0", 8) != 0)
@@ -182,7 +193,7 @@ int main(int argc, char* argv[])
         return EXIT_FAILURE;
     }
 
-    const uint32_t version   = read_pod<uint32_t>(in);
+    const uint32_t version = read_pod<uint32_t>(in);
     if (version != 2)
     {
         std::cerr << "chkdump: unsupported checkpoint version " << version
@@ -190,40 +201,36 @@ int main(int argc, char* argv[])
         return EXIT_FAILURE;
     }
 
-    const uint64_t nbasis      = read_pod<uint64_t>(in);
-    const uint8_t  is_uhf      = read_pod<uint8_t>(in);
-    const uint8_t  is_conv     = read_pod<uint8_t>(in);
-    const uint32_t last_iter   = read_pod<uint32_t>(in);
-    const double   tot_energy  = read_pod<double>(in);
-    const double   nuc_rep     = read_pod<double>(in);
+    const uint64_t nbasis    = read_pod<uint64_t>(in);
+    const uint8_t  is_uhf    = read_pod<uint8_t>(in);
+    const uint8_t  converged = read_pod<uint8_t>(in);
+    const uint32_t last_iter = read_pod<uint32_t>(in);
+    const double   tot_energy = read_pod<double>(in);
+    const double   nuc_rep    = read_pod<double>(in);
 
-    // ── Molecule ──────────────────────────────────────────────────────────────
-    const uint64_t natoms   = read_pod<uint64_t>(in);
-    const int32_t  charge   = read_pod<int32_t>(in);
-    const uint32_t mult     = read_pod<uint32_t>(in);
+    const uint64_t natoms = read_pod<uint64_t>(in);
+    const int32_t  charge = read_pod<int32_t>(in);
+    const uint32_t mult   = read_pod<uint32_t>(in);
 
     std::vector<int32_t> atomic_numbers(natoms);
     for (uint64_t i = 0; i < natoms; ++i)
-        atomic_numbers[i] = read_pod<int32_t>(in);
+        atomic_numbers[static_cast<std::size_t>(i)] = read_pod<int32_t>(in);
 
     std::vector<double> coords(natoms * 3);
     for (uint64_t i = 0; i < natoms * 3; ++i)
-        coords[i] = read_pod<double>(in);
+        coords[static_cast<std::size_t>(i)] = read_pod<double>(in);
 
-    const std::string basis_name     = read_string(in);
-    const uint8_t     has_opt_coords = read_pod<uint8_t>(in);
+    const std::string basis_name = read_string(in);
+    const uint8_t has_opt_coords = read_pod<uint8_t>(in);
 
-    // ── 1e matrices ───────────────────────────────────────────────────────────
     const Matrix overlap = read_matrix(in);
     const Matrix hcore   = read_matrix(in);
 
-    // ── Alpha spin channel ────────────────────────────────────────────────────
     const Matrix alpha_density = read_matrix(in);
     const Matrix alpha_fock    = read_matrix(in);
     const Matrix alpha_mo_e    = read_vector_as_matrix(in);
     const Matrix alpha_mo_c    = read_matrix(in);
 
-    // ── Beta spin channel (UHF only) ──────────────────────────────────────────
     Matrix beta_density, beta_fock, beta_mo_e, beta_mo_c;
     if (is_uhf)
     {
@@ -239,153 +246,72 @@ int main(int argc, char* argv[])
         return EXIT_FAILURE;
     }
 
-    // ── Derive electron counts ────────────────────────────────────────────────
-    int Z_total = 0;
-    for (auto z : atomic_numbers) Z_total += z;
-    const int n_elec   = Z_total - charge;
-    const int n_unpair = static_cast<int>(mult) - 1;
-    const int n_alpha  = (n_elec + n_unpair) / 2;
-    const int n_beta   = (n_elec - n_unpair) / 2;
-    const int homo_a   = n_alpha - 1;
-    const int lumo_a   = n_alpha;
-    const int homo_b   = n_beta  - 1;
-    const int lumo_b   = n_beta;
+    int z_total = 0;
+    for (int32_t z : atomic_numbers)
+        z_total += z;
+    const int n_elec = z_total - charge;
+    const int n_unpaired = static_cast<int>(mult) - 1;
+    const int n_alpha = (n_elec + n_unpaired) / 2;
+    const int n_beta  = (n_elec - n_unpaired) / 2;
 
-    // ── Output ────────────────────────────────────────────────────────────────
-    rule(out);
-    out << "  Planck Checkpoint File  —  " << in_path << "\n";
-    rule(out);
-    out << "\n";
-
-    // General info
-    kv(out, "Format version",  std::to_string(version));
-    kv(out, "SCF type",        is_uhf ? "UHF" : "RHF");
-    kv(out, "Converged",       is_conv ? "yes" : "no");
-    if (last_iter > 0) kv(out, "Last SCF iter", std::to_string(last_iter));
-    {
-        std::ostringstream s;
-        s << std::fixed << std::setprecision(10) << tot_energy << " Eh";
-        kv(out, "Total energy", s.str());
-    }
-    {
-        std::ostringstream s;
-        s << std::fixed << std::setprecision(10) << nuc_rep << " Eh";
-        kv(out, "Nuclear repulsion", s.str());
-    }
-    kv(out, "Basis set",       basis_name);
-    kv(out, "Nbasis",          std::to_string(nbasis));
-    kv(out, "Geometry source", has_opt_coords
-                               ? "optimized (converged geomopt)"
-                               : "input (single-point or gradient)");
-
-    // Molecule
-    section(out, "Molecule");
-    kv(out, "Natoms",       std::to_string(natoms));
-    kv(out, "Charge",       std::to_string(charge));
-    kv(out, "Multiplicity", std::to_string(mult));
-    kv(out, "Electrons",    std::to_string(n_elec)
-                            + "  (" + std::to_string(n_alpha) + " alpha, "
-                            + std::to_string(n_beta)  + " beta)");
-
-    out << "\n";
-    out << "  " << std::setw(4) << "Atom"
-        << std::setw(4) << "Z"
-        << std::setw(5) << "Sym"
-        << std::setw(18) << "X (Bohr)"
-        << std::setw(16) << "Y (Bohr)"
-        << std::setw(16) << "Z (Bohr)" << "\n";
-    out << "  " << std::string(59, '-') << "\n";
-    for (uint64_t i = 0; i < natoms; ++i)
-    {
-        const int    Z  = atomic_numbers[i];
-        const double x  = coords[i * 3 + 0];
-        const double y  = coords[i * 3 + 1];
-        const double z  = coords[i * 3 + 2];
-        out << "  "
-            << std::setw(4) << (i + 1)
-            << std::setw(4) << Z
-            << std::setw(5) << element_symbol(Z)
-            << std::setw(18) << std::fixed << std::setprecision(8) << x
-            << std::setw(16) << std::fixed << std::setprecision(8) << y
-            << std::setw(16) << std::fixed << std::setprecision(8) << z
-            << "\n";
-    }
-
-    // MO energies
-    auto print_mo_energies = [&](const Matrix& mo_e, int homo, int lumo,
-                                 const std::string& spin_label)
-    {
-        section(out, spin_label + " MO Energies (Eh)");
-        out << "  " << std::setw(6)  << "MO"
-            << std::setw(18) << "Energy (Eh)"
-            << "  \n";
-        out << "  " << std::string(26, '-') << "\n";
-        for (int64_t i = 0; i < mo_e.rows; ++i)
-        {
-            out << "  " << std::setw(6) << (i + 1)
-                << std::setw(18) << std::fixed << std::setprecision(6) << mo_e.data[i];
-            if (i == homo) out << "  <-- HOMO";
-            if (i == lumo) out << "  <-- LUMO";
-            out << "\n";
-        }
-    };
+    std::vector<double> nuclear_charges = to_double_vector(atomic_numbers);
+    std::vector<double> overlap_packed  = packed_lower_triangle(overlap);
+    std::vector<double> hcore_packed    = packed_lower_triangle(hcore);
+    std::vector<double> alpha_density_packed = packed_lower_triangle(alpha_density);
+    std::vector<double> total_density_packed = alpha_density_packed;
 
     if (is_uhf)
     {
-        print_mo_energies(alpha_mo_e, homo_a, lumo_a, "Alpha");
-        print_mo_energies(beta_mo_e,  homo_b, lumo_b, "Beta");
+        total_density_packed.clear();
+        const int64_t n = std::min(alpha_density.rows, alpha_density.cols);
+        total_density_packed.reserve(static_cast<std::size_t>(n * (n + 1) / 2));
+        for (int64_t i = 0; i < n; ++i)
+            for (int64_t j = 0; j <= i; ++j)
+                total_density_packed.push_back(alpha_density(i, j) + beta_density(i, j));
     }
-    else
-    {
-        print_mo_energies(alpha_mo_e, homo_a, lumo_a, "");
-    }
 
-    // 1e matrices
-    section(out, "Overlap Matrix  (" + std::to_string(overlap.rows)
-                 + " x " + std::to_string(overlap.cols) + ")");
-    print_matrix(out, overlap);
+    out << "Planck checkpoint export\n";
+    out << std::left << std::setw(10) << "SP"
+        << std::setw(10) << (is_uhf ? "UHF" : "RHF")
+        << uppercase(basis_name) << "\n";
 
-    section(out, "Core Hamiltonian  (" + std::to_string(hcore.rows)
-                 + " x " + std::to_string(hcore.cols) + ")");
-    print_matrix(out, hcore);
+    write_scalar_int(out, "Number of atoms", static_cast<long long>(natoms));
+    write_scalar_int(out, "Charge", static_cast<long long>(charge));
+    write_scalar_int(out, "Multiplicity", static_cast<long long>(mult));
+    write_scalar_int(out, "Number of electrons", static_cast<long long>(n_elec));
+    write_scalar_int(out, "Number of alpha electrons", static_cast<long long>(n_alpha));
+    write_scalar_int(out, "Number of beta electrons", static_cast<long long>(n_beta));
+    write_scalar_int(out, "Number of basis functions", static_cast<long long>(nbasis));
+    write_scalar_int(out, "Number of independent functions", static_cast<long long>(nbasis));
+    write_scalar_int(out, "SCF converged", static_cast<long long>(converged));
+    write_scalar_int(out, "Last SCF iteration", static_cast<long long>(last_iter));
+    write_scalar_int(out, "Has optimized geometry", static_cast<long long>(has_opt_coords));
+    write_scalar_real(out, "SCF Energy", tot_energy);
+    write_scalar_real(out, "Nuclear repulsion energy", nuc_rep);
 
-    // SCF results
-    auto print_spin = [&](const Matrix& dens, const Matrix& fock,
-                          const Matrix& mo_c, const std::string& label)
-    {
-        const std::string prefix = label.empty() ? "" : label + " ";
-
-        section(out, prefix + "Density Matrix  ("
-                + std::to_string(dens.rows) + " x " + std::to_string(dens.cols) + ")");
-        print_matrix(out, dens);
-
-        section(out, prefix + "Fock Matrix  ("
-                + std::to_string(fock.rows) + " x " + std::to_string(fock.cols) + ")");
-        print_matrix(out, fock);
-
-        section(out, prefix + "MO Coefficients  ("
-                + std::to_string(mo_c.rows) + " x " + std::to_string(mo_c.cols) + ")");
-        print_matrix(out, mo_c);
-    };
+    write_integer_array(out, "Atomic numbers", to_int32_vector(atomic_numbers));
+    write_real_array(out, "Nuclear charges", nuclear_charges);
+    write_real_array(out, "Current cartesian coordinates", coords);
+    write_real_array(out, "Alpha Orbital Energies", flatten_matrix(alpha_mo_e));
+    write_real_array(out, "Alpha MO coefficients", flatten_matrix(alpha_mo_c));
 
     if (is_uhf)
     {
-        print_spin(alpha_density, alpha_fock, alpha_mo_c, "Alpha");
-        print_spin(beta_density,  beta_fock,  beta_mo_c,  "Beta");
-    }
-    else
-    {
-        print_spin(alpha_density, alpha_fock, alpha_mo_c, "");
+        write_real_array(out, "Beta Orbital Energies", flatten_matrix(beta_mo_e));
+        write_real_array(out, "Beta MO coefficients", flatten_matrix(beta_mo_c));
     }
 
-    out << "\n";
-    rule(out);
-    out << "  End of checkpoint dump\n";
-    rule(out);
-    out << "\n";
+    write_real_array(out, "Total SCF Density", total_density_packed);
+    write_real_array(out, "Alpha Density Matrix", alpha_density_packed);
+    if (is_uhf)
+        write_real_array(out, "Beta Density Matrix", packed_lower_triangle(beta_density));
 
-    if (to_file)
-        std::cerr << "chkdump: wrote " << out_path << "\n";
+    write_real_array(out, "Alpha Fock Matrix", packed_lower_triangle(alpha_fock));
+    if (is_uhf)
+        write_real_array(out, "Beta Fock Matrix", packed_lower_triangle(beta_fock));
+
+    write_real_array(out, "Core Hamiltonian Matrix", hcore_packed);
+    write_real_array(out, "Overlap Matrix", overlap_packed);
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This commit folds together the outstanding workflow, testing, and tooling work on the current branch.

It adds a manifest-driven regression runner with smoke/core/extended suites, new gradient and opt+freq inputs, and CTest/CMake entry points so the main RHF, MP2, CASSCF, gradient, and combined geometry-optimization-plus-frequency paths can be exercised consistently.

It extends the driver and frequency stack to support a combined optfreq calculation mode and to perform vibrational mode symmetry analysis. Normal modes are now classified with libmsym-based Cartesian displacement representations and printed with Mulliken irrep labels when symmetry analysis succeeds.

It also refactors the shared closed-shell derivative path, adds the current RMP2 gradient/response scaffolding and explicit numerical RMP2 gradient integration through gradient and geometry-optimization workflows, updates checkpoint/logging behavior for the new workflows, and teaches chkdump to emit Gaussian-style formatted-checkpoint output.

Finally, it adds the teaching guide and static-site exporter so the codebase and theory can be browsed as either Markdown or a standalone HTML page.

Validation performed:
- cmake -S . -B build
- cmake --build build --target hartree-fock -j4
- python3 tests/run_regressions.py --build-dir build --suite smoke
- python3 tests/run_regressions.py --build-dir build --suite core
- python3 tests/run_regressions.py --build-dir build --suite extended
- ./build/hartree-fock tests/inputs/water_freq_symmetry.hfinp