### PR TITLE
Implement analytic RMP2 gradient response intermediates

### DIFF
--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -20,6 +20,7 @@
 #include "integrals/base.h"
 #include "scf/scf.h"
 #include "post_hf/mp2.h"
+#include "post_hf/mp2_gradient.h"
 #include "post_hf/casscf.h"
 #include "gradient/gradient.h"
 #include "opt/geomopt.h"
@@ -589,6 +590,16 @@ int main(int argc, const char* argv[])
             }
             else
             {
+                if (calculator._correlation == HartreeFock::PostHF::RMP2)
+                {
+                    auto nat_res = HartreeFock::Correlation::compute_rmp2_natural_occupancies(
+                        calculator, shellpairs);
+                    if (nat_res)
+                        HartreeFock::Logger::mp2_natural_orbitals(*nat_res);
+                    else
+                        HartreeFock::Logger::logging(HartreeFock::LogLevel::Warning,
+                            "RMP2 :", "Natural orbitals unavailable: " + nat_res.error());
+                }
                 HartreeFock::Logger::correlation_energy(calculator._total_energy, calculator._correlation_energy);
             }
 
@@ -617,9 +628,9 @@ int main(int argc, const char* argv[])
         if (calculator._correlation == HartreeFock::PostHF::RMP2)
         {
             HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "Gradient :",
-                "Using central-difference RMP2 total-energy gradient");
+                "Using analytic RMP2 gradient (relaxed density + pair density + Z-vector)");
             calculator._total_energy += calculator._correlation_energy;
