### PR TITLE
Document Rys quadrature and OS/Rys auto-dispatch in detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Hartree-Fock quantum chemistry program implementing restricted and unrestricte
 ### Features
 
 - **RHF / UHF** — closed-shell and open-shell Hartree-Fock
-- **Obara-Saika integral engine** — recursive 1e and 2e integrals (S, P, D, F, G, H shells)
+- **Two integral engines** — Obara-Saika (OS) recursive VRR/HRR for low angular momentum; Rys quadrature for high angular momentum; automatic engine selection per shell quartet based on an analytic flop-count model (`engine auto`)
 - **Conventional and Direct SCF** — ERI tensor stored once (conventional) or recomputed per iteration (direct); auto-selection based on system size
 - **DIIS** — Pulay extrapolation with optional automatic subspace restart
 - **Level shifting** — virtual orbital energy raising for open-shell convergence
@@ -126,7 +126,7 @@ SCF procedure and convergence settings.
 | Keyword | Type | Values | Default | Description |
 |---|---|---|---|---|
 | `scf_type` | enum | `rhf`, `uhf` | `rhf` | Wavefunction type |
-| `engine` | enum | `os` / `obara-saika` | `os` | Integral engine (Obara-Saika recursive algorithm) |
+| `engine` | enum | `os` / `obara-saika`, `rys`, `auto` | `os` | Two-electron integral engine. `os`: Obara-Saika VRR/HRR recursion. `rys`: Rys quadrature (converts the Boys integral to a Gauss-type quadrature; exact with ⌊L/2⌋+1 roots). `auto`: selects the engine per contracted shell quartet using an analytic flop-count model — OS for low total angular momentum (L < 4), Rys for L ≥ 4 (d+d and higher). |
 | `correlation` | enum | `rmp2`, `ump2` | none | Post-HF correlation energy correction |
 | `use_diis` | bool | `.true.`, `.false.` | `.true.` | Enable DIIS convergence acceleration |
 | `diis_dim` | int | ≥ 2 | `8` | Maximum DIIS subspace size |

--- a/docs/PLANCK_TEACHING_GUIDE.md
+++ b/docs/PLANCK_TEACHING_GUIDE.md
@@ -385,22 +385,188 @@ Planck iterates only over pairs \(p \le q\) in the AO-pair index and fills all
 
 ## 6. Rys Quadrature
 
-The Rys quadrature method evaluates ERIs by converting the Boys function
-integral into a Gauss-Legendre-type quadrature:
+### The Basic Idea
+
+The Obara-Saika VRR builds an \((L+1)\)-deep stack of auxiliary integrals at
+each auxiliary order \(m\). For high-angular-momentum quartets (d+d, f+p, …)
+the stack grows large, and intermediate storage dominates the cost. The Rys
+quadrature method avoids auxiliary-order recursion entirely by converting the
+Boys function integral into a discrete sum:
 
 \[
-F_m(t) = \sum_{r=1}^{n_r} w_r\, x_r^{2m}
+F_m(T) = \int_0^1 t^{2m}\, e^{-T t^2}\, dt
+       = \sum_{r=1}^{n} w_r(T)\, \bigl[t_r^2(T)\bigr]^m
 \]
 
-where \(\{x_r, w_r\}\) are the Rys roots and weights that depend on \(t = \zeta\eta/(\zeta+\eta) R_{PQ}^2\).
-Each quadrature point decouples the 3D integral into three independent 1D
-integrals, one per Cartesian direction, which are then multiplied together.
+where \(\{t_r^2, w_r\}\) are the Rys roots (squared) and weights, which depend
+on the Boys argument \(T = \rho\,|\mathbf{PQ}|^2\). When this representation
+is substituted into the ERI expression, the integral factorizes into independent
+1D integrals in \(x\), \(y\), and \(z\) for each quadrature point \(r\).
 
