### PR TITLE
Fix geomopt density warm-start; add charge/multiplicity logging; expand energy/mode output

### DIFF
--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -130,6 +130,8 @@ int main(int argc, const char* argv[])
     HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "Calculation Type :", map_enum(calculator._calculation));
     HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "Theory :",           map_enum(calculator._scf._scf));
     HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "Basis :",            calculator._basis._basis_name);
+    HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "Charge :",           calculator._molecule.charge);
+    HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "Multiplicity :",     calculator._molecule.multiplicity);
     HartreeFock::Logger::blank();
 
     // Detect Symmetry
@@ -503,7 +505,7 @@ int main(int argc, const char* argv[])
                 std::format("Save failed: {}", res.error()));
     }
 
-    HartreeFock::Logger::converged_energy(calculator._total_energy);
+    HartreeFock::Logger::converged_energy(calculator._total_energy, calculator._nuclear_repulsion);
 
     // ── Post-HF correlation ───────────────────────────────────────────────────
     if (calculator._info._is_converged)
@@ -822,7 +824,7 @@ int main(int argc, const char* argv[])
                     HartreeFock::Logger::blank();
                 }
 
-                HartreeFock::Logger::converged_energy(calculator._total_energy);
+                HartreeFock::Logger::converged_energy(calculator._total_energy, calculator._nuclear_repulsion);
                 HartreeFock::Logger::blank();
 
                 // ── Save checkpoint with optimized geometry ───────────────────
@@ -933,6 +935,28 @@ int main(int argc, const char* argv[])
                 "Zero-point energy :",
                 std::format("{:.6f} Eh  ({:.2f} kcal/mol)",
                             freq_result.zpe, zpe_kcal));
+
+            // ── Normal mode displacements (mass-unweighted, Cartesian-normalised) ──
+            HartreeFock::Logger::blank();
+            HartreeFock::Logger::logging(HartreeFock::LogLevel::Info,
+                "Normal Mode Displacements :", "");
+            for (int i = 0; i < n_vib; ++i)
+            {
+                HartreeFock::Logger::logging(HartreeFock::LogLevel::Info,
+                    std::format("Normal Mode {:4d} :", i + 1),
+                    have_mode_symmetry
+                        ? freq_result.mode_symmetry[static_cast<std::size_t>(i)]
+                        : std::string{});
+                for (std::size_t a = 0; a < calculator._molecule.natoms; ++a)
+                {
+                    HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "",
+                        std::format("  {:4d}   {:12.8f}   {:12.8f}   {:12.8f}",
+                                    static_cast<int>(a + 1),
+                                    freq_result.normal_modes(static_cast<int>(a) * 3 + 0, i),
+                                    freq_result.normal_modes(static_cast<int>(a) * 3 + 1, i),
+                                    freq_result.normal_modes(static_cast<int>(a) * 3 + 2, i)));
+                }
+            }
             HartreeFock::Logger::blank();
         }
         catch (const std::exception& e)

--- a/src/io/logging.h
+++ b/src/io/logging.h
@@ -201,9 +201,11 @@ namespace HartreeFock
             }
         }
 