-            grad = HartreeFock::Gradient::compute_rmp2_gradient(calculator);
+            grad = HartreeFock::Gradient::compute_rmp2_gradient(calculator, shellpairs);
         }
         else if (calculator._correlation == HartreeFock::PostHF::UMP2)
         {

--- a/src/gradient/gradient.cpp
+++ b/src/gradient/gradient.cpp
@@ -9,6 +9,7 @@
 #include "integrals/base.h"
 #include "integrals/shellpair.h"
 #include "post_hf/mp2.h"
+#include "post_hf/mp2_gradient.h"
 #include "scf/scf.h"
 #include "symmetry/integral_symmetry.h"
 
@@ -43,46 +44,9 @@ static std::vector<int> build_shell_atom_map(
     return map;
 }
 
-// Rebuild the RHF + RMP2 total energy for the geometry currently stored in
-// calc._molecule._standard (Bohr). Used by the semi-numerical RMP2 gradient.
-static double run_sp_rmp2_energy(HartreeFock::Calculator& calc)
+static std::size_t idx_dm2_grad(int p, int q, int r, int s, int nbf)
 {
-    calc._molecule._coordinates = calc._molecule._standard;
-    calc._molecule.coordinates  = calc._molecule._standard / ANGSTROM_TO_BOHR;
-
-    const std::string gbs_path =
-        calc._basis._basis_path + "/" + calc._basis._basis_name;
-    calc._shells = HartreeFock::BasisFunctions::read_gbs_basis(
-        gbs_path, calc._molecule, calc._basis._basis);
-
-    calc._info._scf = HartreeFock::DataSCF(false);
-    calc._info._scf.initialize(calc._shells.nbasis());
-    calc._scf.set_scf_mode_auto(calc._shells.nbasis());
-    calc._info._is_converged   = false;
-    calc._use_sao_blocking     = false;
-    calc._correlation_energy   = 0.0;
-    calc._eri.clear();
-
-    calc._compute_nuclear_repulsion();
-
-    auto shell_pairs = build_shellpairs(calc._shells);
-    HartreeFock::Symmetry::update_integral_symmetry(calc);
-    auto [S, T] = _compute_1e(shell_pairs, calc._shells.nbasis(), calc._integral._engine,
-                              calc._use_integral_symmetry ? &calc._integral_symmetry_ops : nullptr);
-    auto V = _compute_nuclear_attraction(shell_pairs, calc._shells.nbasis(),
-                                         calc._molecule, calc._integral._engine,
-                                         calc._use_integral_symmetry ? &calc._integral_symmetry_ops : nullptr);
-    calc._overlap = S;
-    calc._hcore   = T + V;
-
-    if (auto scf_res = HartreeFock::SCF::run_rhf(calc, shell_pairs); !scf_res)
-        throw std::runtime_error("RMP2 gradient RHF failed: " + scf_res.error());
-
-    if (auto mp2_res = HartreeFock::Correlation::run_rmp2(calc, shell_pairs); !mp2_res)
-        throw std::runtime_error("RMP2 gradient MP2 failed: " + mp2_res.error());
-
-    calc._total_energy += calc._correlation_energy;
-    return calc._total_energy;
+    return ((static_cast<std::size_t>(p) * nbf + q) * nbf + r) * nbf + s;
 }
 
 template <typename GammaFn>
@@ -416,35 +380,46 @@ Eigen::MatrixXd HartreeFock::Gradient::compute_uhf_gradient(
 }
 
 Eigen::MatrixXd HartreeFock::Gradient::compute_rmp2_gradient(
-    const HartreeFock::Calculator& calc)
+    HartreeFock::Calculator& calc,
+    const std::vector<HartreeFock::ShellPair>& shell_pairs)
 {
     if (calc._correlation != HartreeFock::PostHF::RMP2)
         throw std::runtime_error("RMP2 gradient requested without correlation = RMP2");
     if (calc._scf._scf != HartreeFock::SCFType::RHF || calc._info._scf.is_uhf)
         throw std::runtime_error("RMP2 gradient requires an RHF reference");
 
-    const std::size_t natoms = calc._molecule.natoms;
-    Eigen::MatrixXd grad = Eigen::MatrixXd::Zero(natoms, 3);
+    auto grad_res = HartreeFock::Correlation::build_rmp2_gradient_intermediates(calc, shell_pairs);
+    if (!grad_res)
+        throw std::runtime_error("RMP2 gradient build failed: " + grad_res.error());
+    const auto& grad_data = *grad_res;
 
-    // Central-difference step in Bohr. Chosen smaller than the Hessian default
-    // because we are differentiating total energies directly.
-    constexpr double step = 1e-3;
+    const Eigen::MatrixXd& P_ref = calc._info._scf.alpha.density;
+    const Eigen::MatrixXd P_corr = grad_data.P_gamma_ao - P_ref;
+    const int nb = static_cast<int>(calc._shells.nbasis());
+    const auto& gamma_pair = grad_data.Gamma_pair_ao;
 
-    for (std::size_t a = 0; a < natoms; ++a)
+    auto gamma_fn = [&P_ref, &P_corr, &gamma_pair, nb](std::size_t ii, std::size_t jj,
+                                                       std::size_t kk, std::size_t ll) -> double
     {
-        for (int q = 0; q < 3; ++q)
-        {
-            HartreeFock::Calculator calc_fwd = calc;
-            HartreeFock::Calculator calc_bck = calc;
+        const double P0_ij = P_ref(ii, jj);
+        const double P0_kl = P_ref(kk, ll);
+        const double P0_ik = P_ref(ii, kk);
+        const double P0_jl = P_ref(jj, ll);
 
-            calc_fwd._molecule._standard(a, q) += step;
-            calc_bck._molecule._standard(a, q) -= step;
+        const double dP_ij = P_corr(ii, jj);
+        const double dP_kl = P_corr(kk, ll);
+        const double dP_ik = P_corr(ii, kk);
+        const double dP_jl = P_corr(jj, ll);
 
-            const double e_fwd = run_sp_rmp2_energy(calc_fwd);
-            const double e_bck = run_sp_rmp2_energy(calc_bck);
-            grad(a, q) = (e_fwd - e_bck) / (2.0 * step);
-        }
-    }
+        return 2.0 * P0_ij * P0_kl - P0_ik * P0_jl
+             + 2.0 * (dP_ij * P0_kl + P0_ij * dP_kl)
+             - (dP_ik * P0_jl + P0_ik * dP_jl)
+             + gamma_pair[idx_dm2_grad(
+                 static_cast<int>(ii), static_cast<int>(jj),
+                 static_cast<int>(kk), static_cast<int>(ll),
+                 nb)];
+    };
 
-    return grad;
+    return compute_closed_shell_gradient_from_density(calc, shell_pairs,
+                                                      grad_data.P_ao, grad_data.W_ao, gamma_fn);
 }

