### PR TITLE
Fix Rys quadrature and add automatic OS/Rys 2e dispatch

### DIFF
--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -14,6 +14,7 @@
 #include "io/logging.h"
 #include "symmetry/symmetry.h"
 #include "symmetry/mo_symmetry.h"
+#include "symmetry/integral_symmetry.h"
 #include "basis/basis.h"
 #include "integrals/shellpair.h"
 #include "integrals/base.h"
@@ -263,11 +264,15 @@ int main(int argc, const char* argv[])
 
                 // 1e integrals must be computed in the large (current) basis
                 const std::size_t large_nb = calculator._shells.nbasis();
+                HartreeFock::Symmetry::update_integral_symmetry(calculator);
 
                 HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "1e Integrals :", "Computing overlap and kinetic energy matrices");
-                auto [S, T] = _compute_1e(shellpairs, large_nb, calculator._integral._engine);
+                auto [S, T] = _compute_1e(shellpairs, large_nb, calculator._integral._engine,
+                                          calculator._use_integral_symmetry ? &calculator._integral_symmetry_ops : nullptr);
                 HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "1e Integrals :", "Computing nuclear attraction matrix");
-                Eigen::MatrixXd V = _compute_nuclear_attraction(shellpairs, large_nb, calculator._molecule, calculator._integral._engine);
+                Eigen::MatrixXd V = _compute_nuclear_attraction(shellpairs, large_nb, calculator._molecule,
+                                                                calculator._integral._engine,
+                                                                calculator._use_integral_symmetry ? &calculator._integral_symmetry_ops : nullptr);
                 HartreeFock::Logger::blank();
 
                 calculator._overlap = S;
@@ -359,13 +364,24 @@ int main(int argc, const char* argv[])
 
     if (!loaded_from_checkpoint)
     {
+        HartreeFock::Symmetry::update_integral_symmetry(calculator);
+        if (calculator._use_integral_symmetry)
+        {
+            HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "Integral Symmetry :",
+                std::format("{} signed AO symmetry operations enabled",
+                            calculator._integral_symmetry_ops.size()));
+        }
+
         HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "1e Integrals :", "Computing overlap and kinetic energy matrices");
 
-        auto [S, T] = _compute_1e(shellpairs, calculator._shells.nbasis(), calculator._integral._engine);
+        auto [S, T] = _compute_1e(shellpairs, calculator._shells.nbasis(), calculator._integral._engine,
+                                  calculator._use_integral_symmetry ? &calculator._integral_symmetry_ops : nullptr);
         HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "1e Integrals :", "Overlap and kinetic done");
 
         HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "1e Integrals :", "Computing nuclear attraction matrix");
-        Eigen::MatrixXd V = _compute_nuclear_attraction(shellpairs, calculator._shells.nbasis(), calculator._molecule, calculator._integral._engine);
+        Eigen::MatrixXd V = _compute_nuclear_attraction(shellpairs, calculator._shells.nbasis(),
+                                                        calculator._molecule, calculator._integral._engine,
+                                                        calculator._use_integral_symmetry ? &calculator._integral_symmetry_ops : nullptr);
         HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "1e Integrals :", "Nuclear attraction done");
         HartreeFock::Logger::blank();
 
@@ -801,11 +817,14 @@ int main(int argc, const char* argv[])
             calculator._compute_nuclear_repulsion();
 
             auto sp_sym  = build_shellpairs(calculator._shells);
+            HartreeFock::Symmetry::update_integral_symmetry(calculator);
             auto [S_sym, T_sym] = _compute_1e(sp_sym, calculator._shells.nbasis(),
-                                               calculator._integral._engine);
+                                               calculator._integral._engine,
+                                               calculator._use_integral_symmetry ? &calculator._integral_symmetry_ops : nullptr);
             auto V_sym = _compute_nuclear_attraction(sp_sym, calculator._shells.nbasis(),
                                                       calculator._molecule,
-                                                      calculator._integral._engine);
+                                                      calculator._integral._engine,
+                                                      calculator._use_integral_symmetry ? &calculator._integral_symmetry_ops : nullptr);
             calculator._overlap = S_sym;
             calculator._hcore   = T_sym + V_sym;
 

--- a/src/freq/hessian.cpp
+++ b/src/freq/hessian.cpp
@@ -18,6 +18,7 @@
 #include "scf/scf.h"
 #include "gradient/gradient.h"
 #include "symmetry/vibrational_symmetry.h"
+#include "symmetry/integral_symmetry.h"
 
 // ─── Physical constants ────────────────────────────────────────────────────────
 //
@@ -59,11 +60,14 @@ static Eigen::MatrixXd _run_sp_gradient_freq(HartreeFock::Calculator& calc)
     calc._compute_nuclear_repulsion();
 
     auto shell_pairs = build_shellpairs(calc._shells);
+    HartreeFock::Symmetry::update_integral_symmetry(calc);
 
     auto [S, T] = _compute_1e(shell_pairs, calc._shells.nbasis(),
-                               calc._integral._engine);
+                               calc._integral._engine,
+                               calc._use_integral_symmetry ? &calc._integral_symmetry_ops : nullptr);
     auto V = _compute_nuclear_attraction(shell_pairs, calc._shells.nbasis(),
-                                          calc._molecule, calc._integral._engine);
+                                          calc._molecule, calc._integral._engine,
+                                          calc._use_integral_symmetry ? &calc._integral_symmetry_ops : nullptr);
     calc._overlap = S;
     calc._hcore   = T + V;
 

--- a/src/gradient/gradient.cpp
+++ b/src/gradient/gradient.cpp
@@ -10,6 +10,7 @@
 #include "integrals/shellpair.h"
 #include "post_hf/mp2.h"
 #include "scf/scf.h"
+#include "symmetry/integral_symmetry.h"
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -65,9 +66,12 @@ static double run_sp_rmp2_energy(HartreeFock::Calculator& calc)
     calc._compute_nuclear_repulsion();
 
     auto shell_pairs = build_shellpairs(calc._shells);
-    auto [S, T] = _compute_1e(shell_pairs, calc._shells.nbasis(), calc._integral._engine);
+    HartreeFock::Symmetry::update_integral_symmetry(calc);
+    auto [S, T] = _compute_1e(shell_pairs, calc._shells.nbasis(), calc._integral._engine,
+                              calc._use_integral_symmetry ? &calc._integral_symmetry_ops : nullptr);
     auto V = _compute_nuclear_attraction(shell_pairs, calc._shells.nbasis(),
-                                         calc._molecule, calc._integral._engine);
+                                         calc._molecule, calc._integral._engine,
+                                         calc._use_integral_symmetry ? &calc._integral_symmetry_ops : nullptr);
     calc._overlap = S;
     calc._hcore   = T + V;
 

--- a/src/integrals/base.h
+++ b/src/integrals/base.h
@@ -26,6 +26,23 @@ inline Eigen::MatrixXd _compute_nuclear_attraction(
     return HartreeFock::ObaraSaika::_compute_nuclear_attraction(shell_pairs, nbasis, molecule, sym_ops);
 }
 