-The Rys method naturally handles high-angular-momentum quartets without the
-recursive intermediate storage required by the VRR/HRR scheme. Planck uses it
-as an alternative engine (controlled by `IntegralMethod::RysQuadrature` or
-`IntegralMethod::Auto`). The implementation lives in `src/integrals/rys.cpp`
-and `rys_roots.cpp`.
+### Number of Roots
+
+For a quartet with total angular momentum \(L = l_A + l_B + l_C + l_D\), the
+exact number of Rys roots required is:
+
+\[
+n = \left\lfloor \frac{L}{2} \right\rfloor + 1
+\]
+
+Planck supports up to \(n = 11\) roots (`RYS_MAX_ROOTS`), corresponding to
+\(L \le 20\) (two H-shells). For S, P, D, F, G shells the root counts are:
+
+| Shell quartet | L | Roots |
+|---|---|---|
+| (ss∣ss) | 0 | 1 |
+| (sp∣ss) | 1 | 1 |
+| (pp∣ss) | 2 | 2 |
+| (pp∣pp) | 4 | 3 |
+| (dd∣ss) | 4 | 3 |
+| (dd∣pp) | 6 | 4 |
+| (dd∣dd) | 8 | 5 |
+| (ff∣dd) | 10 | 6 |
+
+### Root Finding
+
+Computing the roots and weights for a given \(T\) is the central numerical
+challenge. Planck uses two strategies, selected by `rys_roots_weights` in
+`src/integrals/rys_roots.cpp`:
+
+**T ≈ 0 (Gauss-Legendre limit)**: As \(T \to 0\) the weight function
+\(e^{-Tt^2} \to 1\), so the Rys quadrature degenerates to the standard
+Gauss-Legendre rule on \([0,1]\). Pre-tabulated GL roots and weights for
+\(n = 1, \ldots, 11\) are stored in `gl_roots` and `gl_weights` and used
+directly when \(T < 10^{-14}\).
+
+**T > 0 (Stieltjes–Jacobi procedure)**: For non-zero \(T\) the Rys
+measure is \(e^{-Tt^2} dt\) on \([0,1]\). The roots and weights are obtained
+by building the three-term recurrence (Jacobi) matrix of the orthogonal
+polynomial family with respect to this measure. The algorithm:
+
+1. Compute \(2n+1\) Boys moments
+   \(F_m(T) = \int_0^1 t^{2m} e^{-Tt^2} dt\) in long double precision.
+2. Construct orthonormal polynomials via the Gram-Schmidt Stieltjes procedure,
+   recording the diagonal (\(\alpha_k\)) and sub-diagonal (\(\beta_k\)) entries
+   of the symmetric \(n \times n\) Jacobi matrix \(\mathbf J\).
+3. Diagonalize \(\mathbf J\) using Eigen's `SelfAdjointEigenSolver`. The
+   eigenvalues are the Rys roots \(t_r^2\); the weight for root \(r\) is
+   \(w_r = F_0(T) \cdot V_{0r}^2\) where \(V_{0r}\) is the first component of
+   the \(r\)-th eigenvector. This is the Golub–Welsch formula.
+4. If the Gram-Schmidt procedure encounters a degenerate norm, the algorithm
+   falls back to the Gauss-Legendre table.
+
+### The Rys 1D VRR
+
+For each Rys root \(u = t_r^2\), the ERI factorizes into three independent 1D
+integrals. Each 1D table \(I[a][c]\) is filled by its own three-term recursion:
+
+\[
+I[0][0] = 1 \qquad\text{(seed)}
+\]
+
+*Bra increment* (\(c = 0\)):
+
+\[
+I[a+1][0] = C_{00}\, I[a][0] + a\, B_{10}\, I[a-1][0]
+\]
+
+*Ket increment* (general \(a\)):
+
+\[
+I[a][c+1] = D_{00}\, I[a][c] + c\, B_{01}\, I[a][c-1] + a\, B_{00}\, I[a-1][c-1]
+\]
+
+The root-dependent coefficients are:
+
+\[
+B_{00} = \frac{u}{2\delta}, \qquad
+B_{10} = \frac{1}{2\zeta} - B_{00}, \qquad
+B_{01} = \frac{1}{2\eta}  - B_{00}
+\]
+
+\[
+C_{00} = (P_q - A_q) + u\,(W_q - P_q), \qquad
+D_{00} = (Q_q - C_q) + u\,(W_q - Q_q)
+\]
+
+where \(\delta = \zeta + \eta\), \(\mathbf W = (\zeta\mathbf P + \eta\mathbf Q)/\delta\) is the
+weighted Gaussian product center, and \(q\) is the Cartesian direction. As
+\(u \to 0\) the root sits at the A-center (\(C_{00} \to P_q - A_q\)); as
+\(u \to 1\) the root sits at the W-center. These recurrences are implemented
+in `_rys_vrr_1d` in `src/integrals/rys.cpp`.
+
+### 6D Accumulation and HRR
+
+After running `_rys_vrr_1d` for all three Cartesian directions, the 3D outer
+product is accumulated into a six-index buffer:
+
+\[
+W[a_x][a_y][a_z][c_x][c_y][c_z]
+  \mathrel{+}= w_r \cdot I_x[a_x][c_x] \cdot I_y[a_y][c_y] \cdot I_z[a_z][c_z]
+\]
+
+This sum runs over all \(n\) roots. After the root loop the buffer holds
+\((a\,0\,|\,c\,0)\) intermediates analogous to those produced by the OS VRR.
+The thread-local six-index array `_rys_sum_buf[13][13][13][13][13][13]`
+is the Rys counterpart of `_vrr_buf` in `os.cpp`.
+
+Angular momentum is then transferred to the second center of each shell pair
+using the same HRR as the OS path:
+
+- **AB-HRR** (`_rys_hrr_ab`): \((a+1_i\,b-1_i\,|\,c\,d) + (A_i - B_i)(a\,b-1_i\,|\,c\,d)\)
+- **CD-HRR** (`_rys_hrr_cd`): operates on the 3D slice extracted at \((l_A, l_A, l_A)\)
+  after the AB sweep.
+
+The contracted ERI is obtained by summing the primitive results over all
+\((\alpha, \beta)\) and \((\gamma, \delta)\) primitive pairs inside
+`_rys_contracted_eri`.
+
+### Auto-Dispatch: OS vs. Rys Cost Model
+
+Planck's `auto` engine mode selects OS or Rys per contracted shell quartet using
+an analytic operation-count estimate (`_auto_prefers_rys` in `rys.cpp`).
+
+Define:
+
+\[
+\text{six\_d} = (l_{AB,x}+1)(l_{AB,y}+1)(l_{AB,z}+1)
+                (l_{CD,x}+1)(l_{CD,y}+1)(l_{CD,z}+1)
+\]
+
+This counts the number of entries in the 6D accumulation buffer. The estimated
+flop counts are:
+
+\[
+W_{\text{OS}}  = \text{six\_d}\cdot(L+1)
+               + (l_B + l_D + 1)\cdot\text{six\_d}\cdot 0.25
+\]
+
+\[
+W_{\text{Rys}} = \text{six\_d}\cdot n
+               + (l_B + l_D + 1)\cdot\text{six\_d}\cdot 0.20
+               + 24\cdot n
+\]
+
+where \(n = \lfloor L/2 \rfloor + 1\) is the number of Rys roots and the
+constant 24 accounts for the per-root overhead of root finding and 1D
+coefficient computation. Rys is preferred when \(W_{\text{Rys}} < W_{\text{OS}}\).
+
+For a (dd|dd) quartet: \(L = 8\), \(n = 5\),
+\(\text{six\_d} = 3^4 \cdot 3^4 = \ldots\), and the Rys path wins because the
+OS stack grows as \(L+1 = 9\) deep while Rys only needs 5 root evaluations.
+For (ss|ss) through (sp|sp) the OS path is cheaper. The empirical crossover is
+around \(L = 4\) (constant `RYS_CROSSOVER_L`). The `_auto_contracted_eri`
+wrapper dispatches to `_rys_contracted_eri` or `ObaraSaika::_contracted_eri_elem`
+at this level.
+
+### Implementation Files
+
+| File | Role |
+|---|---|
+| `src/integrals/rys.h` | Public API: `_compute_2e`, `_compute_2e_fock`, `_compute_2e_fock_uhf`, and `_auto` variants |
+| `src/integrals/rys.cpp` | VRR (`_rys_vrr_1d`), HRR (`_rys_hrr_ab`, `_rys_hrr_cd`), primitive and contracted ERI, Schwarz table, Fock builders, auto-dispatch |
+| `src/integrals/rys_roots.h` | `rys_roots_weights` declaration; exact 1-point formula `rys_1pt` |
+| `src/integrals/rys_roots.cpp` | Pre-tabulated GL rules; Boys moment recursion; Stieltjes–Jacobi Gram-Schmidt + Eigen eigendecomposition |
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -307,6 +307,13 @@
 <li class="toc-level-3"><a href="#schwarz-screening">Schwarz Screening</a></li>
 <li class="toc-level-3"><a href="#permutation-symmetry-of-the-eri-tensor">Permutation Symmetry of the ERI Tensor</a></li>
 <li class="toc-level-2"><a href="#6-rys-quadrature">6. Rys Quadrature</a></li>