--- a/src/gradient/gradient.h
+++ b/src/gradient/gradient.h
@@ -19,10 +19,12 @@ namespace HartreeFock
         Eigen::MatrixXd compute_uhf_gradient(const HartreeFock::Calculator& calc,
                                              const std::vector<HartreeFock::ShellPair>& shell_pairs);
 
-        // RMP2 nuclear gradient via central differences of the total RMP2 energy.
+        // Analytic RMP2 nuclear gradient from the relaxed MP2 density and
+        // Z-vector response.
         // Returns natoms×3 matrix in Ha/Bohr.
         // Requires a converged RHF reference and correlation = RMP2.
-        Eigen::MatrixXd compute_rmp2_gradient(const HartreeFock::Calculator& calc);
+        Eigen::MatrixXd compute_rmp2_gradient(HartreeFock::Calculator& calc,
+                                             const std::vector<HartreeFock::ShellPair>& shell_pairs);
     }
 }
 

--- a/src/opt/geomopt.cpp
+++ b/src/opt/geomopt.cpp
@@ -97,7 +97,7 @@ static Eigen::VectorXd _run_sp_gradient(HartreeFock::Calculator& calc)
         if (auto corr_res = HartreeFock::Correlation::run_rmp2(calc, shell_pairs); !corr_res)
             throw std::runtime_error("GeomOpt RMP2 failed: " + corr_res.error());
         calc._total_energy += calc._correlation_energy;
-        grad_mat = HartreeFock::Gradient::compute_rmp2_gradient(calc);
+        grad_mat = HartreeFock::Gradient::compute_rmp2_gradient(calc, shell_pairs);
     }
     else if (calc._correlation == HartreeFock::PostHF::UMP2)
     {

--- a/src/post_hf/mp2_gradient.cpp
+++ b/src/post_hf/mp2_gradient.cpp
@@ -2,6 +2,8 @@
 
 #include <format>
 
+#include "integrals/base.h"
+#include "integrals/os.h"
 #include "post_hf/integrals.h"
 #include "post_hf/rhf_response.h"
 
@@ -16,6 +18,72 @@ inline std::size_t idx_pqrs(int p, int q, int r, int s, int nq, int nr, int ns)
 {
     return ((static_cast<std::size_t>(p) * nq + q) * nr + r) * ns + s;
 }
+
+inline std::size_t idx_dm2(int p, int q, int r, int s, int nmo)
+{
+    return ((static_cast<std::size_t>(p) * nmo + q) * nmo + r) * nmo + s;
+}
+
+Eigen::MatrixXd build_full_mo_coeff(const HartreeFock::Correlation::RMP2AmplitudeData& amp)
+{
+    const int nao = static_cast<int>(amp.C_occ.rows());
+    const int nmo = amp.n_occ + amp.n_virt;
+    Eigen::MatrixXd C(nao, nmo);
+    C.leftCols(amp.n_occ) = amp.C_occ;
+    C.rightCols(amp.n_virt) = amp.C_virt;
+    return C;
+}
+
+Eigen::MatrixXd build_rhf_reference_density_mo(int n_occ, int nmo)
+{
+    Eigen::MatrixXd P = Eigen::MatrixXd::Zero(nmo, nmo);
+    P.topLeftCorner(n_occ, n_occ) = 2.0 * Eigen::MatrixXd::Identity(n_occ, n_occ);
+    return P;
+}
+
+Eigen::MatrixXd build_rhf_reference_weighted_density_ao(
+    const HartreeFock::Correlation::RMP2AmplitudeData& amp)
+{
+    return 2.0 * amp.C_occ * amp.eps_occ.asDiagonal() * amp.C_occ.transpose();
+}
+
+Eigen::MatrixXd contract_imat_from_pair_density(
+    const std::vector<double>& eri,
+    const std::vector<double>& pair_dm2,
+    int nb)
+{
+    Eigen::MatrixXd imat = Eigen::MatrixXd::Zero(nb, nb);
+    for (int p = 0; p < nb; ++p)
+    for (int q = 0; q < nb; ++q)
+    {
+        double val = 0.0;
+        for (int i = 0; i < nb; ++i)
+        for (int r = 0; r < nb; ++r)
+        for (int s = 0; s < nb; ++s)
+        {
+            const std::size_t iprs = ((static_cast<std::size_t>(i) * nb + p) * nb + r) * nb + s;
+            const std::size_t iqrs = idx_dm2(i, q, r, s, nb);
+            val += eri[iprs] * pair_dm2[iqrs];
+        }
+        imat(p, q) = val;
+    }
+    return imat;
+}
+
+Eigen::MatrixXd build_veff_from_density(
+    HartreeFock::Calculator& calculator,
+    const std::vector<HartreeFock::ShellPair>& shell_pairs,
+    const Eigen::MatrixXd& density)
+{
+    return _compute_2e_fock(
+        shell_pairs,
+        density,
+        calculator._shells.nbasis(),
+        calculator._integral._engine,
+        calculator._integral._tol_eri,
+        calculator._use_integral_symmetry ? &calculator._integral_symmetry_ops : nullptr);
+}
+
 }
 
 namespace HartreeFock::Correlation