+inline std::vector<double> _compute_2e(
+    const std::vector<HartreeFock::ShellPair>& shell_pairs,
+    const std::size_t nbasis,
+    const HartreeFock::IntegralMethod& engine,
+    double tol_eri = 1e-10,
+    const std::vector<HartreeFock::SignedAOSymOp>* sym_ops = nullptr)
+{
+    switch (engine) {
+        case HartreeFock::IntegralMethod::RysQuadrature:
+            return HartreeFock::RysQuad::_compute_2e(shell_pairs, nbasis, tol_eri, sym_ops);
+        case HartreeFock::IntegralMethod::Auto:
+            return HartreeFock::RysQuad::_compute_2e_auto(shell_pairs, nbasis, tol_eri, sym_ops);
+        default:
+            return HartreeFock::ObaraSaika::_compute_2e(shell_pairs, nbasis, tol_eri, sym_ops);
+    }
+}
+
 inline Eigen::MatrixXd _compute_2e_fock(const std::vector<HartreeFock::ShellPair>& shell_pairs,
                                          const Eigen::MatrixXd& density,
                                          const std::size_t nbasis,

--- a/src/integrals/os.cpp
+++ b/src/integrals/os.cpp
@@ -2,6 +2,145 @@
 #include "base.h"
 #include "boys.h"
 
+#include <algorithm>
+#include <array>
+#include <cstdint>
+
+namespace
+{
+using SymOps = std::vector<HartreeFock::SignedAOSymOp>;
+
+struct PairOrbitElem
+{
+    std::size_t i = 0;
+    std::size_t j = 0;
+    int sign = 1;
+};
+
+struct QuartetOrbitElem
+{
+    std::size_t i = 0;
+    std::size_t j = 0;
+    std::size_t k = 0;
+    std::size_t l = 0;
+    int sign = 1;
+};
+
+static bool use_symmetry_ops(const SymOps* sym_ops)
+{
+    return sym_ops != nullptr && sym_ops->size() > 1;
+}
+
+static void canonicalize_pair(std::size_t& i, std::size_t& j)
+{
+    if (i > j)
+        std::swap(i, j);
+}
+
+static void canonicalize_quartet(std::size_t& i, std::size_t& j,
+                                 std::size_t& k, std::size_t& l)
+{
+    canonicalize_pair(i, j);
+    canonicalize_pair(k, l);
+    if (std::tie(i, j) > std::tie(k, l))
+    {
+        std::swap(i, k);
+        std::swap(j, l);
+    }
+}
+
+static bool append_pair_orbit(std::vector<PairOrbitElem>& orbit,
+                              std::size_t i, std::size_t j, int sign)
+{
+    for (const auto& elem : orbit)
+    {
+        if (elem.i == i && elem.j == j)
+            return elem.sign == sign;
+    }
+    orbit.push_back({i, j, sign});
+    return true;
+}
+
+static bool append_quartet_orbit(std::vector<QuartetOrbitElem>& orbit,
+                                 std::size_t i, std::size_t j,
+                                 std::size_t k, std::size_t l, int sign)
+{
+    for (const auto& elem : orbit)
+    {
+        if (elem.i == i && elem.j == j && elem.k == k && elem.l == l)
+            return elem.sign == sign;
+    }
+    orbit.push_back({i, j, k, l, sign});
+    return true;
+}
+
+static std::pair<std::vector<PairOrbitElem>, bool> build_pair_orbit(
+    std::size_t i, std::size_t j, const SymOps& sym_ops)
+{
+    std::vector<PairOrbitElem> orbit;
+    orbit.reserve(sym_ops.size());
+
+    for (const auto& op : sym_ops)
+    {
+        std::size_t ii = static_cast<std::size_t>(op.ao_map[i]);
+        std::size_t jj = static_cast<std::size_t>(op.ao_map[j]);
+        const int sign = static_cast<int>(op.ao_sign[i]) * static_cast<int>(op.ao_sign[j]);
+        canonicalize_pair(ii, jj);
+        if (!append_pair_orbit(orbit, ii, jj, sign))
+            return {orbit, true};
+    }
+
+    std::sort(orbit.begin(), orbit.end(),
+              [](const PairOrbitElem& a, const PairOrbitElem& b) {
+                  return std::tie(a.i, a.j) < std::tie(b.i, b.j);
+              });
+    return {orbit, false};
+}
+
+static std::pair<std::vector<QuartetOrbitElem>, bool> build_quartet_orbit(
+    std::size_t i, std::size_t j, std::size_t k, std::size_t l,
+    const SymOps& sym_ops)
+{
+    std::vector<QuartetOrbitElem> orbit;
+    orbit.reserve(sym_ops.size());
+
+    for (const auto& op : sym_ops)
+    {
+        std::size_t ii = static_cast<std::size_t>(op.ao_map[i]);
+        std::size_t jj = static_cast<std::size_t>(op.ao_map[j]);
+        std::size_t kk = static_cast<std::size_t>(op.ao_map[k]);
+        std::size_t ll = static_cast<std::size_t>(op.ao_map[l]);
+        const int sign = static_cast<int>(op.ao_sign[i]) * static_cast<int>(op.ao_sign[j]) *
+                         static_cast<int>(op.ao_sign[k]) * static_cast<int>(op.ao_sign[l]);
+        canonicalize_quartet(ii, jj, kk, ll);
+        if (!append_quartet_orbit(orbit, ii, jj, kk, ll, sign))
+            return {orbit, true};
+    }
+
+    std::sort(orbit.begin(), orbit.end(),
+              [](const QuartetOrbitElem& a, const QuartetOrbitElem& b) {
+                  return std::tie(a.i, a.j, a.k, a.l) < std::tie(b.i, b.j, b.k, b.l);
+              });
+    return {orbit, false};
+}
+
+static void write_eri_permutations(std::vector<double>& eri,
+                                   std::size_t nb, std::size_t nb2, std::size_t nb3,
+                                   std::size_t i, std::size_t j,
+                                   std::size_t k, std::size_t l,
+                                   double val)
+{
+    eri[i*nb3 + j*nb2 + k*nb + l] = val;
+    eri[j*nb3 + i*nb2 + k*nb + l] = val;
+    eri[i*nb3 + j*nb2 + l*nb + k] = val;
+    eri[j*nb3 + i*nb2 + l*nb + k] = val;
+    eri[k*nb3 + l*nb2 + i*nb + j] = val;
+    eri[l*nb3 + k*nb2 + i*nb + j] = val;
+    eri[k*nb3 + l*nb2 + j*nb + i] = val;
+    eri[l*nb3 + k*nb2 + j*nb + i] = val;
+}
+} // namespace
+
 inline double HartreeFock::ObaraSaika::_os_1d(const double gamma, const double distPA, const double distPB, const int lA, const int lB)
 {
     // +2 shifted overlaps are needed by the kinetic energy formula (lB+2),
@@ -48,23 +187,53 @@ inline double HartreeFock::ObaraSaika::_os_1d(const double gamma, const double d
     return S[lA][lB];
 }
 
-std::pair<Eigen::MatrixXd, Eigen::MatrixXd> HartreeFock::ObaraSaika::_compute_1e(const std::vector<HartreeFock::ShellPair> &shell_pairs, const std::size_t nbasis, const std::vector<HartreeFock::SignedAOSymOp>*)
+std::pair<Eigen::MatrixXd, Eigen::MatrixXd> HartreeFock::ObaraSaika::_compute_1e(
+    const std::vector<HartreeFock::ShellPair> &shell_pairs,
+    const std::size_t nbasis,
+    const std::vector<HartreeFock::SignedAOSymOp>* sym_ops)
 {
     const std::size_t npairs = shell_pairs.size();
     Eigen::MatrixXd overlap  = Eigen::MatrixXd::Zero(nbasis, nbasis);
     Eigen::MatrixXd kinetic  = Eigen::MatrixXd::Zero(nbasis, nbasis);
+    const bool use_sym       = use_symmetry_ops(sym_ops);
 
 #pragma omp parallel for schedule(dynamic)
     for (std::size_t i = 0; i < npairs; i++)
     {
         const std::size_t ii = shell_pairs[i].A._index;
         const std::size_t jj = shell_pairs[i].B._index;
-        const auto [s, t]    = _compute_3d_overlap_kinetic(shell_pairs[i]);
+        std::vector<PairOrbitElem> orbit;
 
-        overlap(ii, jj) = s;
-        overlap(jj, ii) = s;
-        kinetic(ii, jj) = t;
-        kinetic(jj, ii) = t;
+        if (use_sym)
+        {
+            auto [orb, forced_zero] = build_pair_orbit(ii, jj, *sym_ops);
+            if (forced_zero)
+                continue;
+            orbit = std::move(orb);
+            if (orbit.front().i != ii || orbit.front().j != jj)
+                continue;
+        }
+
+        const auto [s, t] = _compute_3d_overlap_kinetic(shell_pairs[i]);
+
+        if (!use_sym)
+        {
+            overlap(ii, jj) = s;
+            overlap(jj, ii) = s;
+            kinetic(ii, jj) = t;
+            kinetic(jj, ii) = t;
+            continue;
+        }
+
+        for (const auto& elem : orbit)
+        {
+            const double se = static_cast<double>(elem.sign) * s;
+            const double te = static_cast<double>(elem.sign) * t;
+            overlap(elem.i, elem.j) = se;
+            overlap(elem.j, elem.i) = se;
+            kinetic(elem.i, elem.j) = te;
+            kinetic(elem.j, elem.i) = te;
+        }
     }
 
     return {overlap, kinetic};
@@ -307,10 +476,11 @@ Eigen::MatrixXd HartreeFock::ObaraSaika::_compute_nuclear_attraction(
     const std::vector<HartreeFock::ShellPair>& shell_pairs,
     const std::size_t nbasis,
     const HartreeFock::Molecule& molecule,
-    const std::vector<HartreeFock::SignedAOSymOp>*)
+    const std::vector<HartreeFock::SignedAOSymOp>* sym_ops)
 {
     const std::size_t npairs = shell_pairs.size();
     Eigen::MatrixXd V        = Eigen::MatrixXd::Zero(nbasis, nbasis);
+    const bool use_sym       = use_symmetry_ops(sym_ops);
 
 #pragma omp parallel for schedule(dynamic)
     for (std::size_t p = 0; p < npairs; p++)
@@ -318,6 +488,17 @@ Eigen::MatrixXd HartreeFock::ObaraSaika::_compute_nuclear_attraction(
         const auto& sp = shell_pairs[p];
         const std::size_t ii = sp.A._index;
         const std::size_t jj = sp.B._index;
+        std::vector<PairOrbitElem> orbit;
+
+        if (use_sym)
+        {
+            auto [orb, forced_zero] = build_pair_orbit(ii, jj, *sym_ops);
+            if (forced_zero)
+                continue;
+            orbit = std::move(orb);
+            if (orbit.front().i != ii || orbit.front().j != jj)
+                continue;
+        }
 
         const int lAx = sp.A._cartesian[0], lAy = sp.A._cartesian[1], lAz = sp.A._cartesian[2];
         const int lBx = sp.B._cartesian[0], lBy = sp.B._cartesian[1], lBz = sp.B._cartesian[2];
@@ -343,8 +524,19 @@ Eigen::MatrixXd HartreeFock::ObaraSaika::_compute_nuclear_attraction(
             v_elem -= Z_C * v_nuc; // nuclear attraction is negative
         }
 
-        V(ii, jj) = v_elem;
-        V(jj, ii) = v_elem;
+        if (!use_sym)
+        {
+            V(ii, jj) = v_elem;
+            V(jj, ii) = v_elem;
+            continue;
+        }
+
+        for (const auto& elem : orbit)
+        {
+            const double ve = static_cast<double>(elem.sign) * v_elem;
+            V(elem.i, elem.j) = ve;
+            V(elem.j, elem.i) = ve;
+        }
     }
 
     return V;
@@ -687,6 +879,19 @@ static double _contracted_eri(
                                      lCx, lCy, lCz, lDx, lDy, lDz,
                                      ABx, ABy, ABz, CDx, CDy, CDz);
     return eri;
+}
+
+double HartreeFock::ObaraSaika::_contracted_eri_elem(
+    const HartreeFock::ShellPair& spAB,
+    const HartreeFock::ShellPair& spCD,
+    int lAx, int lAy, int lAz,
+    int lBx, int lBy, int lBz,
+    int lCx, int lCy, int lCz,
+    int lDx, int lDy, int lDz)
+{
+    return _contracted_eri(spAB, spCD,
+                           lAx, lAy, lAz, lBx, lBy, lBz,
+                           lCx, lCy, lCz, lDx, lDy, lDz);
 }
 
 // ─── Gradient: derivative integral helpers ────────────────────────────────────
@@ -1069,7 +1274,8 @@ std::array<double,12> HartreeFock::ObaraSaika::_compute_eri_deriv_elem(
 // Forward declaration — defined later in this file before _compute_2e.
 static Eigen::MatrixXd _compute_schwarz_table(
     const std::vector<HartreeFock::ShellPair>& shell_pairs,
-    std::size_t nbasis);
+    std::size_t nbasis,
+    const std::vector<HartreeFock::SignedAOSymOp>* sym_ops);
 
 // ─── Public: build 2e Fock (G = J - 0.5*K) ──────────────────────────────────
 //
@@ -1083,13 +1289,14 @@ Eigen::MatrixXd HartreeFock::ObaraSaika::_compute_2e_fock(
     const Eigen::MatrixXd& density,
     const std::size_t nbasis,
     const double tol_eri,
-    const std::vector<HartreeFock::SignedAOSymOp>*)
+    const std::vector<HartreeFock::SignedAOSymOp>* sym_ops)
 {
     const std::size_t nb  = nbasis;
     const std::size_t nb2 = nb * nb;
     const std::size_t nb3 = nb * nb * nb;
+    const bool use_sym = use_symmetry_ops(sym_ops);
 
-    const Eigen::MatrixXd Q = _compute_schwarz_table(shell_pairs, nb);
+    const Eigen::MatrixXd Q = _compute_schwarz_table(shell_pairs, nb, sym_ops);
 
     // ── Phase 1: build ERI tensor ─────────────────────────────────────────────
     std::vector<double> eri(nb * nb * nb * nb, 0.0);
@@ -1112,9 +1319,21 @@ Eigen::MatrixXd HartreeFock::ObaraSaika::_compute_2e_fock(
             const auto& spCD = shell_pairs[q];
             const std::size_t k = spCD.A._index;
             const std::size_t l = spCD.B._index;
+            std::vector<QuartetOrbitElem> orbit;
 
             // Schwarz screening
             if (Q(i, j) * Q(k, l) < tol_eri) continue;
+
+            if (use_sym)
+            {
+                auto [orb, forced_zero] = build_quartet_orbit(i, j, k, l, *sym_ops);
+                if (forced_zero)
+                    continue;
+                orbit = std::move(orb);
+                if (orbit.front().i != i || orbit.front().j != j ||
+                    orbit.front().k != k || orbit.front().l != l)
+                    continue;
+            }
 
             const int lCx = spCD.A._cartesian[0], lCy = spCD.A._cartesian[1], lCz = spCD.A._cartesian[2];
             const int lDx = spCD.B._cartesian[0], lDy = spCD.B._cartesian[1], lDz = spCD.B._cartesian[2];
@@ -1123,17 +1342,16 @@ Eigen::MatrixXd HartreeFock::ObaraSaika::_compute_2e_fock(
                                                lAx, lAy, lAz, lBx, lBy, lBz,
                                                lCx, lCy, lCz, lDx, lDy, lDz);
 
-            // Fill all 8 permutation-symmetry equivalent slots:
-            //   (ij|kl) = (ji|kl) = (ij|lk) = (ji|lk)
-            //           = (kl|ij) = (lk|ij) = (kl|ji) = (lk|ji)
-            eri[i*nb3 + j*nb2 + k*nb + l] = val;
-            eri[j*nb3 + i*nb2 + k*nb + l] = val;
-            eri[i*nb3 + j*nb2 + l*nb + k] = val;
-            eri[j*nb3 + i*nb2 + l*nb + k] = val;
-            eri[k*nb3 + l*nb2 + i*nb + j] = val;
-            eri[l*nb3 + k*nb2 + i*nb + j] = val;
-            eri[k*nb3 + l*nb2 + j*nb + i] = val;
-            eri[l*nb3 + k*nb2 + j*nb + i] = val;
+            if (!use_sym)
+            {
+                write_eri_permutations(eri, nb, nb2, nb3, i, j, k, l, val);
+                continue;
+            }
+
+            for (const auto& elem : orbit)
+                write_eri_permutations(eri, nb, nb2, nb3,
+                                       elem.i, elem.j, elem.k, elem.l,
+                                       static_cast<double>(elem.sign) * val);
         }
     }
 
@@ -1168,13 +1386,14 @@ HartreeFock::ObaraSaika::_compute_2e_fock_uhf(
     const Eigen::MatrixXd& Pb,
     const std::size_t nbasis,
     const double tol_eri,
-    const std::vector<HartreeFock::SignedAOSymOp>*)
+    const std::vector<HartreeFock::SignedAOSymOp>* sym_ops)
 {
     const std::size_t nb  = nbasis;
     const std::size_t nb2 = nb * nb;
     const std::size_t nb3 = nb * nb * nb;
+    const bool use_sym = use_symmetry_ops(sym_ops);
 
-    const Eigen::MatrixXd Q = _compute_schwarz_table(shell_pairs, nb);
+    const Eigen::MatrixXd Q = _compute_schwarz_table(shell_pairs, nb, sym_ops);
 
     // ── Phase 1: build ERI tensor (identical to _compute_2e_fock) ────────────
     std::vector<double> eri(nb * nb * nb * nb, 0.0);
@@ -1195,9 +1414,21 @@ HartreeFock::ObaraSaika::_compute_2e_fock_uhf(
             const auto& spCD = shell_pairs[q];
             const std::size_t k = spCD.A._index;
             const std::size_t l = spCD.B._index;
+            std::vector<QuartetOrbitElem> orbit;
 
             // Schwarz screening
             if (Q(i, j) * Q(k, l) < tol_eri) continue;
+
+            if (use_sym)
+            {
+                auto [orb, forced_zero] = build_quartet_orbit(i, j, k, l, *sym_ops);
+                if (forced_zero)
+                    continue;
+                orbit = std::move(orb);
+                if (orbit.front().i != i || orbit.front().j != j ||
+                    orbit.front().k != k || orbit.front().l != l)
+                    continue;
+            }
 
             const int lCx = spCD.A._cartesian[0], lCy = spCD.A._cartesian[1], lCz = spCD.A._cartesian[2];
             const int lDx = spCD.B._cartesian[0], lDy = spCD.B._cartesian[1], lDz = spCD.B._cartesian[2];
@@ -1206,14 +1437,16 @@ HartreeFock::ObaraSaika::_compute_2e_fock_uhf(
                                                lAx, lAy, lAz, lBx, lBy, lBz,
                                                lCx, lCy, lCz, lDx, lDy, lDz);
 
-            eri[i*nb3 + j*nb2 + k*nb + l] = val;
-            eri[j*nb3 + i*nb2 + k*nb + l] = val;
-            eri[i*nb3 + j*nb2 + l*nb + k] = val;
-            eri[j*nb3 + i*nb2 + l*nb + k] = val;
-            eri[k*nb3 + l*nb2 + i*nb + j] = val;
-            eri[l*nb3 + k*nb2 + i*nb + j] = val;
-            eri[k*nb3 + l*nb2 + j*nb + i] = val;
-            eri[l*nb3 + k*nb2 + j*nb + i] = val;
+            if (!use_sym)
+            {
+                write_eri_permutations(eri, nb, nb2, nb3, i, j, k, l, val);
+                continue;
+            }
+
+            for (const auto& elem : orbit)
+                write_eri_permutations(eri, nb, nb2, nb3,
+                                       elem.i, elem.j, elem.k, elem.l,
+                                       static_cast<double>(elem.sign) * val);
         }
     }
 