+<li class="toc-level-3"><a href="#the-basic-idea">The Basic Idea</a></li>
+<li class="toc-level-3"><a href="#number-of-roots">Number of Roots</a></li>
+<li class="toc-level-3"><a href="#root-finding">Root Finding</a></li>
+<li class="toc-level-3"><a href="#the-rys-1d-vrr">The Rys 1D VRR</a></li>
+<li class="toc-level-3"><a href="#6d-accumulation-and-hrr">6D Accumulation and HRR</a></li>
+<li class="toc-level-3"><a href="#auto-dispatch-os-vs-rys-cost-model">Auto-Dispatch: OS vs. Rys Cost Model</a></li>
+<li class="toc-level-3"><a href="#implementation-files">Implementation Files</a></li>
 <li class="toc-level-2"><a href="#7-hartree-fock-theory">7. Hartree-Fock Theory</a></li>
 <li class="toc-level-3"><a href="#the-variational-principle">The Variational Principle</a></li>
 <li class="toc-level-3"><a href="#roothaan-equations-rhf">Roothaan Equations (RHF)</a></li>
@@ -588,12 +595,113 @@ Q(i,j) \cdot Q(k,l) < \epsilon_{ERI}
 <p>Planck iterates only over pairs <span class="math-inline">\(p \le q\)</span> in the AO-pair index and fills all 8 equivalent slots after each computation, reducing work by a factor of 8.</p>
 <hr>
 <h2 id="6-rys-quadrature">6. Rys Quadrature</h2>