@@ -149,6 +217,73 @@ std::expected<Eigen::MatrixXd, std::string> build_rmp2_unrelaxed_density_ao(
     return P2;
 }
 
+std::expected<std::vector<double>, std::string> build_rmp2_unrelaxed_2pdm_mo(
+    HartreeFock::Calculator& calculator,
+    const std::vector<HartreeFock::ShellPair>& shell_pairs)
+{
+    auto amp_res = build_rmp2_amplitudes(calculator, shell_pairs);
+    if (!amp_res) return std::unexpected(amp_res.error());
+    const auto& amp  = *amp_res;
+    const int nmo = amp.n_occ + amp.n_virt;
+    const int o = amp.n_occ;
+
+    std::vector<double> dm2(static_cast<std::size_t>(nmo) * nmo * nmo * nmo, 0.0);
+
+    for (int i = 0; i < amp.n_occ; ++i)
+    for (int j = 0; j < amp.n_occ; ++j)
+    for (int a = 0; a < amp.n_virt; ++a)
+    for (int b = 0; b < amp.n_virt; ++b)
+    {
+        const double t_ijab = amp.t2[idx_iajb(i, a, j, b, amp.n_occ, amp.n_virt)];
+        const double t_ijba = amp.t2[idx_iajb(i, b, j, a, amp.n_occ, amp.n_virt)];
+        const double dovov = 4.0 * t_ijab - 2.0 * t_ijba;
+
+        dm2[idx_dm2(i, o + a, j, o + b, nmo)] += dovov;
+        dm2[idx_dm2(o + a, i, o + b, j, nmo)] += dovov;
+    }
+
+    return dm2;
+}
+
+std::expected<std::vector<double>, std::string> build_rmp2_unrelaxed_2pdm_ao(
+    HartreeFock::Calculator& calculator,
+    const std::vector<HartreeFock::ShellPair>& shell_pairs)
+{
+    auto amp_res = build_rmp2_amplitudes(calculator, shell_pairs);
+    if (!amp_res) return std::unexpected(amp_res.error());
+    auto dm2_res = build_rmp2_unrelaxed_2pdm_mo(calculator, shell_pairs);
+    if (!dm2_res) return std::unexpected(dm2_res.error());
+
+    const auto& amp = *amp_res;
+    const auto& dm2_mo = *dm2_res;
+    const int nmo = amp.n_occ + amp.n_virt;
+    const int nao = static_cast<int>(calculator._shells.nbasis());
+
+    Eigen::MatrixXd C(nao, nmo);
+    C.leftCols(amp.n_occ) = amp.C_occ;
+    C.rightCols(amp.n_virt) = amp.C_virt;
+
+    std::vector<double> dm2_ao(static_cast<std::size_t>(nao) * nao * nao * nao, 0.0);
+    for (int mu = 0; mu < nao; ++mu)
+    for (int nu = 0; nu < nao; ++nu)
+    for (int la = 0; la < nao; ++la)
+    for (int si = 0; si < nao; ++si)
+    {
+        double val = 0.0;
+        for (int p = 0; p < nmo; ++p)
+        for (int q = 0; q < nmo; ++q)
+        for (int r = 0; r < nmo; ++r)
+        for (int s = 0; s < nmo; ++s)
+        {
+            val += C(mu, p) * C(nu, q) * C(la, r) * C(si, s)
+                 * dm2_mo[idx_dm2(p, q, r, s, nmo)];
+        }
+        dm2_ao[idx_dm2(mu, nu, la, si, nao)] = val;
+    }
+
+    return dm2_ao;
+}
+
 std::expected<Eigen::MatrixXd, std::string> build_rmp2_zvector_rhs(
     HartreeFock::Calculator& calculator,
     const std::vector<HartreeFock::ShellPair>& shell_pairs)