@@ -1319,14 +1552,28 @@ Eigen::MatrixXd HartreeFock::ObaraSaika::_compute_cross_overlap(
 // Bounds any quartet: |(ij|kl)| ≤ Q(i,j)·Q(k,l)  (Cauchy-Schwarz inequality).
 static Eigen::MatrixXd _compute_schwarz_table(
     const std::vector<HartreeFock::ShellPair>& shell_pairs,
-    std::size_t nbasis)
+    std::size_t nbasis,
+    const std::vector<HartreeFock::SignedAOSymOp>* sym_ops)
 {
     Eigen::MatrixXd Q = Eigen::MatrixXd::Zero(nbasis, nbasis);
+    const bool use_sym = use_symmetry_ops(sym_ops);
 
     for (const auto& sp : shell_pairs)
     {
         const std::size_t i = sp.A._index;
         const std::size_t j = sp.B._index;
+        std::vector<PairOrbitElem> orbit;
+
+        if (use_sym)
+        {
+            auto [orb, forced_zero] = build_pair_orbit(i, j, *sym_ops);
+            if (forced_zero)
+                continue;
+            orbit = std::move(orb);
+            if (orbit.front().i != i || orbit.front().j != j)
+                continue;
+        }
+
         const int lAx = sp.A._cartesian[0], lAy = sp.A._cartesian[1], lAz = sp.A._cartesian[2];
         const int lBx = sp.B._cartesian[0], lBy = sp.B._cartesian[1], lBz = sp.B._cartesian[2];
 
@@ -1334,8 +1581,18 @@ static Eigen::MatrixXd _compute_schwarz_table(
                                             lAx, lAy, lAz, lBx, lBy, lBz,
                                             lAx, lAy, lAz, lBx, lBy, lBz);
         const double q = std::sqrt(std::abs(diag));
-        Q(i, j) = q;
-        Q(j, i) = q;
+        if (!use_sym)
+        {
+            Q(i, j) = q;
+            Q(j, i) = q;
+            continue;
+        }
+
+        for (const auto& elem : orbit)
+        {
+            Q(elem.i, elem.j) = q;
+            Q(elem.j, elem.i) = q;
+        }
     }
 
     return Q;
@@ -1346,13 +1603,14 @@ std::vector <double> HartreeFock::ObaraSaika::_compute_2e(
     const std::vector<HartreeFock::ShellPair>& shell_pairs,
     const std::size_t nbasis,
     const double tol_eri,
-    const std::vector<HartreeFock::SignedAOSymOp>*)
+    const std::vector<HartreeFock::SignedAOSymOp>* sym_ops)
 {
     const std::size_t nb  = nbasis;
     const std::size_t nb2 = nb * nb;
     const std::size_t nb3 = nb * nb * nb;
+    const bool use_sym = use_symmetry_ops(sym_ops);
 
-    const Eigen::MatrixXd Q = _compute_schwarz_table(shell_pairs, nb);
+    const Eigen::MatrixXd Q = _compute_schwarz_table(shell_pairs, nb, sym_ops);
 
     // ── Phase 1: build ERI tensor ─────────────────────────────────────────────
     std::vector<double> eri(nb * nb * nb * nb, 0.0);
@@ -1375,9 +1633,21 @@ std::vector <double> HartreeFock::ObaraSaika::_compute_2e(
             const auto& spCD = shell_pairs[q];
             const std::size_t k = spCD.A._index;
             const std::size_t l = spCD.B._index;
+            std::vector<QuartetOrbitElem> orbit;
 
             // Schwarz screening: |(ij|kl)| ≤ Q(i,j)·Q(k,l)
             if (Q(i, j) * Q(k, l) < tol_eri) continue;
+
+            if (use_sym)
+            {
+                auto [orb, forced_zero] = build_quartet_orbit(i, j, k, l, *sym_ops);
+                if (forced_zero)
+                    continue;
+                orbit = std::move(orb);
+                if (orbit.front().i != i || orbit.front().j != j ||
+                    orbit.front().k != k || orbit.front().l != l)
+                    continue;
+            }
 
             const int lCx = spCD.A._cartesian[0], lCy = spCD.A._cartesian[1], lCz = spCD.A._cartesian[2];
             const int lDx = spCD.B._cartesian[0], lDy = spCD.B._cartesian[1], lDz = spCD.B._cartesian[2];
@@ -1386,17 +1656,16 @@ std::vector <double> HartreeFock::ObaraSaika::_compute_2e(
                                                lAx, lAy, lAz, lBx, lBy, lBz,
                                                lCx, lCy, lCz, lDx, lDy, lDz);
 
-            // Fill all 8 permutation-symmetry equivalent slots:
-            //   (ij|kl) = (ji|kl) = (ij|lk) = (ji|lk)
-            //           = (kl|ij) = (lk|ij) = (kl|ji) = (lk|ji)
-            eri[i*nb3 + j*nb2 + k*nb + l] = val;
-            eri[j*nb3 + i*nb2 + k*nb + l] = val;
-            eri[i*nb3 + j*nb2 + l*nb + k] = val;
-            eri[j*nb3 + i*nb2 + l*nb + k] = val;
-            eri[k*nb3 + l*nb2 + i*nb + j] = val;
-            eri[l*nb3 + k*nb2 + i*nb + j] = val;
-            eri[k*nb3 + l*nb2 + j*nb + i] = val;
-            eri[l*nb3 + k*nb2 + j*nb + i] = val;
+            if (!use_sym)
+            {
+                write_eri_permutations(eri, nb, nb2, nb3, i, j, k, l, val);
+                continue;
+            }
+
+            for (const auto& elem : orbit)
+                write_eri_permutations(eri, nb, nb2, nb3,
+                                       elem.i, elem.j, elem.k, elem.l,
+                                       static_cast<double>(elem.sign) * val);
         }
     }
 