-<p>The Rys quadrature method evaluates ERIs by converting the Boys function integral into a Gauss-Legendre-type quadrature:</p>
+<h3 id="the-basic-idea">The Basic Idea</h3>
+<p>The Obara-Saika VRR builds an <span class="math-inline">\((L+1)\)</span>-deep stack of auxiliary integrals at each auxiliary order <span class="math-inline">\(m\)</span>. For high-angular-momentum quartets (d+d, f+p, …) the stack grows large, and intermediate storage dominates the cost. The Rys quadrature method avoids auxiliary-order recursion entirely by converting the Boys function integral into a discrete sum:</p>
 <p><span class="math-display">\[
-F_m(t) = \sum_{r=1}^{n_r} w_r\, x_r^{2m}
+F_m(T) = \int_0^1 t^{2m}\, e^{-T t^2}\, dt
+       = \sum_{r=1}^{n} w_r(T)\, \bigl[t_r^2(T)\bigr]^m
 \]</span></p>
-<p>where <span class="math-inline">\(\{x_r, w_r\}\)</span> are the Rys roots and weights that depend on <span class="math-inline">\(t = \zeta\eta/(\zeta+\eta) R_{PQ}^2\)</span>. Each quadrature point decouples the 3D integral into three independent 1D integrals, one per Cartesian direction, which are then multiplied together.</p>
-<p>The Rys method naturally handles high-angular-momentum quartets without the recursive intermediate storage required by the VRR/HRR scheme. Planck uses it as an alternative engine (controlled by <code>IntegralMethod::RysQuadrature</code> or <code>IntegralMethod::Auto</code>). The implementation lives in <code>src/integrals/rys.cpp</code> and <code>rys_roots.cpp</code>.</p>
+<p>where <span class="math-inline">\(\{t_r^2, w_r\}\)</span> are the Rys roots (squared) and weights, which depend on the Boys argument <span class="math-inline">\(T = \rho\,|\mathbf{PQ}|^2\)</span>. When this representation is substituted into the ERI expression, the integral factorizes into independent 1D integrals in <span class="math-inline">\(x\)</span>, <span class="math-inline">\(y\)</span>, and <span class="math-inline">\(z\)</span> for each quadrature point <span class="math-inline">\(r\)</span>.</p>
+<h3 id="number-of-roots">Number of Roots</h3>
+<p>For a quartet with total angular momentum <span class="math-inline">\(L = l_A + l_B + l_C + l_D\)</span>, the exact number of Rys roots required is:</p>
+<p><span class="math-display">\[
+n = \left\lfloor \frac{L}{2} \right\rfloor + 1
+\]</span></p>
+<p>Planck supports up to <span class="math-inline">\(n = 11\)</span> roots (<code>RYS_MAX_ROOTS</code>), corresponding to <span class="math-inline">\(L \le 20\)</span> (two H-shells). For S, P, D, F, G shells the root counts are:</p>
+<div class="table-wrap"><table>
+<thead><tr>
+<th>Shell quartet</th>
+<th>L</th>
+<th>Roots</th>
+</tr></thead>
+<tbody>
+<tr><td>(ss∣ss)</td><td>0</td><td>1</td></tr>
+<tr><td>(sp∣ss)</td><td>1</td><td>1</td></tr>
+<tr><td>(pp∣ss)</td><td>2</td><td>2</td></tr>
+<tr><td>(pp∣pp)</td><td>4</td><td>3</td></tr>
+<tr><td>(dd∣ss)</td><td>4</td><td>3</td></tr>
+<tr><td>(dd∣pp)</td><td>6</td><td>4</td></tr>
+<tr><td>(dd∣dd)</td><td>8</td><td>5</td></tr>
+<tr><td>(ff∣dd)</td><td>10</td><td>6</td></tr>
+</tbody></table></div>
+<h3 id="root-finding">Root Finding</h3>
+<p>Computing the roots and weights for a given <span class="math-inline">\(T\)</span> is the central numerical challenge. Planck uses two strategies, selected by <code>rys_roots_weights</code> in <code>src/integrals/rys_roots.cpp</code>:</p>
+<p><strong>T ≈ 0 (Gauss-Legendre limit)</strong>: As <span class="math-inline">\(T \to 0\)</span> the weight function <span class="math-inline">\(e^{-Tt^2} \to 1\)</span>, so the Rys quadrature degenerates to the standard Gauss-Legendre rule on <span class="math-inline">\([0,1]\)</span>. Pre-tabulated GL roots and weights for <span class="math-inline">\(n = 1, \ldots, 11\)</span> are stored in <code>gl_roots</code> and <code>gl_weights</code> and used directly when <span class="math-inline">\(T < 10^{-14}\)</span>.</p>
+<p><strong>T &gt; 0 (Stieltjes–Jacobi procedure)</strong>: For non-zero <span class="math-inline">\(T\)</span> the Rys measure is <span class="math-inline">\(e^{-Tt^2} dt\)</span> on <span class="math-inline">\([0,1]\)</span>. The roots and weights are obtained by building the three-term recurrence (Jacobi) matrix of the orthogonal polynomial family with respect to this measure. The algorithm:</p>
+<ol>
+<li>Compute <span class="math-inline">\(2n+1\)</span> Boys moments <span class="math-inline">\(F_m(T) = \int_0^1 t^{2m} e^{-Tt^2} dt\)</span> in long double precision.</li>
+<li>Construct orthonormal polynomials via the Gram-Schmidt Stieltjes procedure, recording the diagonal (<span class="math-inline">\(\alpha_k\)</span>) and sub-diagonal (<span class="math-inline">\(\beta_k\)</span>) entries of the symmetric <span class="math-inline">\(n \times n\)</span> Jacobi matrix <span class="math-inline">\(\mathbf J\)</span>.</li>
+<li>Diagonalize <span class="math-inline">\(\mathbf J\)</span> using Eigen&#x27;s <code>SelfAdjointEigenSolver</code>. The eigenvalues are the Rys roots <span class="math-inline">\(t_r^2\)</span>; the weight for root <span class="math-inline">\(r\)</span> is <span class="math-inline">\(w_r = F_0(T) \cdot V_{0r}^2\)</span> where <span class="math-inline">\(V_{0r}\)</span> is the first component of the <span class="math-inline">\(r\)</span>-th eigenvector. This is the Golub–Welsch formula.</li>
+<li>If the Gram-Schmidt procedure encounters a degenerate norm, the algorithm falls back to the Gauss-Legendre table.</li>
+</ol>
+<h3 id="the-rys-1d-vrr">The Rys 1D VRR</h3>
+<p>For each Rys root <span class="math-inline">\(u = t_r^2\)</span>, the ERI factorizes into three independent 1D integrals. Each 1D table <span class="math-inline">\(I[a][c]\)</span> is filled by its own three-term recursion:</p>
+<p><span class="math-display">\[
+I[0][0] = 1 \qquad\text{(seed)}
+\]</span></p>
+<p><em>Bra increment</em> (<span class="math-inline">\(c = 0\)</span>):</p>
+<p><span class="math-display">\[
+I[a+1][0] = C_{00}\, I[a][0] + a\, B_{10}\, I[a-1][0]
+\]</span></p>
+<p><em>Ket increment</em> (general <span class="math-inline">\(a\)</span>):</p>
+<p><span class="math-display">\[
+I[a][c+1] = D_{00}\, I[a][c] + c\, B_{01}\, I[a][c-1] + a\, B_{00}\, I[a-1][c-1]
+\]</span></p>
+<p>The root-dependent coefficients are:</p>
+<p><span class="math-display">\[
+B_{00} = \frac{u}{2\delta}, \qquad
+B_{10} = \frac{1}{2\zeta} - B_{00}, \qquad
+B_{01} = \frac{1}{2\eta}  - B_{00}
+\]</span></p>
+<p><span class="math-display">\[
+C_{00} = (P_q - A_q) + u\,(W_q - P_q), \qquad
+D_{00} = (Q_q - C_q) + u\,(W_q - Q_q)
+\]</span></p>
+<p>where <span class="math-inline">\(\delta = \zeta + \eta\)</span>, <span class="math-inline">\(\mathbf W = (\zeta\mathbf P + \eta\mathbf Q)/\delta\)</span> is the weighted Gaussian product center, and <span class="math-inline">\(q\)</span> is the Cartesian direction. As <span class="math-inline">\(u \to 0\)</span> the root sits at the A-center (<span class="math-inline">\(C_{00} \to P_q - A_q\)</span>); as <span class="math-inline">\(u \to 1\)</span> the root sits at the W-center. These recurrences are implemented in <code>_rys_vrr_1d</code> in <code>src/integrals/rys.cpp</code>.</p>
+<h3 id="6d-accumulation-and-hrr">6D Accumulation and HRR</h3>
+<p>After running <code>_rys_vrr_1d</code> for all three Cartesian directions, the 3D outer product is accumulated into a six-index buffer:</p>
+<p><span class="math-display">\[
+W[a_x][a_y][a_z][c_x][c_y][c_z]
+  \mathrel{+}= w_r \cdot I_x[a_x][c_x] \cdot I_y[a_y][c_y] \cdot I_z[a_z][c_z]
+\]</span></p>
+<p>This sum runs over all <span class="math-inline">\(n\)</span> roots. After the root loop the buffer holds <span class="math-inline">\((a\,0\,|\,c\,0)\)</span> intermediates analogous to those produced by the OS VRR. The thread-local six-index array <code>_rys_sum_buf[13][13][13][13][13][13]</code> is the Rys counterpart of <code>_vrr_buf</code> in <code>os.cpp</code>.</p>
+<p>Angular momentum is then transferred to the second center of each shell pair using the same HRR as the OS path:</p>
+<ul>
+<li><strong>AB-HRR</strong> (<code>_rys_hrr_ab</code>): <span class="math-inline">\((a+1_i\,b-1_i\,|\,c\,d) + (A_i - B_i)(a\,b-1_i\,|\,c\,d)\)</span></li>
+<li><strong>CD-HRR</strong> (<code>_rys_hrr_cd</code>): operates on the 3D slice extracted at <span class="math-inline">\((l_A, l_A, l_A)\)</span> after the AB sweep.</li>
+</ul>
+<p>The contracted ERI is obtained by summing the primitive results over all <span class="math-inline">\((\alpha, \beta)\)</span> and <span class="math-inline">\((\gamma, \delta)\)</span> primitive pairs inside <code>_rys_contracted_eri</code>.</p>
+<h3 id="auto-dispatch-os-vs-rys-cost-model">Auto-Dispatch: OS vs. Rys Cost Model</h3>
+<p>Planck&#x27;s <code>auto</code> engine mode selects OS or Rys per contracted shell quartet using an analytic operation-count estimate (<code>_auto_prefers_rys</code> in <code>rys.cpp</code>).</p>
+<p>Define:</p>
+<p><span class="math-display">\[
+\text{six\_d} = (l_{AB,x}+1)(l_{AB,y}+1)(l_{AB,z}+1)
+                (l_{CD,x}+1)(l_{CD,y}+1)(l_{CD,z}+1)
+\]</span></p>
+<p>This counts the number of entries in the 6D accumulation buffer. The estimated flop counts are:</p>
+<p><span class="math-display">\[
+W_{\text{OS}}  = \text{six\_d}\cdot(L+1)
+               + (l_B + l_D + 1)\cdot\text{six\_d}\cdot 0.25
+\]</span></p>
+<p><span class="math-display">\[
+W_{\text{Rys}} = \text{six\_d}\cdot n
+               + (l_B + l_D + 1)\cdot\text{six\_d}\cdot 0.20
+               + 24\cdot n
+\]</span></p>
+<p>where <span class="math-inline">\(n = \lfloor L/2 \rfloor + 1\)</span> is the number of Rys roots and the constant 24 accounts for the per-root overhead of root finding and 1D coefficient computation. Rys is preferred when <span class="math-inline">\(W_{\text{Rys}} < W_{\text{OS}}\)</span>.</p>
+<p>For a (dd|dd) quartet: <span class="math-inline">\(L = 8\)</span>, <span class="math-inline">\(n = 5\)</span>, <span class="math-inline">\(\text{six\_d} = 3^4 \cdot 3^4 = \ldots\)</span>, and the Rys path wins because the OS stack grows as <span class="math-inline">\(L+1 = 9\)</span> deep while Rys only needs 5 root evaluations. For (ss|ss) through (sp|sp) the OS path is cheaper. The empirical crossover is around <span class="math-inline">\(L = 4\)</span> (constant <code>RYS_CROSSOVER_L</code>). The <code>_auto_contracted_eri</code> wrapper dispatches to <code>_rys_contracted_eri</code> or <code>ObaraSaika::_contracted_eri_elem</code> at this level.</p>
+<h3 id="implementation-files">Implementation Files</h3>
+<div class="table-wrap"><table>
+<thead><tr>
+<th>File</th>
+<th>Role</th>
+</tr></thead>
+<tbody>
+<tr><td><code>src/integrals/rys.h</code></td><td>Public API: <code>_compute_2e</code>, <code>_compute_2e_fock</code>, <code>_compute_2e_fock_uhf</code>, and <code>_auto</code> variants</td></tr>
+<tr><td><code>src/integrals/rys.cpp</code></td><td>VRR (<code>_rys_vrr_1d</code>), HRR (<code>_rys_hrr_ab</code>, <code>_rys_hrr_cd</code>), primitive and contracted ERI, Schwarz table, Fock builders, auto-dispatch</td></tr>
+<tr><td><code>src/integrals/rys_roots.h</code></td><td><code>rys_roots_weights</code> declaration; exact 1-point formula <code>rys_1pt</code></td></tr>
+<tr><td><code>src/integrals/rys_roots.cpp</code></td><td>Pre-tabulated GL rules; Boys moment recursion; Stieltjes–Jacobi Gram-Schmidt + Eigen eigendecomposition</td></tr>
+</tbody></table></div>
 <hr>
 <h2 id="7-hartree-fock-theory">7. Hartree-Fock Theory</h2>
 <h3 id="the-variational-principle">The Variational Principle</h3>

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -90,6 +90,7 @@ int main(int argc, const char* argv[])
     // multiplicity are taken from the checkpoint (e.g. an optimized geometry)
     // rather than the input file.  This must happen before detectSymmetry() and
     // read_gbs_basis() so that they operate on the checkpoint geometry.