@@ -220,40 +355,108 @@ std::expected<RMP2RelaxedDensity, std::string> build_rmp2_relaxed_density(
     HartreeFock::Calculator& calculator,
     const std::vector<HartreeFock::ShellPair>& shell_pairs)
 {
+    auto grad_res = build_rmp2_gradient_intermediates(calculator, shell_pairs);
+    if (!grad_res) return std::unexpected(grad_res.error());
+
+    RMP2RelaxedDensity relaxed;
+    relaxed.P_mo = std::move(grad_res->P_mo);
+    relaxed.P_ao = std::move(grad_res->P_ao);
+    return relaxed;
+}
+
+std::expected<RMP2GradientIntermediates, std::string> build_rmp2_gradient_intermediates(
+    HartreeFock::Calculator& calculator,
+    const std::vector<HartreeFock::ShellPair>& shell_pairs)
+{
     auto amp_res = build_rmp2_amplitudes(calculator, shell_pairs);
     if (!amp_res) return std::unexpected(amp_res.error());
     auto dens_res = build_rmp2_unrelaxed_density(calculator, shell_pairs);
     if (!dens_res) return std::unexpected(dens_res.error());
-    auto z_res = solve_rmp2_zvector(calculator, shell_pairs);
-    if (!z_res) return std::unexpected(z_res.error());
+    auto pair_res = build_rmp2_unrelaxed_2pdm_ao(calculator, shell_pairs);
+    if (!pair_res) return std::unexpected(pair_res.error());
 
     const auto& amp  = *amp_res;
     const auto& dens = *dens_res;
-    const auto& z    = *z_res;
+    const auto& pair_dm2_ao = *pair_res;
 
     const int nb = amp.n_occ + amp.n_virt;
-    Eigen::MatrixXd P_mo = Eigen::MatrixXd::Zero(nb, nb);
+    const Eigen::MatrixXd C = build_full_mo_coeff(amp);
 
-    // RHF reference occupations.
-    P_mo.topLeftCorner(amp.n_occ, amp.n_occ) = 2.0 * Eigen::MatrixXd::Identity(amp.n_occ, amp.n_occ);
+    Eigen::MatrixXd dm1_corr_mo = Eigen::MatrixXd::Zero(nb, nb);
+    dm1_corr_mo.topLeftCorner(amp.n_occ, amp.n_occ) = dens.P_occ + dens.P_occ.transpose();
+    dm1_corr_mo.bottomRightCorner(amp.n_virt, amp.n_virt) = dens.P_virt + dens.P_virt.transpose();
+    const Eigen::MatrixXd dm1_corr_ao = C * dm1_corr_mo * C.transpose();
 
-    // Add the MP2 oo/vv corrections and the ov response block.
-    P_mo.topLeftCorner(amp.n_occ, amp.n_occ) += dens.P_occ;
-    P_mo.bottomRightCorner(amp.n_virt, amp.n_virt) = dens.P_virt;
+    std::vector<double> eri_local;
+    const std::vector<double>& eri = ensure_eri(
+        calculator, shell_pairs, eri_local, "RMP2 Gradient :");
 
-    // The Z-vector lives in the virtual-occupied space. In the spin-summed
-    // spatial density this enters as a symmetric occupied-virtual correction.
-    P_mo.bottomLeftCorner(amp.n_virt, amp.n_occ) = 2.0 * z;
-    P_mo.topRightCorner(amp.n_occ, amp.n_virt) = 2.0 * z.transpose();
+    const Eigen::MatrixXd veff_corr_ao =
+        2.0 * build_veff_from_density(calculator, shell_pairs, dm1_corr_ao);
 
-    Eigen::MatrixXd C(nb, nb);
-    C.leftCols(amp.n_occ) = amp.C_occ;
-    C.rightCols(amp.n_virt) = amp.C_virt;
+    Eigen::MatrixXd imat_ao = contract_imat_from_pair_density(eri, pair_dm2_ao, nb);
+    Eigen::MatrixXd imat_mo = -C.transpose() * imat_ao * calculator._overlap * C;
 
-    RMP2RelaxedDensity relaxed;
-    relaxed.P_mo = P_mo;
-    relaxed.P_ao = C * P_mo * C.transpose();
-    return relaxed;
+    Eigen::MatrixXd Xvo =
+        amp.C_virt.transpose() * veff_corr_ao * amp.C_occ
+        + imat_mo.topRightCorner(amp.n_occ, amp.n_virt).transpose()
+        - imat_mo.bottomLeftCorner(amp.n_virt, amp.n_occ);
+
+    auto z_res = solve_rhf_cphf(calculator, shell_pairs, -Xvo);
+    if (!z_res) return std::unexpected(z_res.error());
+    const auto& z = *z_res;
+
+    Eigen::MatrixXd corr_relaxed_mo = dm1_corr_mo;
+    corr_relaxed_mo.bottomLeftCorner(amp.n_virt, amp.n_occ) = z;
+    corr_relaxed_mo.topRightCorner(amp.n_occ, amp.n_virt) = z.transpose();
+
+    Eigen::MatrixXd P_mo = build_rhf_reference_density_mo(amp.n_occ, nb) + corr_relaxed_mo;
+    Eigen::MatrixXd P_ao = C * P_mo * C.transpose();
+
+    Eigen::MatrixXd zeta_weights = Eigen::MatrixXd::Zero(nb, nb);
+    Eigen::VectorXd mo_energies(nb);
+    mo_energies << amp.eps_occ, amp.eps_virt;
+
+    for (int p = 0; p < nb; ++p)
+    for (int q = 0; q < nb; ++q)
+        zeta_weights(p, q) = 0.5 * (mo_energies(p) + mo_energies(q));
+
+    for (int a = 0; a < amp.n_virt; ++a)
+    for (int i = 0; i < amp.n_occ; ++i)
+    {
+        zeta_weights(amp.n_occ + a, i) = amp.eps_occ(i);
+        zeta_weights(i, amp.n_occ + a) = amp.eps_occ(i);
+    }
+
+    Eigen::MatrixXd zeta_ao = build_rhf_reference_weighted_density_ao(amp)
+        + C * zeta_weights.cwiseProduct(corr_relaxed_mo) * C.transpose();
+
+    imat_mo.topRightCorner(amp.n_occ, amp.n_virt) =
+        imat_mo.bottomLeftCorner(amp.n_virt, amp.n_occ).transpose();
+    imat_ao = C * imat_mo * C.transpose();
+
+    const Eigen::MatrixXd occ_projector = amp.C_occ * amp.C_occ.transpose();
+    const Eigen::MatrixXd dm1_corr_relaxed_ao = P_ao - calculator._info._scf.alpha.density;
+    const Eigen::MatrixXd vhf_s1occ =
+        occ_projector
+        * build_veff_from_density(
+            calculator,
+            shell_pairs,
+            dm1_corr_relaxed_ao + dm1_corr_relaxed_ao.transpose())
+        * occ_projector;
+
+    RMP2GradientIntermediates out;
+    out.P_mo = P_mo;
+    out.P_ao = P_ao;
+    out.W_ao = 0.5 * (zeta_ao + zeta_ao.transpose() - imat_ao - imat_ao.transpose()) + vhf_s1occ;
+    out.P_total_ao = P_ao;
+    out.P_gamma_ao = calculator._info._scf.alpha.density + 2.0 * dm1_corr_relaxed_ao;
+    out.im1_ao = std::move(imat_ao);
+    out.zeta_ao = std::move(zeta_ao);
+    out.vhf_s1occ_ao = std::move(vhf_s1occ);
+    out.Gamma_pair_ao = pair_dm2_ao;
+    out.pair_dm2_ao = pair_dm2_ao;
+    return out;
 }
 
 } // namespace HartreeFock::Correlation