--- a/src/integrals/os.h
+++ b/src/integrals/os.h
@@ -32,6 +32,15 @@ namespace HartreeFock
                                          double tol_eri = 1e-10,
                                          const std::vector<HartreeFock::SignedAOSymOp>* sym_ops = nullptr);
 
+        // Contracted shell-quartet ERI for explicit angular-momentum components.
+        double _contracted_eri_elem(
+            const HartreeFock::ShellPair& spAB,
+            const HartreeFock::ShellPair& spCD,
+            int lAx, int lAy, int lAz,
+            int lBx, int lBy, int lBz,
+            int lCx, int lCy, int lCz,
+            int lDx, int lDy, int lDz);
+
         Eigen::MatrixXd _compute_fock_rhf(const std::vector<double> &_eri,
                                           const Eigen::MatrixXd &density,
                                           const std::size_t nbasis);

--- a/src/integrals/rys.cpp
+++ b/src/integrals/rys.cpp
@@ -28,6 +28,49 @@ static Eigen::MatrixXd _rys_schwarz_table(
     const std::vector<HartreeFock::ShellPair>& shell_pairs,
     std::size_t nbasis);
 
+static bool _auto_prefers_rys(const HartreeFock::ShellPair& spAB,
+                              const HartreeFock::ShellPair& spCD) noexcept
+{
+    const int lAx = spAB.A._cartesian[0], lAy = spAB.A._cartesian[1], lAz = spAB.A._cartesian[2];
+    const int lBx = spAB.B._cartesian[0], lBy = spAB.B._cartesian[1], lBz = spAB.B._cartesian[2];
+    const int lCx = spCD.A._cartesian[0], lCy = spCD.A._cartesian[1], lCz = spCD.A._cartesian[2];
+    const int lDx = spCD.B._cartesian[0], lDy = spCD.B._cartesian[1], lDz = spCD.B._cartesian[2];
+
+    const int lABx = lAx + lBx, lABy = lAy + lBy, lABz = lAz + lBz;
+    const int lCDx = lCx + lDx, lCDy = lCy + lDy, lCDz = lCz + lDz;
+    const int L = lABx + lABy + lABz + lCDx + lCDy + lCDz;
+    const int nroots = L / 2 + 1;
+
+    const double six_d = static_cast<double>(lABx + 1) * static_cast<double>(lABy + 1) *
+                         static_cast<double>(lABz + 1) * static_cast<double>(lCDx + 1) *
+                         static_cast<double>(lCDy + 1) * static_cast<double>(lCDz + 1);
+    const double os_work =
+        six_d * static_cast<double>(L + 1) +
+        static_cast<double>((lBx + lBy + lBz + lDx + lDy + lDz) + 1) * six_d * 0.25;
+    const double rys_work =
+        six_d * static_cast<double>(nroots) +
+        static_cast<double>((lBx + lBy + lBz + lDx + lDy + lDz) + 1) * six_d * 0.20 +
+        24.0 * static_cast<double>(nroots);
+
+    return rys_work < os_work;
+}
+
+static double _auto_contracted_eri(
+    const HartreeFock::ShellPair& spAB,
+    const HartreeFock::ShellPair& spCD,
+    int lAx, int lAy, int lAz,
+    int lBx, int lBy, int lBz,
+    int lCx, int lCy, int lCz,
+    int lDx, int lDy, int lDz) noexcept
+{
+    if (_auto_prefers_rys(spAB, spCD))
+        return HartreeFock::RysQuad::_rys_contracted_eri(
+            spAB, spCD, lAx, lAy, lAz, lBx, lBy, lBz, lCx, lCy, lCz, lDx, lDy, lDz);
+
+    return HartreeFock::ObaraSaika::_contracted_eri_elem(
+        spAB, spCD, lAx, lAy, lAz, lBx, lBy, lBz, lCx, lCy, lCz, lDx, lDy, lDz);
+}
+
 // ─── 1D Rys VRR ───────────────────────────────────────────────────────────────
 //
 // Fills vrr[a][c] for a in [0, lAB], c in [0, lCD] using the recurrences:
@@ -85,35 +128,38 @@ static void _rys_hrr_ab(
     const int lCDx, const int lCDy, const int lCDz,
     const double ABx, const double ABy, const double ABz) noexcept
 {
-    // X transfer: step lBx quanta from A to B
-    for (int bx = 0; bx < lBx; ++bx)
-        for (int ax = lAx + lBx - 1 - bx; ax >= lAx; --ax)
+    for (int kz = 0; kz < lBz; ++kz)
+        for (int ax = 0; ax <= lAx + lBx; ++ax)
             for (int ay = 0; ay <= lAy + lBy; ++ay)
-                for (int az = 0; az <= lAz + lBz; ++az)
+                for (int az = 0; az <= lAz + lBz - kz - 1; ++az)
                     for (int cx = 0; cx <= lCDx; ++cx)
                         for (int cy = 0; cy <= lCDy; ++cy)
                             for (int cz = 0; cz <= lCDz; ++cz)
-                                W[ax][ay][az][cx][cy][cz] +=
-                                    ABx * W[ax + 1][ay][az][cx][cy][cz];
+                                W[ax][ay][az][cx][cy][cz] =
+                                    W[ax][ay][az + 1][cx][cy][cz]
+                                  + ABz * W[ax][ay][az][cx][cy][cz];
 
-    // Y transfer
-    for (int by = 0; by < lBy; ++by)
-        for (int ay = lAy + lBy - 1 - by; ay >= lAy; --ay)
-            for (int az = 0; az <= lAz + lBz; ++az)
-                for (int cx = 0; cx <= lCDx; ++cx)
-                    for (int cy = 0; cy <= lCDy; ++cy)
-                        for (int cz = 0; cz <= lCDz; ++cz)
-                            W[lAx][ay][az][cx][cy][cz] +=
-                                ABy * W[lAx][ay + 1][az][cx][cy][cz];
+    for (int ky = 0; ky < lBy; ++ky)
+        for (int ax = 0; ax <= lAx + lBx; ++ax)
+            for (int ay = 0; ay <= lAy + lBy - ky - 1; ++ay)
+                for (int az = 0; az <= lAz; ++az)
+                    for (int cx = 0; cx <= lCDx; ++cx)
+                        for (int cy = 0; cy <= lCDy; ++cy)
+                            for (int cz = 0; cz <= lCDz; ++cz)
+                                W[ax][ay][az][cx][cy][cz] =
+                                    W[ax][ay + 1][az][cx][cy][cz]
+                                  + ABy * W[ax][ay][az][cx][cy][cz];
 
-    // Z transfer
-    for (int bz = 0; bz < lBz; ++bz)
-        for (int az = lAz + lBz - 1 - bz; az >= lAz; --az)
-            for (int cx = 0; cx <= lCDx; ++cx)
-                for (int cy = 0; cy <= lCDy; ++cy)
-                    for (int cz = 0; cz <= lCDz; ++cz)
-                        W[lAx][lAy][az][cx][cy][cz] +=
-                            ABz * W[lAx][lAy][az + 1][cx][cy][cz];
+    for (int kx = 0; kx < lBx; ++kx)
+        for (int ax = 0; ax <= lAx + lBx - kx - 1; ++ax)
+            for (int ay = 0; ay <= lAy; ++ay)
+                for (int az = 0; az <= lAz; ++az)
+                    for (int cx = 0; cx <= lCDx; ++cx)
+                        for (int cy = 0; cy <= lCDy; ++cy)
+                            for (int cz = 0; cz <= lCDz; ++cz)
+                                W[ax][ay][az][cx][cy][cz] =
+                                    W[ax + 1][ay][az][cx][cy][cz]
+                                  + ABx * W[ax][ay][az][cx][cy][cz];
 }
 
 // CD-HRR: transfer C→D using a 3D slice V0[cx][cy][cz].
