### PR TITLE
Fix Rys quadrature roots and mixed-exponent recurrence

### DIFF
--- a/src/integrals/rys.cpp
+++ b/src/integrals/rys.cpp
@@ -214,6 +214,8 @@ double HartreeFock::RysQuad::_rys_eri_primitive(
     const double delta    = zeta + eta;
     const double inv_delta = 1.0 / delta;
     const double rho      = zeta * eta * inv_delta;
+    const double rho_over_zeta = rho * ppAB.inv_zeta;
+    const double rho_over_eta  = rho * ppCD.inv_zeta;
 
     // Gaussian product centers P and Q
     const double Px = ppAB.center[0], Py = ppAB.center[1], Pz = ppAB.center[2];
@@ -266,9 +268,9 @@ double HartreeFock::RysQuad::_rys_eri_primitive(
         const double wr = w[r];
 
         // Root-dependent scalars (same for all axes)
-        const double B00 = u * inv_delta * 0.5;
-        const double B10 = 0.5 * ppAB.inv_zeta - B00;
-        const double B01 = 0.5 * ppCD.inv_zeta - B00;
+        const double B00 = 0.5 * inv_delta * u;
+        const double B10 = 0.5 * ppAB.inv_zeta * (1.0 - rho_over_zeta * u);
+        const double B01 = 0.5 * ppCD.inv_zeta * (1.0 - rho_over_eta * u);
 
         // 1D VRR tables for each Cartesian component
         double Ix[VRR_DIM][VRR_DIM];
@@ -392,9 +394,10 @@ std::vector<double> HartreeFock::RysQuad::_compute_2e(
 
             const int lCx = spCD.A._cartesian[0], lCy = spCD.A._cartesian[1], lCz = spCD.A._cartesian[2];
             const int lDx = spCD.B._cartesian[0], lDy = spCD.B._cartesian[1], lDz = spCD.B._cartesian[2];
-            const double val = _auto_contracted_eri(spAB, spCD,
-                                                    lAx, lAy, lAz, lBx, lBy, lBz,
-                                                    lCx, lCy, lCz, lDx, lDy, lDz);
+            const double val = HartreeFock::RysQuad::_rys_contracted_eri(
+                spAB, spCD,
+                lAx, lAy, lAz, lBx, lBy, lBz,
+                lCx, lCy, lCz, lDx, lDy, lDz);
 
             eri[i*nb3 + j*nb2 + k*nb + l] = val;
             eri[j*nb3 + i*nb2 + k*nb + l] = val;

--- a/src/integrals/rys_roots.cpp
+++ b/src/integrals/rys_roots.cpp
@@ -7,14 +7,11 @@
 
 #include <Eigen/Eigenvalues>
 
-// ─── Gauss-Legendre roots/weights on [0,1] for t^2 variable ─────────────────
+// ─── Numerical fallback nodes/weights on [0,1] ───────────────────────────────
 //
-// Used as the T→0 limit: weight exp(-T*t^2) → 1, Rys → Gauss-Legendre on [0,1].
-// gl_roots[n-1][r] = r-th GL root (t^2) for n-point rule, r = 0..n-1.
-// gl_weights[n-1][r] = corresponding weight.
-//
-// Generated from standard n-point GL on [-1,1]: x_r → t_r^2 = (x_r+1)/2,
-// w_r^GL → w_r = w_r^GL / 2.
+// These tables are retained only as a last-resort safety net if the Jacobi
+// build fails. The normal small-T path goes through exact moments in
+// _boys_moment() and should not use these values.
 
 static const double gl_roots[HartreeFock::Rys::RYS_MAX_ROOTS]
                              [HartreeFock::Rys::RYS_MAX_ROOTS] = {
@@ -91,6 +88,26 @@ static long double _boys_moment(int m, long double T) noexcept
 {
     if (T < static_cast<long double>(HartreeFock::Rys::RYS_T_ZERO))
         return 1.0L / static_cast<long double>(2 * m + 1);
+
+    // The upward Boys recursion loses many digits for small-but-nonzero T and
+    // can drive the moment sequence negative enough to break the Jacobi build.
+    // Use the convergent power series there instead:
+    //   F_m(T) = sum_{n>=0} (-T)^n / (n! (2m + 2n + 1)).
+    if (T < 1.0L)
+    {
+        long double sum = 0.0L;
+        long double coeff = 1.0L;
+        for (int n = 0; n < 256; ++n)
+        {
+            const long double term =
+                coeff / static_cast<long double>(2 * m + 2 * n + 1);
+            sum += term;
+            if (std::abs(term) < 1.0e-28L * std::abs(sum))
+                break;
+            coeff *= -T / static_cast<long double>(n + 1);
+        }
+        return sum;
+    }
 
     const long double sqrtT = std::sqrt(T);
     long double F = 0.5L * std::sqrt(static_cast<long double>(M_PI) / T) * std::erfl(sqrtT);
@@ -209,15 +226,6 @@ void HartreeFock::Rys::rys_roots_weights(int n, double T,
     // n=1: always use exact closed form.
     if (n == 1) {
         HartreeFock::Rys::rys_1pt(T, roots[0], weights[0]);
-        return;
-    }
-
-    // T→0: use Gauss-Legendre limit.
-    if (T < RYS_T_ZERO) {
-        for (int r = 0; r < n; ++r) {
-            roots  [r] = gl_roots  [n - 1][r];
-            weights[r] = gl_weights[n - 1][r];
-        }
         return;
     }
 

--- a/src/integrals/rys_roots.h
+++ b/src/integrals/rys_roots.h
@@ -27,7 +27,7 @@ namespace HartreeFock
     inline void rys_1pt(double T, double& root, double& weight) noexcept
     {
         if (T < RYS_T_ZERO) {
-            root   = 0.5;
+            root   = 1.0 / 3.0;
             weight = 1.0;
         } else {
             const double sqrtT = std::sqrt(T);

--- a/tests/inputs/ethylene_rhf_ccpvdz_auto.hfinp
+++ b/tests/inputs/ethylene_rhf_ccpvdz_auto.hfinp
@@ -1,0 +1,32 @@
+%begin_control
+    basis       cc-pvdz
+    calculation energy
+    verbosity   normal
+    basis_type  cartesian
+%end_control
+
+%begin_scf
+    scf_type    rhf
+    use_diis    .true.
+    diis_dim    8
+    engine      auto
+    guess       hcore
+    max_cycles  100
+%end_scf
+
+%begin_geom
+    coord_type  cartesian
+    coord_units angstrom
+    use_symm    .false.
+%end_geom
+
+%begin_coords
+6
+0   1
+C     -3.438338    0.906062   -0.000000
+C     -3.438338    2.230667   -0.000001
+H     -2.836048    0.343683   -0.709301
+H     -4.040627    0.343684    0.709301
+H     -2.836049    2.793045   -0.709302
+H     -4.040627    2.793046    0.709300
+%end_coords

--- a/tests/inputs/ethylene_rhf_ccpvdz_rys.hfinp
+++ b/tests/inputs/ethylene_rhf_ccpvdz_rys.hfinp
@@ -1,0 +1,32 @@
+%begin_control
+    basis       cc-pvdz
+    calculation energy
+    verbosity   normal
+    basis_type  cartesian
+%end_control
+
+%begin_scf
+    scf_type    rhf
+    use_diis    .true.
+    diis_dim    8
+    engine      rys
+    guess       hcore
+    max_cycles  100
+%end_scf
+
+%begin_geom
+    coord_type  cartesian
+    coord_units angstrom
+    use_symm    .false.
+%end_geom
+
+%begin_coords
+6
+0   1
+C     -3.438338    0.906062   -0.000000
+C     -3.438338    2.230667   -0.000001
+H     -2.836048    0.343683   -0.709301
+H     -4.040627    0.343684    0.709301
+H     -2.836049    2.793045   -0.709302
+H     -4.040627    2.793046    0.709300
+%end_coords

--- a/tests/regression_cases.json
+++ b/tests/regression_cases.json
@@ -96,6 +96,28 @@
       ]
     },
     {
+      "id": "ethylene_rhf_ccpvdz_auto",
+      "input": "tests/inputs/ethylene_rhf_ccpvdz_auto.hfinp",
+      "tags": ["core", "extended"],
+      "expected_exit_code": 0,
+      "contains": ["SCF Converged after", "Total Energy"],
+      "checks": [
+        {"type": "metric_close", "metric": "rhf_total_energy", "expected": -78.0401905750, "atol": 1e-9},
+        {"type": "metric_eq", "metric": "scf_converged_iterations", "expected": 16}
+      ]
+    },
+    {
+      "id": "ethylene_rhf_ccpvdz_rys",
+      "input": "tests/inputs/ethylene_rhf_ccpvdz_rys.hfinp",
+      "tags": ["extended"],
+      "expected_exit_code": 0,
+      "contains": ["SCF Converged after", "Total Energy"],
+      "checks": [
+        {"type": "metric_close", "metric": "rhf_total_energy", "expected": -78.0401905750, "atol": 1e-9},
+        {"type": "metric_eq", "metric": "scf_converged_iterations", "expected": 17}
+      ]
+    },
+    {
       "id": "water_rhf_gradient_smoke",
       "input": "tests/inputs/water_rhf_gradient.hfinp",
       "tags": ["smoke", "extended"],


### PR DESCRIPTION
Fix the root cause behind the bad ethylene cc-pVDZ RHF energies on the Rys and auto integral paths.

Documented failure modes:
- rys_1pt() used the wrong T->0 node for the one-point rule, returning 1/2 instead of the correct 1/3 for the x=t^2 moment sequence.
- rys_roots_weights() short-circuited small-T cases to a legacy Gauss-Legendre table even though the Rys moments are not the uniform [0,1] measure.
- _boys_moment() relied on an upward Boys recursion that became numerically unstable for small-to-moderate T and could poison the Jacobi build.
- _rys_eri_primitive() used B10/B01 = 1/(2 zeta or eta) - u/(2 delta), which drops the rho/zeta and rho/eta factors required to match the OS VRR for mixed-exponent primitive quartets.
- _compute_2e() for the explicit Rys engine called the auto contracted-ERI helper instead of the pure Rys contracted-ERI path.

Applied fixes:
- correct the closed-form one-point T->0 root to 1/3;
- remove the small-T shortcut so root construction continues to use the exact Rys moments;
- use a convergent power-series expansion for Boys moments below T < 1 to stabilize the Jacobi build;
- restore the explicit Rys ERI builder in _compute_2e();
- fix B10/B01 so the primitive Rys recurrence matches the OS algebra for mixed-exponent quartets;
- add RHF-only ethylene cc-pVDZ regression inputs for engine auto and engine rys so the integral path is tested without entering CASSCF.

Validation:
- OMP_NUM_THREADS=1 python3 tests/run_regressions.py --build-dir build --suite all --case ethylene_rhf_ccpvdz_auto --case ethylene_rhf_ccpvdz_rys