--- a/src/post_hf/mp2_gradient.h
+++ b/src/post_hf/mp2_gradient.h
@@ -40,6 +40,20 @@ namespace HartreeFock::Correlation
         Eigen::MatrixXd P_ao;  // full AO-space density
     };
 
+    struct RMP2GradientIntermediates
+    {
+        Eigen::MatrixXd P_mo;            // HF + correlated first-order density in MO basis
+        Eigen::MatrixXd P_ao;            // HF + correlated first-order density in AO basis
+        Eigen::MatrixXd W_ao;            // correlated energy-weighted AO density for Pulay terms
+        Eigen::MatrixXd P_total_ao;      // HF + correlated first-order density
+        Eigen::MatrixXd P_gamma_ao;      // HF + 2 * correlated density
+        Eigen::MatrixXd im1_ao;          // AO-space Imat overlap term
+        Eigen::MatrixXd zeta_ao;         // AO-space energy-weighted/Lagrangian term
+        Eigen::MatrixXd vhf_s1occ_ao;    // occupied-projected correlated veff term
+        std::vector<double> Gamma_pair_ao; // explicit MP2 pair-density correction
+        std::vector<double> pair_dm2_ao; // explicit MP2 pair-density correction
+    };
+
     std::expected<RMP2AmplitudeData, std::string> build_rmp2_amplitudes(
         HartreeFock::Calculator& calculator,
         const std::vector<HartreeFock::ShellPair>& shell_pairs);