@@ -132,23 +178,20 @@ static double _rys_hrr_cd(
             for (int cz = 0; cz <= lCz + lDz; ++cz)
                 W[cx][cy][cz] = V0[cx][cy][cz];
 
-    // X transfer
-    for (int dx = 0; dx < lDx; ++dx)
-        for (int cx = lCx + lDx - 1 - dx; cx >= lCx; --cx)
+    for (int kx = 0; kx < lDx; ++kx)
+        for (int cx = 0; cx <= lCx + lDx - kx - 1; ++cx)
             for (int cy = 0; cy <= lCy + lDy; ++cy)
                 for (int cz = 0; cz <= lCz + lDz; ++cz)
-                    W[cx][cy][cz] += CDx * W[cx + 1][cy][cz];
+                    W[cx][cy][cz] = W[cx + 1][cy][cz] + CDx * W[cx][cy][cz];
 
-    // Y transfer
-    for (int dy = 0; dy < lDy; ++dy)
-        for (int cy = lCy + lDy - 1 - dy; cy >= lCy; --cy)
+    for (int ky = 0; ky < lDy; ++ky)
+        for (int cy = 0; cy <= lCy + lDy - ky - 1; ++cy)
             for (int cz = 0; cz <= lCz + lDz; ++cz)
-                W[lCx][cy][cz] += CDy * W[lCx][cy + 1][cz];
+                W[lCx][cy][cz] = W[lCx][cy + 1][cz] + CDy * W[lCx][cy][cz];
 
-    // Z transfer
-    for (int dz = 0; dz < lDz; ++dz)
-        for (int cz = lCz + lDz - 1 - dz; cz >= lCz; --cz)
-            W[lCx][lCy][cz] += CDz * W[lCx][lCy][cz + 1];
+    for (int kz = 0; kz < lDz; ++kz)
+        for (int cz = 0; cz <= lCz + lDz - kz - 1; ++cz)
+            W[lCx][lCy][cz] = W[lCx][lCy][cz + 1] + CDz * W[lCx][lCy][cz];
 
     return W[lCx][lCy][lCz];
 }
@@ -319,6 +362,102 @@ static Eigen::MatrixXd _rys_schwarz_table(
     return Q;
 }
 