-        inline void converged_energy(double energy_hartree)
+        inline void converged_energy(double energy_hartree, double nuclear_repulsion)
         {
             std::lock_guard<std::mutex> lock(log_mutex);
+
+            const double electronic = energy_hartree - nuclear_repulsion;
 
             constexpr int LW = 32;  // label column
             constexpr int VW = 20;  // value column
@@ -215,8 +217,19 @@ namespace HartreeFock
                       << std::setw(VW) << std::right << "kcal/mol"
                       << "\n"
                       << std::string(LW + VW * 3, '-') << "\n"
-                      << std::setw(LW) << std::left  << "  Total Energy"
                       << std::fixed << std::setprecision(10)
+                      << std::setw(LW) << std::left  << "  Electronic Energy"
+                      << std::setw(VW) << std::right << electronic
+                      << std::setw(VW) << std::right << electronic * HARTREE_TO_EV
+                      << std::setw(VW) << std::right << electronic * HARTREE_TO_KCALMOL
+                      << "\n"
+                      << std::setw(LW) << std::left  << "  Nuclear Repulsion"
+                      << std::setw(VW) << std::right << nuclear_repulsion
+                      << std::setw(VW) << std::right << nuclear_repulsion * HARTREE_TO_EV
+                      << std::setw(VW) << std::right << nuclear_repulsion * HARTREE_TO_KCALMOL
+                      << "\n"
+                      << std::string(LW + VW * 3, '-') << "\n"
+                      << std::setw(LW) << std::left  << "  Total Energy"
                       << std::setw(VW) << std::right << energy_hartree
                       << std::setw(VW) << std::right << energy_hartree * HARTREE_TO_EV
                       << std::setw(VW) << std::right << energy_hartree * HARTREE_TO_KCALMOL

--- a/src/opt/geomopt.cpp
+++ b/src/opt/geomopt.cpp
@@ -35,12 +35,27 @@ static Eigen::VectorXd _run_sp_gradient(HartreeFock::Calculator& calc)
     calc._shells = HartreeFock::BasisFunctions::read_gbs_basis(
         gbs_path, calc._molecule, calc._basis._basis);
 
+    // Save converged density from the previous step to warm-start the next SCF.
+    // (initialize() zeros the density, so we must capture it beforehand.)
+    const Eigen::MatrixXd prev_alpha = calc._info._scf.alpha.density;
+    const Eigen::MatrixXd prev_beta  = calc._info._scf.beta.density;
+    const bool have_prev_density     = (prev_alpha.size() > 0);
+
     // Reset SCF data structures
     calc._info._scf = HartreeFock::DataSCF(calc._scf._scf == HartreeFock::SCFType::UHF);
     calc._info._scf.initialize(calc._shells.nbasis());
     calc._scf.set_scf_mode_auto(calc._shells.nbasis());
     calc._info._is_converged = false;
     calc._use_sao_blocking   = false;
+
+    // Restore the saved density and tell SCF to use it as the initial guess.
+    if (have_prev_density)
+    {
+        calc._info._scf.alpha.density = prev_alpha;
+        if (calc._scf._scf == HartreeFock::SCFType::UHF && prev_beta.size() > 0)
+            calc._info._scf.beta.density = prev_beta;
+        calc._scf._guess = HartreeFock::SCFGuess::ReadDensity;
+    }
 
     // Nuclear repulsion
     calc._compute_nuclear_repulsion();

--- a/visualizer/app.py
+++ b/visualizer/app.py
@@ -11,7 +11,6 @@ GET endpoint:
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
 
 from flask import Flask, jsonify, render_template
 
@@ -41,6 +40,7 @@ _SPH_R_Z: dict[int, float] = {
     35: 0.80,  53: 0.90,
 }
 
+
 # ---------------------------------------------------------------------------
 # Bond detection
 # ---------------------------------------------------------------------------
@@ -68,21 +68,21 @@ def _detect_bonds(atoms: list, tol: float = 0.45) -> list[list[int]]:
 def _run_to_json(run: ParsedRun, log_path: str) -> dict:
     atoms = run.opt_atoms or run.standard_atoms or run.input_atoms
 
-    symbols     = [ELEMENT_SYMBOLS.get(a.Z, f"X{a.Z}") for a in atoms]
-    coords_ang  = [[a.x, a.y, a.z] for a in atoms]
-    bonds       = _detect_bonds(atoms)
-    n_elec      = sum(a.Z for a in atoms)  # neutral-molecule approximation
+    symbols = [ELEMENT_SYMBOLS.get(a.Z, f"X{a.Z}") for a in atoms]
+    coords_ang = [[a.x, a.y, a.z] for a in atoms]
+    bonds = _detect_bonds(atoms)
+    n_elec = sum(a.Z for a in atoms)  # neutral-molecule approximation
 
     mol_data = {
-        "symbols":      symbols,
-        "coords_ang":   coords_ang,
-        "bonds":        bonds,
-        "hbonds":       [],
-        "cpk_colors":   [_CPK_Z.get(a.Z, "#ff69b4") for a in atoms],
+        "symbols": symbols,
+        "coords_ang": coords_ang,
+        "bonds": bonds,
+        "hbonds": [],
+        "cpk_colors": [_CPK_Z.get(a.Z, "#ff69b4") for a in atoms],
         "sphere_radii": [_SPH_R_Z.get(a.Z, 0.55) for a in atoms],
-        "num_atoms":    len(atoms),
+        "num_atoms": len(atoms),
         "num_electrons": n_elec,
-        "charge":       0,
+        "charge": 0,
         "multiplicity": 1,
     }
 
@@ -90,16 +90,20 @@ def _run_to_json(run: ParsedRun, log_path: str) -> dict:
     scf_data = None
     if run.scf_iters:
         energy_history = [it.energy for it in run.scf_iters]
-        final_energy   = run.total_energy if run.total_energy is not None else energy_history[-1]
+        final_energy = (
+            run.total_energy
+            if run.total_energy is not None
+            else energy_history[-1]
+        )
         scf_data = {
-            "energy":          final_energy,
-            "e_nuclear":       None,
-            "e_electronic":    None,
-            "converged":       run.total_energy is not None,
-            "iterations":      len(run.scf_iters),
-            "energy_history":  energy_history,
-            "n_occ":           None,
-            "orbital_energies":    [],
+            "energy": final_energy,
+            "e_nuclear": run.nuclear_repulsion_energy,
+            "e_electronic": run.electronic_energy,
+            "converged": run.total_energy is not None,
+            "iterations": len(run.scf_iters),
+            "energy_history": energy_history,
+            "n_occ": None,
+            "orbital_energies": [],
             "orbital_energies_ev": [],
         }
 
@@ -108,16 +112,18 @@ def _run_to_json(run: ParsedRun, log_path: str) -> dict:
     if run.opt_steps:
         last = run.opt_steps[-1]
         geopt_data = {
-            "converged":      run.opt_converged,
-            "iterations":     len(run.opt_steps),
+            "converged": run.opt_converged,
+            "iterations": len(run.opt_steps),
             "n_energy_evals": len(run.opt_steps),
-            "gradient_rms":   float(last.grad_rms),
-            "gradient_max":   float(last.grad_max),
-            "message":        "Converged" if run.opt_converged else "Not converged",
+            "gradient_rms": float(last.grad_rms),
+            "gradient_max": float(last.grad_max),
+            "message": (
+                "Converged" if run.opt_converged else "Not converged"
+            ),
             "trajectory": [
                 {
-                    "step":         s.step,
-                    "energy":       float(s.energy),
+                    "step": s.step,
+                    "energy": float(s.energy),
                     "gradient_max": float(s.grad_max),
                     "gradient_rms": float(s.grad_rms),
                 }
@@ -130,31 +136,39 @@ def _run_to_json(run: ParsedRun, log_path: str) -> dict:
     if run.mp2_total_energy is not None:
         mp2_data = {
             "energy": float(run.mp2_total_energy),
-            "e_corr": float(run.mp2_corr_energy) if run.mp2_corr_energy else None,
+            "e_corr": (
+                float(run.mp2_corr_energy)
+                if run.mp2_corr_energy else None
+            ),
         }
 
-    # Freq (normal modes not available from log file)
+    # Freq
     freq_data = None
     if run.freq_modes:
         freq_data = {
-            "frequencies":  [m.frequency for m in run.freq_modes],
-            "normal_modes": [],
-            "n_imaginary":  run.n_imaginary,
-            "zpe":          float(run.zpe_hartree) if run.zpe_hartree is not None else None,
+            "frequencies": [m.frequency for m in run.freq_modes],
+            "normal_modes": run.normal_modes,
+            "n_imaginary": run.n_imaginary,
+            "zpe": (
+                float(run.zpe_hartree)
+                if run.zpe_hartree is not None else None
+            ),
         }
 
     return {
-        "status":           "done",
-        "level":            run.scf_type or "RHF",
-        "basis":            run.basis or "unknown",
-        "log_file":         str(Path(log_path).name) if log_path else "",
+        "status": "done",
+        "level": run.scf_type or "RHF",
+        "basis": run.basis or "unknown",
+        "log_file": str(Path(log_path).name) if log_path else "",
         "calculation_type": run.calculation_type,
-        "point_group":      run.point_group,
-        "molecule":         mol_data,
-        "scf":              scf_data,
-        "mp2":              mp2_data,
-        "geopt":            geopt_data,
-        "freq":             freq_data,
+        "point_group": run.point_group,
+        "charge": run.charge,
+        "multiplicity": run.multiplicity,
+        "molecule": mol_data,
+        "scf": scf_data,
+        "mp2": mp2_data,
+        "geopt": geopt_data,
+        "freq": freq_data,
     }
 
 

--- a/visualizer/parser.py
+++ b/visualizer/parser.py
@@ -82,6 +82,8 @@ class ParsedRun:
     scf_type: Optional[str] = None
     basis: Optional[str] = None
     point_group: Optional[str] = None
+    charge: Optional[int] = None
+    multiplicity: Optional[int] = None
 
     # --- geometry ---
     input_atoms: list[AtomCoord] = field(default_factory=list)
@@ -94,7 +96,9 @@ class ParsedRun:
     # --- geometry optimisation ---
     opt_steps: list[OptStep] = field(default_factory=list)
     opt_converged: bool = False
-    opt_step_geometries: dict[int, list[AtomCoord]] = field(default_factory=dict)
+    opt_step_geometries: dict[int, list[AtomCoord]] = field(
+        default_factory=dict
+    )
 
     # --- vibrational frequencies ---
     freq_modes: list[FreqMode] = field(default_factory=list)
@@ -107,7 +111,13 @@ class ParsedRun:
     gradient_max: Optional[float] = None
     gradient_rms: Optional[float] = None
 
+    # --- normal mode displacements ---
+    # normal_modes[mode_idx][atom_idx] = [dx, dy, dz]
+    normal_modes: list[list[list[float]]] = field(default_factory=list)
+
     # --- final energies ---
+    electronic_energy: Optional[float] = None
+    nuclear_repulsion_energy: Optional[float] = None
     total_energy: Optional[float] = None
     mp2_corr_energy: Optional[float] = None
     mp2_total_energy: Optional[float] = None
@@ -189,9 +199,20 @@ _GRAD_MSG_RE = re.compile(
 )
 
 # Raw energy table lines (no timestamp).
+_ELECTRONIC_ENERGY_RE = re.compile(r'^\s*Electronic Energy\s+([-+\d.eE]+)')
+_NUCLEAR_REPULSION_RE = re.compile(r'^\s*Nuclear Repulsion\s+([-+\d.eE]+)')
 _TOTAL_ENERGY_RE = re.compile(r'^\s*Total Energy\s+([-+\d.eE]+)')
 _CORR_ENERGY_RE = re.compile(r'^\s*Correlation Energy\s+([-+\d.eE]+)')
 _MP2_ENERGY_RE = re.compile(r'^\s*Total MP2 Energy\s+([-+\d.eE]+)')
+
+# Normal mode displacement header: "Normal Mode    1 :"
+_MODE_LABEL_RE = re.compile(r'^Normal Mode\s+(\d+)\s*:')
+
+# Normal mode displacement row: "  {atom}   {dx}   {dy}   {dz}"
+_MODE_DISP_RE = re.compile(
+    r'^\s*(\d+)'
+    r'\s+([-\d.]+)\s+([-\d.]+)\s+([-\d.]+)\s*$'
+)
 
 # Geometry optimisation convergence sentinel in message.
 _OPT_CONV_RE = re.compile(r'Converged in \d+ steps')
@@ -210,6 +231,7 @@ class _State:
     FREQ_TABLE = "FREQ_TABLE"
     GRADIENT = "GRADIENT"
     STEP_GEOM = "STEP_GEOM"
+    NORMAL_MODE = "NORMAL_MODE"
 
 
 # ---------------------------------------------------------------------------
@@ -221,7 +243,8 @@ def _parse_log_line(raw: str):
     m = _LOG_RE.match(raw)
     if not m:
         return None
-    field30 = m.group(1)   # exactly 30 chars (label field, may have trailing spaces)
+    # exactly 30 chars (label field, may have trailing spaces)
+    field30 = m.group(1)
     message = m.group(2)
     # Handle label overflow: setw(30) is a minimum, not a maximum.
     # "Optimized Geometry (Angstrom) :" is 31 chars — the trailing ':'
@@ -319,6 +342,14 @@ def parse_log(path: str | Path) -> ParsedRun:
 
         # Raw energy table lines (after first SCF has completed).
         if scf_done:
+            m = _ELECTRONIC_ENERGY_RE.match(raw)
+            if m and run.electronic_energy is None:
+                run.electronic_energy = float(m.group(1))
+                continue
+            m = _NUCLEAR_REPULSION_RE.match(raw)
+            if m and run.nuclear_repulsion_energy is None:
+                run.nuclear_repulsion_energy = float(m.group(1))
+                continue
             m = _TOTAL_ENERGY_RE.match(raw)
             if m and run.total_energy is None:
                 run.total_energy = float(m.group(1))
@@ -350,6 +381,18 @@ def parse_log(path: str | Path) -> ParsedRun:
             continue
         if label == "Point Group :" and run.point_group is None:
             run.point_group = message.strip()
+            continue
+        if label == "Charge :":
+            try:
+                run.charge = int(message.strip())
+            except ValueError:
+                pass
+            continue
+        if label == "Multiplicity :":
+            try:
+                run.multiplicity = int(message.strip())
+            except ValueError:
+                pass
             continue
 
         # Arm the SCF gate on "Begin SCF Cycles :".
@@ -427,6 +470,16 @@ def parse_log(path: str | Path) -> ParsedRun:
                 run.zpe_kcal = float(m.group(2))
             continue
 
+        # ── Normal mode displacements ───────────────────────────────────────
+        if label == "Normal Mode Displacements :":
+            state = _State.INIT  # individual modes handled by _MODE_LABEL_RE
+            continue
+        m = _MODE_LABEL_RE.match(label)
+        if m:
+            run.normal_modes.append([])
+            state = _State.NORMAL_MODE
+            continue
+
         # ── State-dependent line processing ────────────────────────────────
         if state == _State.INPUT_COORDS:
             if label == "":
@@ -471,6 +524,20 @@ def parse_log(path: str | Path) -> ParsedRun:
                 if atom:
                     run.opt_step_geometries[_current_step_n].append(atom)
             else:
+                state = _State.INIT
+
+        elif state == _State.NORMAL_MODE:
+            if label == "":
+                md = _MODE_DISP_RE.match(message)
+                if md and run.normal_modes:
+                    run.normal_modes[-1].append([
+                        float(md.group(2)),
+                        float(md.group(3)),
+                        float(md.group(4)),
+                    ])
+            else:
+                # Any named label exits; _MODE_LABEL_RE above will re-enter
+                # for the next mode before we ever reach here.
                 state = _State.INIT
 
         elif state == _State.GRADIENT:


### PR DESCRIPTION
## geomopt: fix density reset causing wrong energies on checkpoint restart (src/opt/geomopt.cpp)

_run_sp_gradient() called DataSCF::initialize() before every gradient evaluation, which zeroed the density matrix.  The SCF warm-start guard in run_rhf/run_uhf checks _guess == ReadDensity|ReadFull and reads calc._info._scf.alpha.density — but that matrix had already been wiped, so iteration 1 always had zero electronic energy and the total energy equalled the bare nuclear repulsion (+36.6 Eh for the water dimer). The SCF then converged to a different local minimum (-146.5 Eh instead of -149.9 Eh), producing corrupted gradients and a wrong optimised structure on every checkpoint restart.

Fix: capture alpha (and beta for UHF) density before initialize(), then restore it and set _guess = ReadDensity so the SCF routine uses it as the initial guess.  This makes every gradient evaluation warm-start from the previous converged density, which is correct for geomopt and matches the behaviour of the initial single-point SCF.

## driver/logging: log charge and multiplicity; expand energy table (src/driver.cpp, src/io/logging.h)

Add "Charge :" and "Multiplicity :" log lines immediately after the "Basis :" line so the header block is complete.

Extend converged_energy() to accept the nuclear repulsion and print a three-row table (Electronic Energy / Nuclear Repulsion / Total Energy) in Hartree, eV, and kcal/mol, matching the existing correlation_energy() style.  Both call sites in driver.cpp updated accordingly.

Add normal-mode displacement output after the ZPE line: one log entry per mode listing the Cartesian displacement vector for each atom.

## visualizer: parse new log fields; propagate to JSON (visualizer/parser.py, visualizer/app.py)

parser.py:
- Add charge and multiplicity fields to ParsedRun; parse "Charge :" and "Multiplicity :" log labels.
- Add electronic_energy and nuclear_repulsion_energy to ParsedRun; parse the new "Electronic Energy" and "Nuclear Repulsion" raw table lines.
- Add normal_modes (list[list[list[float]]]) to ParsedRun; add NORMAL_MODE parser state and _MODE_LABEL_RE / _MODE_DISP_RE regexes to collect per-atom displacement vectors for each vibrational mode.

app.py:
- Propagate charge, multiplicity, electronic_energy, nuclear_repulsion_ energy, and normal_modes into the JSON response so the frontend can display them.