@@ -53,6 +67,19 @@ namespace HartreeFock::Correlation
     // Build the AO-space unrelaxed density contribution:
     //   P^(2)_AO = C_occ P_occ C_occ^T + C_virt P_virt C_virt^T
     std::expected<Eigen::MatrixXd, std::string> build_rmp2_unrelaxed_density_ao(
+        HartreeFock::Calculator& calculator,
+        const std::vector<HartreeFock::ShellPair>& shell_pairs);
+
+    // Build the explicit MP2 pair-density correction in MO chemists' notation,
+    // dm2[p,q,r,s]. This contains only the ovov/vovo MP2 amplitude term and
+    // excludes the disconnected 1PDM and RHF reference pieces.
+    std::expected<std::vector<double>, std::string> build_rmp2_unrelaxed_2pdm_mo(
+        HartreeFock::Calculator& calculator,
+        const std::vector<HartreeFock::ShellPair>& shell_pairs);
+
+    // Transform the explicit MP2 pair-density correction to the AO basis in
+    // chemists' notation.
+    std::expected<std::vector<double>, std::string> build_rmp2_unrelaxed_2pdm_ao(
         HartreeFock::Calculator& calculator,
         const std::vector<HartreeFock::ShellPair>& shell_pairs);
 
@@ -74,6 +101,13 @@ namespace HartreeFock::Correlation
     // reference occupations, the MP2 unrelaxed oo/vv corrections, and the
     // occupied-virtual Z-vector response block.
     std::expected<RMP2RelaxedDensity, std::string> build_rmp2_relaxed_density(
+        HartreeFock::Calculator& calculator,
+        const std::vector<HartreeFock::ShellPair>& shell_pairs);
+
+    // Build the analytic-gradient intermediates required by the RMP2 gradient:
+    // the first-order densities used in the one- and two-electron terms, the
+    // correlated overlap/Lagrangian objects, and the explicit pair density.
+    std::expected<RMP2GradientIntermediates, std::string> build_rmp2_gradient_intermediates(
         HartreeFock::Calculator& calculator,
         const std::vector<HartreeFock::ShellPair>& shell_pairs);
 }

--- a/tests/regression_cases.json
+++ b/tests/regression_cases.json
@@ -114,7 +114,7 @@
       "tags": ["extended"],
       "expected_exit_code": 0,
       "contains": [
-        "Using central-difference RMP2 total-energy gradient",
+        "Using analytic RMP2 gradient (relaxed density + pair density + Z-vector)",
         "Nuclear Gradient (Ha/Bohr) :"
       ],
       "checks": [


### PR DESCRIPTION
Replace the old semi-numerical/placeholder RMP2 gradient path with an analytic response implementation built from MP2 amplitudes, explicit pair density, and RHF CPHF response. The new code constructs relaxed 1PDM intermediates, contracts the MP2 pair density into an Imat-like response source, solves the occupied-virtual response equation, and feeds the resulting correlated density and energy-weighted AO matrix into the existing closed-shell gradient contraction.

This also updates the driver and geometry optimizer to call the analytic RMP2 gradient interface directly, logs RMP2 natural occupancies when available, and refreshes the regression expectation for the analytic gradient banner. Local validation preserved the reference MP2 total energy for inputs/val_h2.hfinp and improved the H2 analytic gradient from the earlier undercounted implementation to 0.02900507 Ha/Bohr on tests/inputs/h2_rmp2_gradient.hfinp.