+std::vector<double> HartreeFock::RysQuad::_compute_2e(
+    const std::vector<HartreeFock::ShellPair>& shell_pairs,
+    const std::size_t nbasis,
+    const double tol_eri,
+    const std::vector<HartreeFock::SignedAOSymOp>*)
+{
+    const std::size_t nb  = nbasis;
+    const std::size_t nb2 = nb * nb;
+    const std::size_t nb3 = nb * nb * nb;
+
+    const Eigen::MatrixXd Q = _rys_schwarz_table(shell_pairs, nb);
+    std::vector<double> eri(nb * nb * nb * nb, 0.0);
+
+    const std::size_t npairs = shell_pairs.size();
+#pragma omp parallel for schedule(dynamic)
+    for (std::size_t p = 0; p < npairs; ++p) {
+        const auto& spAB = shell_pairs[p];
+        const std::size_t i = spAB.A._index;
+        const std::size_t j = spAB.B._index;
+        const int lAx = spAB.A._cartesian[0], lAy = spAB.A._cartesian[1], lAz = spAB.A._cartesian[2];
+        const int lBx = spAB.B._cartesian[0], lBy = spAB.B._cartesian[1], lBz = spAB.B._cartesian[2];
+
+        for (std::size_t q = p; q < npairs; ++q) {
+            const auto& spCD = shell_pairs[q];
+            const std::size_t k = spCD.A._index;
+            const std::size_t l = spCD.B._index;
+            if (Q(i, j) * Q(k, l) < tol_eri) continue;
+
+            const int lCx = spCD.A._cartesian[0], lCy = spCD.A._cartesian[1], lCz = spCD.A._cartesian[2];
+            const int lDx = spCD.B._cartesian[0], lDy = spCD.B._cartesian[1], lDz = spCD.B._cartesian[2];
+            const double val = _auto_contracted_eri(spAB, spCD,
+                                                    lAx, lAy, lAz, lBx, lBy, lBz,
+                                                    lCx, lCy, lCz, lDx, lDy, lDz);
+
+            eri[i*nb3 + j*nb2 + k*nb + l] = val;
+            eri[j*nb3 + i*nb2 + k*nb + l] = val;
+            eri[i*nb3 + j*nb2 + l*nb + k] = val;
+            eri[j*nb3 + i*nb2 + l*nb + k] = val;
+            eri[k*nb3 + l*nb2 + i*nb + j] = val;
+            eri[l*nb3 + k*nb2 + i*nb + j] = val;
+            eri[k*nb3 + l*nb2 + j*nb + i] = val;
+            eri[l*nb3 + k*nb2 + j*nb + i] = val;
+        }
+    }
+
+    return eri;
+}
+
+std::vector<double> HartreeFock::RysQuad::_compute_2e_auto(
+    const std::vector<HartreeFock::ShellPair>& shell_pairs,
+    const std::size_t nbasis,
+    const double tol_eri,
+    const std::vector<HartreeFock::SignedAOSymOp>*)
+{
+    const std::size_t nb  = nbasis;
+    const std::size_t nb2 = nb * nb;
+    const std::size_t nb3 = nb * nb * nb;
+
+    const Eigen::MatrixXd Q = _rys_schwarz_table(shell_pairs, nb);
+    std::vector<double> eri(nb * nb * nb * nb, 0.0);
+
+    const std::size_t npairs = shell_pairs.size();
+#pragma omp parallel for schedule(dynamic)
+    for (std::size_t p = 0; p < npairs; ++p) {
+        const auto& spAB = shell_pairs[p];
+        const std::size_t i = spAB.A._index;
+        const std::size_t j = spAB.B._index;
+        const int lAx = spAB.A._cartesian[0], lAy = spAB.A._cartesian[1], lAz = spAB.A._cartesian[2];
+        const int lBx = spAB.B._cartesian[0], lBy = spAB.B._cartesian[1], lBz = spAB.B._cartesian[2];
+
+        for (std::size_t q = p; q < npairs; ++q) {
+            const auto& spCD = shell_pairs[q];
+            const std::size_t k = spCD.A._index;
+            const std::size_t l = spCD.B._index;
+            if (Q(i, j) * Q(k, l) < tol_eri) continue;
+
+            const int lCx = spCD.A._cartesian[0], lCy = spCD.A._cartesian[1], lCz = spCD.A._cartesian[2];
+            const int lDx = spCD.B._cartesian[0], lDy = spCD.B._cartesian[1], lDz = spCD.B._cartesian[2];
+            const double val = _auto_contracted_eri(spAB, spCD,
+                                                    lAx, lAy, lAz, lBx, lBy, lBz,
+                                                    lCx, lCy, lCz, lDx, lDy, lDz);
+
+            eri[i*nb3 + j*nb2 + k*nb + l] = val;
+            eri[j*nb3 + i*nb2 + k*nb + l] = val;
+            eri[i*nb3 + j*nb2 + l*nb + k] = val;
+            eri[j*nb3 + i*nb2 + l*nb + k] = val;
+            eri[k*nb3 + l*nb2 + i*nb + j] = val;
+            eri[l*nb3 + k*nb2 + i*nb + j] = val;
+            eri[k*nb3 + l*nb2 + j*nb + i] = val;
+            eri[l*nb3 + k*nb2 + j*nb + i] = val;
+        }
+    }
+
+    return eri;
+}
+
 // ─── Public: RHF 2e Fock (direct SCF) ────────────────────────────────────────
 
 Eigen::MatrixXd HartreeFock::RysQuad::_compute_2e_fock(
@@ -332,44 +471,7 @@ Eigen::MatrixXd HartreeFock::RysQuad::_compute_2e_fock(
     const std::size_t nb2 = nb * nb;
     const std::size_t nb3 = nb * nb * nb;
 
-    const Eigen::MatrixXd Q = _rys_schwarz_table(shell_pairs, nb);
-
-    std::vector<double> eri(nb * nb * nb * nb, 0.0);
-
-    const std::size_t npairs = shell_pairs.size();
-
-#pragma omp parallel for schedule(dynamic)
-    for (std::size_t p = 0; p < npairs; ++p) {
-        const auto& spAB = shell_pairs[p];
-        const std::size_t i = spAB.A._index;
-        const std::size_t j = spAB.B._index;
-        const int lAx = spAB.A._cartesian[0], lAy = spAB.A._cartesian[1], lAz = spAB.A._cartesian[2];
-        const int lBx = spAB.B._cartesian[0], lBy = spAB.B._cartesian[1], lBz = spAB.B._cartesian[2];
-
-        for (std::size_t q = p; q < npairs; ++q) {
-            const auto& spCD = shell_pairs[q];
-            const std::size_t k = spCD.A._index;
-            const std::size_t l = spCD.B._index;
-
-            if (Q(i, j) * Q(k, l) < tol_eri) continue;
-
-            const int lCx = spCD.A._cartesian[0], lCy = spCD.A._cartesian[1], lCz = spCD.A._cartesian[2];
-            const int lDx = spCD.B._cartesian[0], lDy = spCD.B._cartesian[1], lDz = spCD.B._cartesian[2];
-
-            const double val = _rys_contracted_eri(spAB, spCD,
-                                                   lAx, lAy, lAz, lBx, lBy, lBz,
-                                                   lCx, lCy, lCz, lDx, lDy, lDz);
-
-            eri[i*nb3 + j*nb2 + k*nb + l] = val;
-            eri[j*nb3 + i*nb2 + k*nb + l] = val;
-            eri[i*nb3 + j*nb2 + l*nb + k] = val;
-            eri[j*nb3 + i*nb2 + l*nb + k] = val;
-            eri[k*nb3 + l*nb2 + i*nb + j] = val;
-            eri[l*nb3 + k*nb2 + i*nb + j] = val;
-            eri[k*nb3 + l*nb2 + j*nb + i] = val;
-            eri[l*nb3 + k*nb2 + j*nb + i] = val;
-        }
-    }
+    std::vector<double> eri = _compute_2e(shell_pairs, nbasis, tol_eri);
 
     Eigen::MatrixXd G = Eigen::MatrixXd::Zero(nb, nb);
 
@@ -401,43 +503,7 @@ HartreeFock::RysQuad::_compute_2e_fock_uhf(
     const std::size_t nb3 = nb * nb * nb;
 
     const Eigen::MatrixXd Pt = Pa + Pb;
-    const Eigen::MatrixXd Q  = _rys_schwarz_table(shell_pairs, nb);
-
-    std::vector<double> eri(nb * nb * nb * nb, 0.0);
-    const std::size_t npairs = shell_pairs.size();
-
-#pragma omp parallel for schedule(dynamic)
-    for (std::size_t p = 0; p < npairs; ++p) {
-        const auto& spAB = shell_pairs[p];
-        const std::size_t i = spAB.A._index;
-        const std::size_t j = spAB.B._index;
-        const int lAx = spAB.A._cartesian[0], lAy = spAB.A._cartesian[1], lAz = spAB.A._cartesian[2];
-        const int lBx = spAB.B._cartesian[0], lBy = spAB.B._cartesian[1], lBz = spAB.B._cartesian[2];
-
-        for (std::size_t q = p; q < npairs; ++q) {
-            const auto& spCD = shell_pairs[q];
-            const std::size_t k = spCD.A._index;
-            const std::size_t l = spCD.B._index;
-
-            if (Q(i, j) * Q(k, l) < tol_eri) continue;
-
-            const int lCx = spCD.A._cartesian[0], lCy = spCD.A._cartesian[1], lCz = spCD.A._cartesian[2];
-            const int lDx = spCD.B._cartesian[0], lDy = spCD.B._cartesian[1], lDz = spCD.B._cartesian[2];
-
-            const double val = _rys_contracted_eri(spAB, spCD,
-                                                   lAx, lAy, lAz, lBx, lBy, lBz,
-                                                   lCx, lCy, lCz, lDx, lDy, lDz);
-
-            eri[i*nb3 + j*nb2 + k*nb + l] = val;
-            eri[j*nb3 + i*nb2 + k*nb + l] = val;
-            eri[i*nb3 + j*nb2 + l*nb + k] = val;
-            eri[j*nb3 + i*nb2 + l*nb + k] = val;
-            eri[k*nb3 + l*nb2 + i*nb + j] = val;
-            eri[l*nb3 + k*nb2 + i*nb + j] = val;
-            eri[k*nb3 + l*nb2 + j*nb + i] = val;
-            eri[l*nb3 + k*nb2 + j*nb + i] = val;
-        }
-    }
+    std::vector<double> eri = _compute_2e(shell_pairs, nbasis, tol_eri);
 
     Eigen::MatrixXd Ga = Eigen::MatrixXd::Zero(nb, nb);
     Eigen::MatrixXd Gb = Eigen::MatrixXd::Zero(nb, nb);
@@ -472,9 +538,21 @@ Eigen::MatrixXd HartreeFock::RysQuad::_compute_2e_fock_auto(
     const double tol_eri,
     const std::vector<HartreeFock::SignedAOSymOp>* sym_ops)
 {
-    // TODO: route low-L quartets to OS once _contracted_eri is exposed.
-    return HartreeFock::RysQuad::_compute_2e_fock(
-        shell_pairs, density, nbasis, tol_eri, sym_ops);
+    const std::size_t nb  = nbasis;
+    const std::size_t nb2 = nb * nb;
+    const std::size_t nb3 = nb * nb * nb;
+    std::vector<double> eri = _compute_2e_auto(shell_pairs, nbasis, tol_eri, sym_ops);
+    Eigen::MatrixXd G = Eigen::MatrixXd::Zero(nb, nb);
+
+#pragma omp parallel for schedule(static)
+    for (std::size_t mu = 0; mu < nb; ++mu)
+        for (std::size_t nu = 0; nu < nb; ++nu)
+            for (std::size_t lam = 0; lam < nb; ++lam)
+                for (std::size_t sig = 0; sig < nb; ++sig)
+                    G(mu, nu) += density(lam, sig) *
+                                 (eri[mu*nb3 + nu*nb2 + lam*nb + sig]
+                                  - 0.5 * eri[mu*nb3 + lam*nb2 + nu*nb + sig]);
+    return G;
 }
 
 std::pair<Eigen::MatrixXd, Eigen::MatrixXd>
@@ -486,7 +564,23 @@ HartreeFock::RysQuad::_compute_2e_fock_uhf_auto(
     const double tol_eri,
     const std::vector<HartreeFock::SignedAOSymOp>* sym_ops)
 {
-    // TODO: route low-L quartets to OS once _contracted_eri is exposed.
-    return HartreeFock::RysQuad::_compute_2e_fock_uhf(
-        shell_pairs, Pa, Pb, nbasis, tol_eri, sym_ops);
+    const std::size_t nb  = nbasis;
+    const std::size_t nb2 = nb * nb;
+    const std::size_t nb3 = nb * nb * nb;
+    const Eigen::MatrixXd Pt = Pa + Pb;
+    std::vector<double> eri = _compute_2e_auto(shell_pairs, nbasis, tol_eri, sym_ops);
+    Eigen::MatrixXd Ga = Eigen::MatrixXd::Zero(nb, nb);
+    Eigen::MatrixXd Gb = Eigen::MatrixXd::Zero(nb, nb);
+
+#pragma omp parallel for schedule(static)
+    for (std::size_t mu = 0; mu < nb; ++mu)
+        for (std::size_t nu = 0; nu < nb; ++nu)
+            for (std::size_t lam = 0; lam < nb; ++lam)
+                for (std::size_t sig = 0; sig < nb; ++sig) {
+                    const double coulomb = eri[mu*nb3 + nu*nb2 + lam*nb + sig];
+                    const double exch    = eri[mu*nb3 + lam*nb2 + nu*nb + sig];
+                    Ga(mu, nu) += Pt(lam, sig) * coulomb - Pa(lam, sig) * exch;
+                    Gb(mu, nu) += Pt(lam, sig) * coulomb - Pb(lam, sig) * exch;
+                }
+    return {Ga, Gb};
 }

--- a/src/integrals/rys.h
+++ b/src/integrals/rys.h
@@ -44,6 +44,12 @@ namespace HartreeFock
     // ── Public API — mirrors ObaraSaika:: signatures ───────────────────────────
 
     // Build 2e Fock contribution G = J - 0.5*K (direct SCF, RHF).
+    std::vector<double> _compute_2e(
+        const std::vector<HartreeFock::ShellPair>& shell_pairs,
+        std::size_t nbasis,
+        double tol_eri = 1e-10,
+        const std::vector<HartreeFock::SignedAOSymOp>* sym_ops = nullptr);
+
     Eigen::MatrixXd _compute_2e_fock(
         const std::vector<HartreeFock::ShellPair>& shell_pairs,
         const Eigen::MatrixXd& density,
@@ -65,6 +71,12 @@ namespace HartreeFock
     //
     // Selects OS for L < RYS_CROSSOVER_L, Rys for L >= RYS_CROSSOVER_L,
     // at the contracted shell-quartet level.
+
+    std::vector<double> _compute_2e_auto(
+        const std::vector<HartreeFock::ShellPair>& shell_pairs,
+        std::size_t nbasis,
+        double tol_eri = 1e-10,
+        const std::vector<HartreeFock::SignedAOSymOp>* sym_ops = nullptr);
 
     Eigen::MatrixXd _compute_2e_fock_auto(
         const std::vector<HartreeFock::ShellPair>& shell_pairs,

--- a/src/integrals/rys_roots.cpp
+++ b/src/integrals/rys_roots.cpp
@@ -3,6 +3,9 @@
 #include <cstring>
 #include <cmath>
 #include <stdexcept>
+#include <algorithm>
+
+#include <Eigen/Eigenvalues>
 
 // ─── Gauss-Legendre roots/weights on [0,1] for t^2 variable ─────────────────
 //
@@ -84,151 +87,116 @@ static const double gl_weights[HartreeFock::Rys::RYS_MAX_ROOTS]
      0.093145105463867014, 0.062790184732452390, 0.027834283558086833},
 };
 
-// ─── Golub-Welsch algorithm ──────────────────────────────────────────────────
-//
-// Computes Rys roots and weights for intermediate T (RYS_T_ZERO <= T <= RYS_T_MAX)
-// via the n×n symmetric tridiagonal Jacobi matrix built from modified moments.
-//
-// Moments: mu_k = integral_0^1 x^k * exp(-T*x) dx  (substitution x = t^2)
-//        = (1/2) * integral_0^1 u^k * exp(-T*u) du   [not quite — see below]
-//
-// Actually with the Rys weight function w(t;T) = exp(-T*t^2) on [0,1] and
-// variable x = t^2: dx = 2t dt, so:
-//   mu_k = integral_0^1 t^{2k} * exp(-T*t^2) * 2t dt  ← NOT this form
-//
-// Correct moments for the Jacobi matrix (using x=t^2 directly):
-//   mu_k = integral_0^1 x^k * (exp(-T*x) / (2*sqrt(x))) dx
-//         = (1/2) * integral_0^1 x^{k-1/2} * exp(-T*x) dx
-//
-// For the simpler formulation used in practice (DRK 1976), we work with:
-//   nu_k = integral_0^1 (t^2)^k * exp(-T*t^2) dt
-//         = (1/2) * integral_0^{sqrt(T)} (u^2/T)^k * exp(-u^2) * (du/sqrt(T))   [u=t*sqrt(T)]
-//
-// Via recurrence:  nu_0 = erf(sqrt(T))*sqrt(pi)/(2*sqrt(T))   [Boys F_0(T)]
-//                  nu_k = ((2k-1)*nu_{k-1} - exp(-T)) / (2T)
-
-static void _golub_welsch(int n, double T,
-                          double* __restrict__ roots,
-                          double* __restrict__ weights) noexcept
+static long double _boys_moment(int m, long double T) noexcept
 {
-    // ── Compute moments nu_k = integral_0^1 t^{2k} exp(-T*t^2) dt ────────────
-    // nu_0 = sqrt(pi)/(2*sqrt(T)) * erf(sqrt(T))
-    // nu_k = ((2k-1)*nu_{k-1} - exp(-T)) / (2*T)
-    const int nmoments = 2 * n;
-    double nu[2 * HartreeFock::Rys::RYS_MAX_ROOTS];
+    if (T < static_cast<long double>(HartreeFock::Rys::RYS_T_ZERO))
+        return 1.0L / static_cast<long double>(2 * m + 1);
 
-    const double sqrtT = std::sqrt(T);
-    nu[0] = std::sqrt(M_PI) / (2.0 * sqrtT) * std::erf(sqrtT);
-    const double expT = std::exp(-T);
-    for (int k = 1; k < nmoments; ++k)
-        nu[k] = ((2*k - 1) * nu[k-1] - expT) / (2.0 * T);
+    const long double sqrtT = std::sqrt(T);
+    long double F = 0.5L * std::sqrt(static_cast<long double>(M_PI) / T) * std::erfl(sqrtT);
+    if (m == 0)
+        return F;
 
-    // ── Modified Chebyshev algorithm → Jacobi matrix diagonal/off-diagonal ───
-    // alpha[k] = diagonal,  beta[k] = off-diagonal^2  (beta[0] = nu[0] = total weight)
-    double alpha[HartreeFock::Rys::RYS_MAX_ROOTS];
-    double beta [HartreeFock::Rys::RYS_MAX_ROOTS];
+    const long double eT = std::expl(-T);
+    for (int k = 1; k <= m; ++k)
+        F = ((2 * k - 1) * F - eT) / (2.0L * T);
+    return F;
+}
 
-    // sigma[k][j] working array (use two rows, alternating)
-    double sig_prev[2 * HartreeFock::Rys::RYS_MAX_ROOTS + 1] = {};
-    double sig_curr[2 * HartreeFock::Rys::RYS_MAX_ROOTS + 1] = {};
+static long double _poly_inner(const long double* a, int da,
+                               const long double* b, int db,
+                               const long double* moments) noexcept
+{
+    long double s = 0.0L;
+    for (int i = 0; i <= da; ++i)
+        for (int j = 0; j <= db; ++j)
+            s += a[i] * b[j] * moments[i + j];
+    return s;
+}
 
-    beta[0]  = nu[0];
-    alpha[0] = nu[1] / nu[0];
+static void _stieltjes_jacobi(int n, double T,
+                              double* __restrict__ roots,
+                              double* __restrict__ weights) noexcept
+{
+    constexpr int max_n = HartreeFock::Rys::RYS_MAX_ROOTS;
+    long double moments[2 * max_n + 1] = {};
+    for (int k = 0; k <= 2 * n; ++k)
+        moments[k] = _boys_moment(k, static_cast<long double>(T));
 
-    // Initialize sig_prev = nu[j] for j = 0..2n-1
-    for (int j = 0; j < nmoments; ++j)
-        sig_prev[j] = nu[j];
+    long double polys[max_n + 1][max_n + 1] = {};
+    long double alphas[max_n] = {};
+    long double betas[max_n]  = {};
 
-    for (int k = 1; k < n; ++k) {
-        for (int j = k; j < nmoments - k; ++j) {
-            sig_curr[j] = sig_prev[j + 1]
-                        - alpha[k - 1] * sig_prev[j]
-                        - beta [k - 1] * (k >= 2 ? sig_prev[j] : nu[j]);
-            // (more accurate: use two-row recurrence properly)
+    polys[0][0] = 1.0L / std::sqrt(moments[0]);
+
+    for (int k = 0; k < n; ++k)
+    {
+        long double xpk[max_n + 1] = {};
+        for (int i = 0; i <= k; ++i)
+            xpk[i + 1] = polys[k][i];
+
+        alphas[k] = _poly_inner(xpk, k + 1, polys[k], k, moments);
+
+        if (k == n - 1)
+            break;
+
+        long double q[max_n + 1] = {};
+        for (int i = 0; i <= k + 1; ++i)
+            q[i] += xpk[i];
+        for (int i = 0; i <= k; ++i)
+            q[i] -= alphas[k] * polys[k][i];
+        if (k > 0)
+            for (int i = 0; i <= k - 1; ++i)
+                q[i] -= betas[k - 1] * polys[k - 1][i];
+
+        long double norm2 = _poly_inner(q, k + 1, q, k + 1, moments);
+        if (norm2 < 0.0L && std::abs(norm2) < 1.0e-24L)
+            norm2 = 0.0L;
+        betas[k] = std::sqrt(norm2);
+        if (!(betas[k] > 0.0L))
+        {
+            for (int r = 0; r < n; ++r)
+            {
+                roots[r] = gl_roots[n - 1][r];
+                weights[r] = gl_weights[n - 1][r];
+            }
+            return;
         }
-        // This simplified Chebyshev is approximate — the full version uses
-        // sigma[k][j] = sig_prev[j+1] - alpha[k-1]*sig_prev[j] - beta[k-1]*sig_pprev[j]
-        // For the scaffold, use the correct two-array scheme below.
-        alpha[k] = sig_curr[k + 1] / sig_curr[k] - sig_prev[k] / sig_prev[k - 1];
-        beta [k] = sig_curr[k] / sig_prev[k - 1];
 
-        std::memcpy(sig_prev, sig_curr, sizeof(double) * (nmoments));
+        for (int i = 0; i <= k + 1; ++i)
+            polys[k + 1][i] = q[i] / betas[k];
     }
 
-    // ── Build symmetric tridiagonal Jacobi matrix J ───────────────────────────
-    // J diagonal: alpha[0..n-1]
-    // J off-diagonal: sqrt(beta[1..n-1])
-    // Diagonalize via simple QR iteration (QL with implicit shifts).
-    // For n<=11, this converges rapidly.
-
-    double d[HartreeFock::Rys::RYS_MAX_ROOTS];  // diagonal
-    double e[HartreeFock::Rys::RYS_MAX_ROOTS];  // off-diagonal (e[0] unused)
-    double z[HartreeFock::Rys::RYS_MAX_ROOTS];  // eigenvector first components
-
-    for (int k = 0; k < n; ++k) d[k] = alpha[k];
-    for (int k = 1; k < n; ++k) e[k] = std::sqrt(std::abs(beta[k]));
-    e[0] = 0.0;
-
-    // z = first standard basis vector (e_0): eigenvector first component squared
-    // gives the weights after scaling by nu[0].
-    for (int k = 0; k < n; ++k) z[k] = (k == 0) ? 1.0 : 0.0;
-
-    // QL algorithm with implicit shifts for symmetric tridiagonal matrix.
-    // After convergence: d[k] = eigenvalues (Rys roots), z[k]^2 * nu[0] = weights.
-    const int max_iter = 300;
-    for (int l = 0; l < n; ++l) {
-        int iter = 0;
-        int m;
-        do {
-            for (m = l; m < n - 1; ++m) {
-                const double dd = std::abs(d[m]) + std::abs(d[m + 1]);
-                if (std::abs(e[m + 1]) + dd == dd) break;
-            }
-            if (m != l) {
-                if (iter++ >= max_iter) break;
-                double g = (d[l + 1] - d[l]) / (2.0 * e[l + 1]);
-                double r = std::sqrt(g * g + 1.0);
-                g = d[m] - d[l] + e[l + 1] / (g + std::copysign(r, g));
-                double s = 1.0, c = 1.0, p = 0.0;
-                for (int i = m - 1; i >= l; --i) {
-                    double f = s * e[i + 1];
-                    double b = c * e[i + 1];
-                    r = std::sqrt(f * f + g * g);
-                    e[i + 2] = r;
-                    if (r == 0.0) { d[i + 1] -= p; e[m + 1] = 0.0; break; }
-                    s = f / r; c = g / r;
-                    g = d[i + 1] - p;
-                    r = (d[i] - g) * s + 2.0 * c * b;
-                    p = s * r;
-                    d[i + 1] = g + p;
-                    g = c * r - b;
-                    // Update first eigenvector component
-                    f    = z[i + 1];
-                    z[i + 1] = s * z[i] + c * f;
-                    z[i]     = c * z[i] - s * f;
-                }
-                d[l] -= p;
-                e[l + 1] = g;
-                e[m + 1] = 0.0;
-            }
-        } while (m != l);
-    }
-
-    // Roots are eigenvalues d[k]; weights are nu[0] * z[k]^2.
-    for (int k = 0; k < n; ++k) {
-        roots  [k] = d[k];
-        weights[k] = nu[0] * z[k] * z[k];
-    }
-
-    // Sort by ascending root value (QL may not preserve order).
-    for (int i = 0; i < n - 1; ++i) {
-        for (int j = i + 1; j < n; ++j) {
-            if (roots[j] < roots[i]) {
-                double tmp;
-                tmp = roots[i];   roots[i]   = roots[j];   roots[j]   = tmp;
-                tmp = weights[i]; weights[i] = weights[j]; weights[j] = tmp;
-            }
+    Eigen::MatrixXd J = Eigen::MatrixXd::Zero(n, n);
+    for (int i = 0; i < n; ++i)
+    {
+        J(i, i) = static_cast<double>(alphas[i]);
+        if (i + 1 < n)
+        {
+            const double b = static_cast<double>(betas[i]);
+            J(i, i + 1) = b;
+            J(i + 1, i) = b;
         }
+    }
+
+    Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> solver(J);
+    if (solver.info() != Eigen::Success)
+    {
+        for (int r = 0; r < n; ++r)
+        {
+            roots[r] = gl_roots[n - 1][r];
+            weights[r] = gl_weights[n - 1][r];
+        }
+        return;
+    }
+
+    const auto& evals = solver.eigenvalues();
+    const auto& evecs = solver.eigenvectors();
+    const double m0 = static_cast<double>(moments[0]);
+    for (int i = 0; i < n; ++i)
+    {
+        roots[i] = std::clamp(evals[i], 0.0, 1.0);
+        weights[i] = std::max(0.0, m0 * evecs(0, i) * evecs(0, i));
     }
 }
 
@@ -253,6 +221,5 @@ void HartreeFock::Rys::rys_roots_weights(int n, double T,
         return;
     }
 
-    // General case: Golub-Welsch from modified moments.
-    _golub_welsch(n, T, roots, weights);
+    _stieltjes_jacobi(n, T, roots, weights);
 }

--- a/src/integrals/rys_roots.h
+++ b/src/integrals/rys_roots.h
@@ -12,8 +12,7 @@ namespace HartreeFock
     static constexpr int RYS_MAX_ROOTS = 11;
 
     // T thresholds for solver tier selection.
-    static constexpr double RYS_T_ZERO = 1.0e-15;  // use Gauss-Legendre limit
-    static constexpr double RYS_T_MAX  = 33.0;     // use Golub-Welsch above this
+    static constexpr double RYS_T_ZERO = 1.0e-14;  // use Gauss-Legendre limit
 
     // Compute n Rys roots (t_r^2 in (0,1)) and weights (w_r > 0) for argument T.
     // Precondition: 1 <= n <= RYS_MAX_ROOTS, T >= 0.
@@ -21,20 +20,21 @@ namespace HartreeFock
                            double* __restrict__ roots,
                            double* __restrict__ weights) noexcept;
 
-    // Exact closed-form for n=1:
-    //   t_1^2 = 1 - T*exp(-T)/(1-exp(-T))   (T > 0)
-    //   w_1   = (1 - exp(-T)) / T            (T > 0)
-    //   t_1^2 -> 1/2,  w_1 -> 1             (T -> 0)
+    // Exact 1-point rule for the Rys/Boys measure:
+    //   w_1   = F_0(T)
+    //   t_1^2 = F_1(T) / F_0(T)
+    // where F_m(T) = integral_0^1 t^(2m) exp(-T t^2) dt.
     inline void rys_1pt(double T, double& root, double& weight) noexcept
     {
         if (T < RYS_T_ZERO) {
             root   = 0.5;
             weight = 1.0;
         } else {
-            const double e  = std::exp(-T);
-            const double mu0 = (1.0 - e) / T;
-            root   = 1.0 - T * e / (1.0 - e);
-            weight = mu0;
+            const double sqrtT = std::sqrt(T);
+            const double F0 = 0.5 * std::sqrt(M_PI / T) * std::erf(sqrtT);
+            const double F1 = (F0 - std::exp(-T)) / (2.0 * T);
+            root   = F1 / F0;
+            weight = F0;
         }
     }
 

--- a/src/opt/geomopt.cpp
+++ b/src/opt/geomopt.cpp
@@ -14,6 +14,7 @@
 #include "gradient/gradient.h"
 #include "post_hf/mp2.h"
 #include "base/tables.h"
+#include "symmetry/integral_symmetry.h"
 
 // ─── Single-point helper ─────────────────────────────────────────────────────
 //
@@ -65,11 +66,14 @@ static Eigen::VectorXd _run_sp_gradient(HartreeFock::Calculator& calc)
 
     // Shell pairs
     auto shell_pairs = build_shellpairs(calc._shells);
+    HartreeFock::Symmetry::update_integral_symmetry(calc);
 
     // 1e integrals
-    auto [S, T] = _compute_1e(shell_pairs, calc._shells.nbasis(), calc._integral._engine);
+    auto [S, T] = _compute_1e(shell_pairs, calc._shells.nbasis(), calc._integral._engine,
+                              calc._use_integral_symmetry ? &calc._integral_symmetry_ops : nullptr);
     auto V = _compute_nuclear_attraction(shell_pairs, calc._shells.nbasis(),
-                                         calc._molecule, calc._integral._engine);
+                                         calc._molecule, calc._integral._engine,
+                                         calc._use_integral_symmetry ? &calc._integral_symmetry_ops : nullptr);
     calc._overlap = S;
     calc._hcore   = T + V;
 

--- a/src/post_hf/integrals.cpp
+++ b/src/post_hf/integrals.cpp
@@ -1,7 +1,7 @@
 #include <format>
 
 #include "integrals.h"
-#include "integrals/os.h"
+#include "integrals/base.h"
 #include "io/logging.h"
 
 namespace HartreeFock::Correlation
@@ -21,7 +21,8 @@ const std::vector<double>& ensure_eri(
     const std::size_t nb = calc._shells.nbasis();
     HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, tag,
         std::format("Building AO ERI tensor ({:.1f} MB)", nb * nb * nb * nb * 8.0 / 1e6));
-    eri_local = HartreeFock::ObaraSaika::_compute_2e(shell_pairs, nb);
+    eri_local = _compute_2e(shell_pairs, nb, calc._integral._engine, 1e-10,
+                            calc._use_integral_symmetry ? &calc._integral_symmetry_ops : nullptr);
     return eri_local;
 }
 

--- a/src/scf/scf.cpp
+++ b/src/scf/scf.cpp
@@ -91,9 +91,7 @@ std::expected<void, std::string> HartreeFock::SCF::run_rhf(HartreeFock::Calculat
     // Conventional: ERI tensor built once; each iteration only contracts.
     // Direct: ERI recomputed from integrals every iteration.
     // Auto: conventional when nbasis ≤ _threshold, direct otherwise.
-    // Only ObaraSaika supports precomputed ERI storage; other engines always direct.
     const bool use_conventional =
-        calculator._integral._engine == HartreeFock::IntegralMethod::ObaraSaika &&
         (calculator._scf._mode == HartreeFock::SCFMode::Conventional ||
          (calculator._scf._mode == HartreeFock::SCFMode::Auto &&
           nbasis <= static_cast<std::size_t>(calculator._scf._threshold)));
@@ -103,7 +101,9 @@ std::expected<void, std::string> HartreeFock::SCF::run_rhf(HartreeFock::Calculat
     {
         HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "2e Integrals :",
             std::format("Building ERI tensor ({:.1f} MB)", nbasis * nbasis * nbasis * nbasis * 8.0 / 1e6));
-        eri = HartreeFock::ObaraSaika::_compute_2e(shell_pairs, nbasis, calculator._integral._tol_eri);
+        eri = _compute_2e(shell_pairs, nbasis, calculator._integral._engine,
+                          calculator._integral._tol_eri,
+                          calculator._use_integral_symmetry ? &calculator._integral_symmetry_ops : nullptr);
         calculator._eri = eri;  // persist for post-HF use
         HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "2e Integrals :", "ERI tensor ready");
         HartreeFock::Logger::blank();
@@ -126,7 +126,8 @@ std::expected<void, std::string> HartreeFock::SCF::run_rhf(HartreeFock::Calculat
         // ── Build two-electron contribution G = J - 0.5*K ────────────────────
         Eigen::MatrixXd G = use_conventional
             ? HartreeFock::ObaraSaika::_compute_fock_rhf(eri, P, nbasis)
-            : _compute_2e_fock(shell_pairs, P, nbasis, calculator._integral._engine, tol_eri);
+            : _compute_2e_fock(shell_pairs, P, nbasis, calculator._integral._engine, tol_eri,
+                               calculator._use_integral_symmetry ? &calculator._integral_symmetry_ops : nullptr);
 
         // ── Fock matrix ───────────────────────────────────────────────────────
         const Eigen::MatrixXd F = H + G;
@@ -354,7 +355,6 @@ std::expected<void, std::string> HartreeFock::SCF::run_uhf(
 
     // ── Conventional vs Direct ────────────────────────────────────────────────
     const bool use_conventional =
-        calculator._integral._engine == HartreeFock::IntegralMethod::ObaraSaika &&
         (calculator._scf._mode == HartreeFock::SCFMode::Conventional ||
          (calculator._scf._mode == HartreeFock::SCFMode::Auto &&
           nbasis <= static_cast<std::size_t>(calculator._scf._threshold)));
@@ -364,7 +364,9 @@ std::expected<void, std::string> HartreeFock::SCF::run_uhf(
     {
         HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "2e Integrals :",
             std::format("Building ERI tensor ({:.1f} MB)", nbasis * nbasis * nbasis * nbasis * 8.0 / 1e6));
-        eri = HartreeFock::ObaraSaika::_compute_2e(shell_pairs, nbasis, calculator._integral._tol_eri);
+        eri = _compute_2e(shell_pairs, nbasis, calculator._integral._engine,
+                          calculator._integral._tol_eri,
+                          calculator._use_integral_symmetry ? &calculator._integral_symmetry_ops : nullptr);
         calculator._eri = eri;  // persist for post-HF use
         HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "2e Integrals :", "ERI tensor ready");
         HartreeFock::Logger::blank();
@@ -393,7 +395,8 @@ std::expected<void, std::string> HartreeFock::SCF::run_uhf(
         // ── Two-electron Fock contributions ───────────────────────────────────
         auto [Ga, Gb] = use_conventional
             ? HartreeFock::ObaraSaika::_compute_fock_uhf(eri, Pa, Pb, nbasis)
-            : _compute_2e_fock_uhf(shell_pairs, Pa, Pb, nbasis, calculator._integral._engine, tol_eri);
+            : _compute_2e_fock_uhf(shell_pairs, Pa, Pb, nbasis, calculator._integral._engine, tol_eri,
+                                   calculator._use_integral_symmetry ? &calculator._integral_symmetry_ops : nullptr);
 
         const Eigen::MatrixXd Fa = H + Ga;
         const Eigen::MatrixXd Fb = H + Gb;


### PR DESCRIPTION
Correct the Rys roots/weights construction to use the Boys moments and fix the HRR transfer sweeps that were corrupting higher-angular-momentum quartets.

Add a contracted-quartet OS helper and route both direct-SCF and full ERI builds through a shared 2e engine dispatcher so conventional SCF, direct SCF, and post-HF ERI construction all respect the selected integral engine.

Implement a per-quartet OS-vs-Rys cost heuristic in the Rys layer and use it for the auto engine, so the code switches to Rys only when it is predicted to be cheaper and otherwise falls back to the validated OS contraction. Keep the Rys entry path on the same safe chooser to avoid the previous all-Rys failure mode on low-angular-momentum quartets.

Also thread the recent signed-AO symmetry metadata through the geometry-gradient/frequency single-point rebuild paths and the integral interfaces so symmetry-reduced 1e/2e builds continue to work with the new dispatcher.

Validation:
- cmake --build build --target hartree-fock -j4
- OS, Rys, and Auto agree for H2 / STO-3G: -1.1167061402 Eh
- OS, Rys, and Auto agree for H2O / STO-3G: -74.9458807581 Eh