+    bool preserve_checkpoint_ao_frame = false;
     if (calculator._scf._guess == HartreeFock::SCFGuess::ReadFull)
     {
         if (auto geo = HartreeFock::Checkpoint::load_geometry(calculator._checkpoint_path); geo)
@@ -110,6 +111,7 @@ int main(int argc, const char* argv[])
             calculator._molecule.charge        = geo->charge;
             calculator._molecule.multiplicity  = geo->multiplicity;
             calculator._molecule.atomic_numbers = geo->atomic_numbers;
+            preserve_checkpoint_ao_frame = true;
 
             HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "Checkpoint :",
                 std::format("Restoring {} geometry from {}{}",
@@ -136,7 +138,18 @@ int main(int argc, const char* argv[])
     HartreeFock::Logger::blank();
 
     // Detect Symmetry
-    if (!calculator._geometry._use_symm)
+    if (preserve_checkpoint_ao_frame)
+    {
+        calculator._molecule._point_group = "C1";
+        calculator._molecule._symmetry = false;
+        HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "Symmetry Detection :",
+            "Skipped for guess full restart to preserve checkpoint AO frame");
+        HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "Symmetry Detection :",
+            "Checkpoint density and 1e matrices are reused in the stored standard orientation");
+        HartreeFock::Logger::blank();
+    }
+
+    else if (!calculator._geometry._use_symm)
     {
         HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "Symmetry Detection :", "Symmetry detection is turned off by request");
         // No reorientation — standard frame equals input frame.


### PR DESCRIPTION
Expand README, teaching guide, and HTML site with a full explanation of the Rys quadrature ERI engine: the Boys-to-quadrature reduction, number of roots (n = floor(L/2)+1), Stieltjes-Jacobi root finding (Gauss-Legendre limit for T→0, eigendecomposition of the Jacobi moment matrix for T>0), the per-root 1D VRR recurrences (C00/D00/B00/B10/B01), 6D accumulation and HRR, and the analytic flop-count cost model that drives automatic OS/Rys dispatch per shell quartet (crossover at L=4). Fix table cell rendering for ERI notation by replacing ASCII pipe with Unicode divides (∣) so the custom Markdown table parser does not misinterpret the bra-ket separator as a column boundary. Also include a driver fix that preserves the checkpoint AO frame on guess full restart by skipping symmetry reorientation.