### PR TITLE
Implement OS multipole moment reporting and docs refresh

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,7 +285,18 @@ if(BUILD_TESTING)
         ${CMAKE_SOURCE_DIR}/tests/dft_grid_invariants.cpp
     )
 
+    add_executable(planck-multipole-integrals
+        ${CMAKE_SOURCE_DIR}/tests/multipole_integrals.cpp
+        ${INT_SRC}
+        ${LOOKUP_SRC}
+    )
+
     target_include_directories(planck-dft-grid-invariants PRIVATE
+        ${SRC_DIR}
+        ${eigen_SOURCE_DIR}
+    )
+
+    target_include_directories(planck-multipole-integrals PRIVATE
         ${SRC_DIR}
         ${eigen_SOURCE_DIR}
     )
@@ -296,9 +307,25 @@ if(BUILD_TESTING)
         CXX_EXTENSIONS OFF
     )
 
+    set_target_properties(planck-multipole-integrals PROPERTIES
+        CXX_STANDARD 23
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF
+    )
+
+    if(USE_OPENMP AND OpenMP_CXX_FOUND)
+        target_link_libraries(planck-multipole-integrals OpenMP::OpenMP_CXX)
+        target_compile_definitions(planck-multipole-integrals PRIVATE USE_OPENMP)
+    endif()
+
     add_test(
         NAME planck-dft-grid-invariants
         COMMAND planck-dft-grid-invariants
+    )
+
+    add_test(
+        NAME planck-multipole-integrals
+        COMMAND planck-multipole-integrals
     )
 endif()
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -55,14 +55,14 @@ Run it:
 Expected output (abbreviated):
 
 ```
-[INF]  SCF Mode :          Conventional
-[INF]  2e Integrals :      Building ERI tensor (0.0 MB)
-[INF]  2e Integrals :      ERI tensor ready
+SCF Mode :                    Conventional
+2e Integrals :                Building ERI tensor (0.0 MB)
+2e Integrals :                ERI tensor ready
 
 Iter  Energy              DeltaE         RMS(D)      ...
 1     -73.24098642        73.24098642    ...
 ...
-[INF]  SCF Converged after 18 iterations
+SCF Converged after 18 iterations
 
     MO    Symmetry              Energy (Eh)
      1          A1                  -20.252
@@ -73,10 +73,23 @@ Iter  Energy              DeltaE         RMS(D)      ...
      6          A1                    0.582  <-- LUMO
      7          B2                    0.693
 
-  Total Energy    -74.9659012173    -2039.190    -47012.6
+  Total Energy                        -74.9659012173    -2039.190    -47012.6
+Dipole Moment (origin at 0.000000, 0.000000, 0.000000 bohr)
+Component        Electronic (au)      Nuclear (au)        Total (au)     Debye
+X                       0.000000          0.000000          0.000000  0.000000
+Y                       0.000000          0.000000          0.000000  0.000000
+Z                      -1.23...           1.90...           0.67...   1.71...
+Quadrupole Moment (traceless Cartesian tensor, au)
+Component             Electronic           Nuclear             Total
+XX                     ...
+XY                     ...
+XZ                     ...
+YY                     ...
+YZ                     ...
+ZZ                     ...
 ```
 
-The total energy is printed in Hartree, eV, and kcal/mol.
+The total energy is printed in Hartree, eV, and kcal/mol. After convergence, Planck also prints dipole and quadrupole components automatically from the final AO density matrix. Dipoles are reported in atomic units and Debye; quadrupoles are reported as a traceless Cartesian tensor in atomic units.
 
 ### 3. Open-shell calculation (UHF)
 
@@ -548,15 +561,31 @@ Run with:
 Expected output (abbreviated):
 
 ```
-[INF]  Theory :            Kohn-Sham DFT
-[INF]  Reference :         RKS
-[INF]  DFT Grid :          Normal
-[INF]  Exchange :          PBE
-[INF]  Correlation :       PBE
+Theory :                      Kohn-Sham DFT
+Reference :                   RKS
+DFT Grid :                    Normal
+Exchange :                    PBE
+Correlation :                 PBE
 ...
-[INF]  DFT Energy :        -74.xxxxxxxxxx Eh
-[INF]  Converged :         true
+RKS Converged :               E = -75.xxxxxxxxxx Eh after N iterations
+Dipole Moment (origin at 0.000000, 0.000000, 0.000000 bohr)
+Component        Electronic (au)      Nuclear (au)        Total (au)     Debye
+X                       0.000000          0.000000          0.000000  0.000000
+Y                       0.000000          0.000000          0.000000  0.000000
+Z                      -1.24...           1.90...           0.66...   1.68...
+Quadrupole Moment (traceless Cartesian tensor, au)
+Component             Electronic           Nuclear             Total
+XX                     ...
+XY                     ...
+XZ                     ...
+YY                     ...
+YZ                     ...
+ZZ                     ...
+DFT Energy :                  -75.xxxxxxxxxx Eh
+Converged :                   true
 ```
+
+The same post-SCF multipole analysis is available in `planck-dft`, because the dipole and quadrupole tensors are evaluated from the converged KS density just like in the HF executable.
 
 #### Common functional combinations
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ### Planck
 
 <p align="justify">
-A quantum chemistry program implementing restricted and unrestricted Hartree-Fock SCF and Kohn-Sham DFT with an Obara-Saika integral engine, analytic nuclear gradients, geometry optimization, vibrational frequency analysis, DIIS convergence acceleration, symmetry detection, and binary checkpoint support.
+A quantum chemistry program implementing restricted and unrestricted Hartree-Fock SCF and Kohn-Sham DFT with an Obara-Saika integral engine, dipole and quadrupole moment analysis, analytic nuclear gradients, geometry optimization, vibrational frequency analysis, DIIS convergence acceleration, symmetry detection, and binary checkpoint support.
 </p>
 
 ### Features
@@ -11,6 +11,7 @@ A quantum chemistry program implementing restricted and unrestricted Hartree-Foc
 - **RHF / UHF** — closed-shell and open-shell Hartree-Fock
 - **RKS / UKS (Kohn-Sham DFT)** — closed-shell and open-shell Kohn-Sham SCF via the `planck-dft` executable; numerical integration on a Becke–Treutler-Ahlrichs–Lebedev molecular grid with ORCA-inspired five-region pruning; LDA (Slater/VWN5) and GGA (B88, PBE, PW91 exchange; LYP, P86, PBE, PW91 correlation) exchange-correlation functionals through libxc; four grid presets (Coarse/Normal/Fine/UltraFine); arbitrary libxc functionals via integer ID
 - **Two integral engines** — Obara-Saika (OS) recursive VRR/HRR for low angular momentum; Rys quadrature for high angular momentum; automatic engine selection per shell quartet based on an analytic flop-count model (`engine auto`)
+- **Electric multipole moments** — AO dipole and quadrupole matrices are built with Obara-Saika recursion after SCF convergence; the log prints electronic, nuclear, and total dipole components (`X`, `Y`, `Z`) plus the traceless Cartesian quadrupole tensor components (`XX`, `XY`, `XZ`, `YY`, `YZ`, `ZZ`) for both `hartree-fock` and `planck-dft`
 - **Conventional and Direct SCF** — ERI tensor stored once (conventional) or recomputed per iteration (direct); auto-selection based on system size
 - **DIIS** — Pulay extrapolation with optional automatic subspace restart
 - **Level shifting** — virtual orbital energy raising for open-shell convergence
@@ -457,6 +458,10 @@ H     0.000000   -0.756950    -0.468703
 %end_coords
 ```
 
+<p align="justify">
+After the converged energy table, Planck prints a dipole and quadrupole report automatically. The dipole block includes electronic, nuclear, and total components in atomic units and Debye. The quadrupole block reports the traceless Cartesian tensor in atomic units.
+</p>
+
 ### RKS single point — water, PBE/STO-3G
 
 <p align="justify">
@@ -843,6 +848,8 @@ The program prints a structured log to standard output. Key sections:
 - **MO Energies** — orbital energies in Hartree with HOMO/LUMO labels and irrep labels when symmetry is enabled
 - **⟨S²⟩ / ⟨S⟩** — spin contamination diagnostics (UHF only)
 - **Converged Energy** — total energy in Hartree, eV, and kcal/mol; MP2 correlation and corrected total if post-HF enabled
+- **Dipole Moment** — printed automatically after a converged SCF/KS solution; includes the electronic, nuclear, and total `X`, `Y`, `Z` components in atomic units, plus the total vector norm in atomic units and Debye
+- **Quadrupole Moment** — printed automatically after the dipole block; includes electronic, nuclear, and total components of the traceless Cartesian tensor (`XX`, `XY`, `XZ`, `YY`, `YZ`, `ZZ`) in atomic units
 - **RMP2 Natural Orbitals** — printed after single-point RMP2: occupation numbers (descending) and MO expansion of each natural orbital (coefficients above 1e-2 threshold); helps identify the dominant occupied/virtual MOs contributing to correlation
 - **Nuclear Gradient** — printed when `calculation gradient` or `calculation geomopt`; one row per atom showing ∂E/∂x, ∂E/∂y, ∂E/∂z in Ha/Bohr, followed by max and RMS norms
 - **IC System** — when `opt_coords internal`, logs the count of stretches, bends, and torsions in the redundant GIC set
@@ -866,6 +873,7 @@ For `planck-dft` runs, the log additionally includes:
 - **Integrated Electrons** — electron count from numerical density integration (should match the formal count to 4–5 significant figures on a Normal grid)
 - **XC Energy** — exchange-correlation energy contribution in Hartree
 - **DFT Energy** — total Kohn-Sham energy (T + V_ne + J + E_xc + V_nn) in Hartree
+- **Dipole / Quadrupole Moments** — the same post-SCF multipole report is printed for converged RKS/UKS calculations because the property analysis uses the final KS density matrix
 
 </div>
 

--- a/src/base/tables.h
+++ b/src/base/tables.h
@@ -4,6 +4,7 @@
 // Length conversion factors
 const double BOHR_TO_ANGSTROM = 0.529177210903;
 const double ANGSTROM_TO_BOHR = 1.8897259886;
+const double AU_TO_DEBYE      = 2.541746473;
 
 // Energy conversion factors
 const double HARTREE_TO_EV      = 27.211386245988;

--- a/src/base/types.h
+++ b/src/base/types.h
@@ -688,6 +688,25 @@ namespace HartreeFock
         std::vector<int8_t>   ao_sign;  // phase of the mapped Cartesian AO (+1 / -1)
     };
 
+    struct MultipoleMatrices
+    {
+        std::array<Eigen::MatrixXd, 3> dipole;
+        std::array<Eigen::MatrixXd, 6> quadrupole;
+    };
+
+    struct MultipoleMoments
+    {
+        Eigen::Vector3d origin = Eigen::Vector3d::Zero();
+
+        Eigen::Vector3d electronic_dipole = Eigen::Vector3d::Zero();
+        Eigen::Vector3d nuclear_dipole    = Eigen::Vector3d::Zero();
+        Eigen::Vector3d total_dipole      = Eigen::Vector3d::Zero();
+
+        Eigen::Matrix3d electronic_quadrupole = Eigen::Matrix3d::Zero();
+        Eigen::Matrix3d nuclear_quadrupole    = Eigen::Matrix3d::Zero();
+        Eigen::Matrix3d total_quadrupole      = Eigen::Matrix3d::Zero();
+    };
+
     struct Calculator
     {
         OptionsSCF      _scf;

--- a/src/dft/main.cpp
+++ b/src/dft/main.cpp
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "driver.h"
+#include "integrals/os.h"
 #include "io/io.h"
 #include "io/logging.h"
 
@@ -42,6 +43,28 @@ std::string dft_reference_label(HartreeFock::SCFType scf_type)
     }
 
     return "Unknown";
+}
+
+void log_multipole_report(const HartreeFock::Calculator& calculator)
+{
+    auto shell_pairs = build_shellpairs(calculator._shells);
+    auto moments = HartreeFock::ObaraSaika::_compute_multipole_moments(
+        calculator,
+        shell_pairs,
+        Eigen::Vector3d::Zero());
+
+    if (!moments)
+    {
+        HartreeFock::Logger::logging(
+            HartreeFock::LogLevel::Warning,
+            "Multipole Moments :",
+            "Unavailable: " + moments.error());
+        HartreeFock::Logger::blank();
+        return;
+    }
+
+    HartreeFock::Logger::multipole_moments(*moments);
+    HartreeFock::Logger::blank();
 }
 
 } // namespace
@@ -107,6 +130,9 @@ int main(int argc, const char* argv[])
             result.error());
         return EXIT_FAILURE;
     }
+
+    if (result->converged)
+        log_multipole_report(calculator);
 
     HartreeFock::Logger::logging(
         HartreeFock::LogLevel::Info,

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -43,6 +43,29 @@ static std::string format_time(SystemClock::time_point tp)
     return os.str();
 }
 
+static void log_multipole_report(
+    const HartreeFock::Calculator& calculator,
+    const std::vector<HartreeFock::ShellPair>& shell_pairs)
+{
+    auto moments = HartreeFock::ObaraSaika::_compute_multipole_moments(
+        calculator,
+        shell_pairs,
+        Eigen::Vector3d::Zero());
+
+    if (!moments)
+    {
+        HartreeFock::Logger::logging(
+            HartreeFock::LogLevel::Warning,
+            "Multipole Moments :",
+            "Unavailable: " + moments.error());
+        HartreeFock::Logger::blank();
+        return;
+    }
+
+    HartreeFock::Logger::multipole_moments(*moments);
+    HartreeFock::Logger::blank();
+}
+
 int main(int argc, const char* argv[])
 {
     const auto program_start    = SystemClock::now();   // Start time
@@ -535,6 +558,7 @@ int main(int argc, const char* argv[])
     }
 
     HartreeFock::Logger::converged_energy(calculator._total_energy, calculator._nuclear_repulsion);
+    log_multipole_report(calculator, shellpairs);
 
     // ── Post-HF correlation ───────────────────────────────────────────────────
     if (calculator._info._is_converged)
@@ -951,6 +975,7 @@ int main(int argc, const char* argv[])
                 }
 
                 HartreeFock::Logger::converged_energy(calculator._total_energy, calculator._nuclear_repulsion);
+                log_multipole_report(calculator, sp_sym);
                 HartreeFock::Logger::blank();
 
                 // ── Save checkpoint with optimized geometry ───────────────────

--- a/src/integrals/os.cpp
+++ b/src/integrals/os.cpp
@@ -187,6 +187,64 @@ inline double HartreeFock::ObaraSaika::_os_1d(const double gamma, const double d
     return S[lA][lB];
 }
 
+static std::array<double, 3> _os_1d_moments(
+    const double gamma,
+    const double distPA,
+    const double distPB,
+    const double distPC,
+    const int lA,
+    const int lB)
+{
+    double M[MAX_L + 1][MAX_L + 1][3] = {};
+
+    M[0][0][0] = 1.0;
+    M[0][0][1] = distPC;
+    M[0][0][2] = distPC * distPC + gamma;
+
+    for (int i = 1; i <= lA; ++i)
+    {
+        for (int n = 0; n <= 2; ++n)
+        {
+            M[i][0][n] = distPA * M[i - 1][0][n];
+            if (i > 1)
+                M[i][0][n] += (i - 1) * gamma * M[i - 2][0][n];
+            if (n > 0)
+                M[i][0][n] += n * gamma * M[i - 1][0][n - 1];
+        }
+    }
+
+    for (int j = 1; j <= lB; ++j)
+    {
+        for (int n = 0; n <= 2; ++n)
+        {
+            M[0][j][n] = distPB * M[0][j - 1][n];
+            if (j > 1)
+                M[0][j][n] += (j - 1) * gamma * M[0][j - 2][n];
+            if (n > 0)
+                M[0][j][n] += n * gamma * M[0][j - 1][n - 1];
+        }
+    }
+
+    for (int i = 1; i <= lA; ++i)
+    {
+        for (int j = 1; j <= lB; ++j)
+        {
+            for (int n = 0; n <= 2; ++n)
+            {
+                M[i][j][n] = distPA * M[i - 1][j][n] +
+                             j * gamma * M[i - 1][j - 1][n];
+
+                if (i > 1)
+                    M[i][j][n] += (i - 1) * gamma * M[i - 2][j][n];
+                if (n > 0)
+                    M[i][j][n] += n * gamma * M[i - 1][j][n - 1];
+            }
+        }
+    }
+
+    return {M[lA][lB][0], M[lA][lB][1], M[lA][lB][2]};
+}
+
 std::pair<Eigen::MatrixXd, Eigen::MatrixXd> HartreeFock::ObaraSaika::_compute_1e(
     const std::vector<HartreeFock::ShellPair> &shell_pairs,
     const std::size_t nbasis,
@@ -237,6 +295,177 @@ std::pair<Eigen::MatrixXd, Eigen::MatrixXd> HartreeFock::ObaraSaika::_compute_1e
     }
 
     return {overlap, kinetic};
+}
+
+HartreeFock::MultipoleMatrices HartreeFock::ObaraSaika::_compute_multipole_matrices(
+    const std::vector<HartreeFock::ShellPair>& shell_pairs,
+    std::size_t nbasis,
+    const Eigen::Vector3d& origin)
+{
+    HartreeFock::MultipoleMatrices matrices{};
+    for (auto& component : matrices.dipole)
+        component = Eigen::MatrixXd::Zero(nbasis, nbasis);
+    for (auto& component : matrices.quadrupole)
+        component = Eigen::MatrixXd::Zero(nbasis, nbasis);
+
+    const std::size_t npairs = shell_pairs.size();
+
+#pragma omp parallel for schedule(dynamic)
+    for (std::size_t p = 0; p < npairs; ++p)
+    {
+        const auto& sp = shell_pairs[p];
+        const std::size_t ii = sp.A._index;
+        const std::size_t jj = sp.B._index;
+
+        const auto& cartA = sp.A._cartesian;
+        const auto& cartB = sp.B._cartesian;
+
+        double dipole_x = 0.0;
+        double dipole_y = 0.0;
+        double dipole_z = 0.0;
+        double quad_xx = 0.0;
+        double quad_xy = 0.0;
+        double quad_xz = 0.0;
+        double quad_yy = 0.0;
+        double quad_yz = 0.0;
+        double quad_zz = 0.0;
+
+        for (const auto& pp : sp.primitive_pairs)
+        {
+            const double gamma = 0.5 * pp.inv_zeta;
+            const double scale = pp.prefactor * pp.coeff_product;
+
+            const auto mx = _os_1d_moments(
+                gamma,
+                pp.pA[0],
+                pp.pB[0],
+                pp.center[0] - origin[0],
+                cartA[0],
+                cartB[0]);
+            const auto my = _os_1d_moments(
+                gamma,
+                pp.pA[1],
+                pp.pB[1],
+                pp.center[1] - origin[1],
+                cartA[1],
+                cartB[1]);
+            const auto mz = _os_1d_moments(
+                gamma,
+                pp.pA[2],
+                pp.pB[2],
+                pp.center[2] - origin[2],
+                cartA[2],
+                cartB[2]);
+
+            dipole_x += mx[1] * my[0] * mz[0] * scale;
+            dipole_y += mx[0] * my[1] * mz[0] * scale;
+            dipole_z += mx[0] * my[0] * mz[1] * scale;
+
+            quad_xx += mx[2] * my[0] * mz[0] * scale;
+            quad_xy += mx[1] * my[1] * mz[0] * scale;
+            quad_xz += mx[1] * my[0] * mz[1] * scale;
+            quad_yy += mx[0] * my[2] * mz[0] * scale;
+            quad_yz += mx[0] * my[1] * mz[1] * scale;
+            quad_zz += mx[0] * my[0] * mz[2] * scale;
+        }
+
+        matrices.dipole[0](ii, jj) = dipole_x;
+        matrices.dipole[1](ii, jj) = dipole_y;
+        matrices.dipole[2](ii, jj) = dipole_z;
+        matrices.dipole[0](jj, ii) = dipole_x;
+        matrices.dipole[1](jj, ii) = dipole_y;
+        matrices.dipole[2](jj, ii) = dipole_z;
+
+        matrices.quadrupole[0](ii, jj) = quad_xx;
+        matrices.quadrupole[1](ii, jj) = quad_xy;
+        matrices.quadrupole[2](ii, jj) = quad_xz;
+        matrices.quadrupole[3](ii, jj) = quad_yy;
+        matrices.quadrupole[4](ii, jj) = quad_yz;
+        matrices.quadrupole[5](ii, jj) = quad_zz;
+        matrices.quadrupole[0](jj, ii) = quad_xx;
+        matrices.quadrupole[1](jj, ii) = quad_xy;
+        matrices.quadrupole[2](jj, ii) = quad_xz;
+        matrices.quadrupole[3](jj, ii) = quad_yy;
+        matrices.quadrupole[4](jj, ii) = quad_yz;
+        matrices.quadrupole[5](jj, ii) = quad_zz;
+    }
+
+    return matrices;
+}
+
+std::expected<HartreeFock::MultipoleMoments, std::string>
+HartreeFock::ObaraSaika::_compute_multipole_moments(
+    const HartreeFock::Calculator& calculator,
+    const std::vector<HartreeFock::ShellPair>& shell_pairs,
+    const Eigen::Vector3d& origin)
+{
+    const std::size_t nbasis = calculator._shells.nbasis();
+    const Eigen::Index nbasis_idx = static_cast<Eigen::Index>(nbasis);
+    const auto& alpha_density = calculator._info._scf.alpha.density;
+
+    if (alpha_density.rows() != nbasis_idx || alpha_density.cols() != nbasis_idx)
+        return std::unexpected("alpha density matrix is not initialized for multipole analysis");
+
+    Eigen::MatrixXd total_density = alpha_density;
+    if (calculator._info._scf.is_uhf)
+    {
+        const auto& beta_density = calculator._info._scf.beta.density;
+        if (beta_density.rows() != nbasis_idx || beta_density.cols() != nbasis_idx)
+            return std::unexpected("beta density matrix is not initialized for multipole analysis");
+        total_density += beta_density;
+    }
+
+    const HartreeFock::MultipoleMatrices matrices =
+        _compute_multipole_matrices(shell_pairs, nbasis, origin);
+
+    HartreeFock::MultipoleMoments moments{};
+    moments.origin = origin;
+
+    for (int axis = 0; axis < 3; ++axis)
+        moments.electronic_dipole[axis] =
+            -(total_density.array() * matrices.dipole[axis].array()).sum();
+
+    for (std::size_t atom = 0; atom < calculator._molecule.natoms; ++atom)
+    {
+        const double charge = static_cast<double>(calculator._molecule.atomic_numbers[atom]);
+        const Eigen::Vector3d position =
+            calculator._molecule._standard.row(static_cast<Eigen::Index>(atom)).transpose() - origin;
+        moments.nuclear_dipole += charge * position;
+    }
+    moments.total_dipole = moments.nuclear_dipole + moments.electronic_dipole;
+
+    Eigen::Matrix3d raw_electronic = Eigen::Matrix3d::Zero();
+    raw_electronic(0, 0) = -(total_density.array() * matrices.quadrupole[0].array()).sum();
+    raw_electronic(0, 1) = -(total_density.array() * matrices.quadrupole[1].array()).sum();
+    raw_electronic(0, 2) = -(total_density.array() * matrices.quadrupole[2].array()).sum();
+    raw_electronic(1, 1) = -(total_density.array() * matrices.quadrupole[3].array()).sum();
+    raw_electronic(1, 2) = -(total_density.array() * matrices.quadrupole[4].array()).sum();
+    raw_electronic(2, 2) = -(total_density.array() * matrices.quadrupole[5].array()).sum();
+    raw_electronic(1, 0) = raw_electronic(0, 1);
+    raw_electronic(2, 0) = raw_electronic(0, 2);
+    raw_electronic(2, 1) = raw_electronic(1, 2);
+
+    Eigen::Matrix3d raw_nuclear = Eigen::Matrix3d::Zero();
+    for (std::size_t atom = 0; atom < calculator._molecule.natoms; ++atom)
+    {
+        const double charge = static_cast<double>(calculator._molecule.atomic_numbers[atom]);
+        const Eigen::Vector3d position =
+            calculator._molecule._standard.row(static_cast<Eigen::Index>(atom)).transpose() - origin;
+        raw_nuclear += charge * (position * position.transpose());
+    }
+
+    auto to_traceless = [](const Eigen::Matrix3d& raw) {
+        Eigen::Matrix3d quadrupole = 3.0 * raw;
+        quadrupole.diagonal().array() -= raw.trace();
+        return quadrupole;
+    };
+
+    moments.electronic_quadrupole = to_traceless(raw_electronic);
+    moments.nuclear_quadrupole = to_traceless(raw_nuclear);
+    moments.total_quadrupole =
+        moments.electronic_quadrupole + moments.nuclear_quadrupole;
+
+    return moments;
 }
 
 std::tuple<double, double> HartreeFock::ObaraSaika::_compute_3d_overlap_kinetic(const ShellPair &shell_pair)

--- a/src/integrals/os.h
+++ b/src/integrals/os.h
@@ -20,6 +20,14 @@ namespace HartreeFock
             const std::vector<HartreeFock::ShellPair> &shell_pairs,
             const std::size_t nbasis,
             const std::vector<HartreeFock::SignedAOSymOp>* sym_ops = nullptr);
+        HartreeFock::MultipoleMatrices _compute_multipole_matrices(
+            const std::vector<HartreeFock::ShellPair>& shell_pairs,
+            std::size_t nbasis,
+            const Eigen::Vector3d& origin = Eigen::Vector3d::Zero());
+        std::expected<HartreeFock::MultipoleMoments, std::string> _compute_multipole_moments(
+            const HartreeFock::Calculator& calculator,
+            const std::vector<HartreeFock::ShellPair>& shell_pairs,
+            const Eigen::Vector3d& origin = Eigen::Vector3d::Zero());
         Eigen::MatrixXd _compute_nuclear_attraction(
             const std::vector<HartreeFock::ShellPair> &shell_pairs,
             const std::size_t nbasis,

--- a/src/integrals/shellpair.cpp
+++ b/src/integrals/shellpair.cpp
@@ -4,7 +4,7 @@
 
 #include "shellpair.h"
 
-std::vector <HartreeFock::ShellPair> build_shellpairs(HartreeFock::Basis &basis)
+std::vector <HartreeFock::ShellPair> build_shellpairs(const HartreeFock::Basis &basis)
 {
     std::size_t n_shells = basis.nbasis();                  // Number of contracted gaussians
     std::vector <HartreeFock::ShellPair> shell_pairs{};     // Shellpair container

--- a/src/integrals/shellpair.h
+++ b/src/integrals/shellpair.h
@@ -3,7 +3,7 @@
 
 #include "base/types.h"
 
-std::vector <HartreeFock::ShellPair> build_shellpairs(HartreeFock::Basis &basis);
+std::vector <HartreeFock::ShellPair> build_shellpairs(const HartreeFock::Basis &basis);
 
 // Compute the shell pair index for (i,j) given total number of shells
 inline std::size_t pair_index(std::size_t i, std::size_t j)

--- a/src/io/logging.h
+++ b/src/io/logging.h
@@ -4,7 +4,6 @@
 #include <string>
 #include <iostream>
 #include <iomanip>
-#include <chrono>
 #include <mutex>
 
 #include "base/types.h"
@@ -25,12 +24,6 @@ namespace HartreeFock
     {
         inline std::mutex log_mutex;
         inline thread_local int silence_depth = 0;
-
-        constexpr const char *info_prefix   = "[Planck][INF]    ";
-        constexpr const char *error_prefix  = "[Planck][ERR]    ";
-        constexpr const char *matrix_prefix = "[Planck][MAT]    ";
-        constexpr const char *warn_prefix   = "[Planck][WARN]   ";
-//        constexpr const char *scf_prefix    = "[Planck][SCF]    ";
 
         inline bool is_silenced() noexcept
         {
@@ -62,37 +55,10 @@ namespace HartreeFock
 
             std::lock_guard<std::mutex> lock(log_mutex);
 
-            // Prefix selection
-            const char* prefix = nullptr;
-            switch(level)
-            {
-                case Info:      prefix = info_prefix;   break;
-                case Warning:   prefix = warn_prefix;   break;
-                case Error:     prefix = error_prefix;  break;
-                case Matrix:    prefix = matrix_prefix; break;
-//                case Cycle:       prefix = scf_prefix;    break;
-            }
-            
-            // Timestamp
-            auto now = std::chrono::system_clock::now();
-            std::time_t now_time = std::chrono::system_clock::to_time_t(now);
-
-            std::tm local_tm{};
-        #ifdef _WIN32
-            localtime_s(&local_tm, &now_time);
-        #else
-            local_tm = *std::localtime(&now_time);
-        #endif
-
             std::ostream& out_stream =
                 (level == Info || level == Error) ? std::cout : std::cerr;
 
-            // Print header
-            out_stream << "["
-                       << std::put_time(&local_tm, "%Y-%m-%d %H:%M:%S")
-                       << "] "
-                       << std::setw(20) << std::left << prefix
-                       << std::setw(30) << std::left << label;
+            out_stream << std::setw(30) << std::left << label;
 
             // Variadic message printing
             if constexpr (sizeof...(Args) > 0)
@@ -341,6 +307,78 @@ namespace HartreeFock
                     std::cout << " <all coefficients below threshold>";
                 std::cout << "\n";
             }
+        }
+
+        inline void multipole_moments(const HartreeFock::MultipoleMoments& moments)
+        {
+            if (is_silenced())
+                return;
+
+            std::lock_guard<std::mutex> lock(log_mutex);
+
+            const Eigen::Vector3d total_dipole_debye = moments.total_dipole * AU_TO_DEBYE;
+
+            std::cout << "Dipole Moment (origin at "
+                      << std::fixed << std::setprecision(6)
+                      << moments.origin[0] << ", "
+                      << moments.origin[1] << ", "
+                      << moments.origin[2] << " bohr)\n";
+            std::cout << std::string(78, '-') << "\n"
+                      << std::setw(12) << std::left  << "Component"
+                      << std::setw(20) << std::right << "Electronic (au)"
+                      << std::setw(18) << std::right << "Nuclear (au)"
+                      << std::setw(18) << std::right << "Total (au)"
+                      << std::setw(10) << std::right << "Debye"
+                      << "\n"
+                      << std::string(78, '-') << "\n";
+
+            const std::array<const char*, 3> axes = {"X", "Y", "Z"};
+            for (int axis = 0; axis < 3; ++axis)
+            {
+                std::cout << std::setw(12) << std::left  << axes[axis]
+                          << std::setw(20) << std::right << moments.electronic_dipole[axis]
+                          << std::setw(18) << std::right << moments.nuclear_dipole[axis]
+                          << std::setw(18) << std::right << moments.total_dipole[axis]
+                          << std::setw(10) << std::right << total_dipole_debye[axis]
+                          << "\n";
+            }
+
+            std::cout << std::string(78, '-') << "\n"
+                      << std::setw(12) << std::left  << "|mu|"
+                      << std::setw(20) << std::right << moments.electronic_dipole.norm()
+                      << std::setw(18) << std::right << moments.nuclear_dipole.norm()
+                      << std::setw(18) << std::right << moments.total_dipole.norm()
+                      << std::setw(10) << std::right << total_dipole_debye.norm()
+                      << "\n"
+                      << std::string(78, '-') << "\n";
+
+            std::cout << "Quadrupole Moment (traceless Cartesian tensor, au)\n";
+            std::cout << std::string(78, '-') << "\n"
+                      << std::setw(12) << std::left  << "Component"
+                      << std::setw(20) << std::right << "Electronic"
+                      << std::setw(18) << std::right << "Nuclear"
+                      << std::setw(18) << std::right << "Total"
+                      << "\n"
+                      << std::string(78, '-') << "\n";
+
+            const std::array<std::pair<const char*, std::pair<int, int>>, 6> quad_components = {{
+                {"XX", {0, 0}},
+                {"XY", {0, 1}},
+                {"XZ", {0, 2}},
+                {"YY", {1, 1}},
+                {"YZ", {1, 2}},
+                {"ZZ", {2, 2}}
+            }};
+
+            for (const auto& [label, idx] : quad_components)
+            {
+                std::cout << std::setw(12) << std::left  << label
+                          << std::setw(20) << std::right << moments.electronic_quadrupole(idx.first, idx.second)
+                          << std::setw(18) << std::right << moments.nuclear_quadrupole(idx.first, idx.second)
+                          << std::setw(18) << std::right << moments.total_quadrupole(idx.first, idx.second)
+                          << "\n";
+            }
+            std::cout << std::string(78, '-') << "\n";
         }
 
         inline void blank()

--- a/tests/multipole_integrals.cpp
+++ b/tests/multipole_integrals.cpp
@@ -1,0 +1,105 @@
+#include <cmath>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+
+#include "base/types.h"
+#include "integrals/os.h"
+#include "integrals/shellpair.h"
+
+namespace
+{
+
+void require_near(double actual, double expected, double tol, const std::string& message)
+{
+    if (std::abs(actual - expected) > tol)
+    {
+        std::ostringstream oss;
+        oss << message << ": expected " << expected << ", got " << actual
+            << " (tol " << tol << ")";
+        throw std::runtime_error(oss.str());
+    }
+}
+
+double primitive_s_normalization(double exponent)
+{
+    return std::pow(2.0 * exponent / M_PI, 0.75);
+}
+
+HartreeFock::Basis make_single_s_basis(const Eigen::Vector3d& center, double exponent)
+{
+    HartreeFock::Basis basis;
+    basis._shells.emplace_back();
+
+    auto& shell = basis._shells.back();
+    shell._center = center;
+    shell._shell = HartreeFock::ShellType::S;
+    shell._atom_index = 0;
+    shell._primitives = Eigen::VectorXd::Constant(1, exponent);
+    shell._coefficients = Eigen::VectorXd::Ones(1);
+    shell._normalizations = Eigen::VectorXd::Constant(1, primitive_s_normalization(exponent));
+
+    basis._basis_functions.emplace_back(&shell, Eigen::Vector3i::Zero());
+    basis._basis_functions.back()._index = 0;
+    basis._basis_functions.back()._component_norm = 1.0;
+
+    return basis;
+}
+
+void test_centered_s_orbital()
+{
+    const auto basis = make_single_s_basis(Eigen::Vector3d::Zero(), 1.0);
+    const auto shell_pairs = build_shellpairs(basis);
+    const auto matrices = HartreeFock::ObaraSaika::_compute_multipole_matrices(
+        shell_pairs,
+        basis.nbasis(),
+        Eigen::Vector3d::Zero());
+
+    require_near(matrices.dipole[0](0, 0), 0.0, 1e-12, "Centered s orbital should have zero x dipole");
+    require_near(matrices.dipole[1](0, 0), 0.0, 1e-12, "Centered s orbital should have zero y dipole");
+    require_near(matrices.dipole[2](0, 0), 0.0, 1e-12, "Centered s orbital should have zero z dipole");
+
+    require_near(matrices.quadrupole[0](0, 0), 0.25, 1e-12, "Centered s orbital x^2 moment mismatch");
+    require_near(matrices.quadrupole[3](0, 0), 0.25, 1e-12, "Centered s orbital y^2 moment mismatch");
+    require_near(matrices.quadrupole[5](0, 0), 0.25, 1e-12, "Centered s orbital z^2 moment mismatch");
+    require_near(matrices.quadrupole[1](0, 0), 0.0, 1e-12, "Centered s orbital xy moment mismatch");
+    require_near(matrices.quadrupole[2](0, 0), 0.0, 1e-12, "Centered s orbital xz moment mismatch");
+    require_near(matrices.quadrupole[4](0, 0), 0.0, 1e-12, "Centered s orbital yz moment mismatch");
+}
+
+void test_shifted_s_orbital()
+{
+    const Eigen::Vector3d center(1.0, 0.0, 0.0);
+    const auto basis = make_single_s_basis(center, 1.0);
+    const auto shell_pairs = build_shellpairs(basis);
+    const auto matrices = HartreeFock::ObaraSaika::_compute_multipole_matrices(
+        shell_pairs,
+        basis.nbasis(),
+        Eigen::Vector3d::Zero());
+
+    require_near(matrices.dipole[0](0, 0), 1.0, 1e-12, "Shifted s orbital x dipole mismatch");
+    require_near(matrices.dipole[1](0, 0), 0.0, 1e-12, "Shifted s orbital y dipole should vanish");
+    require_near(matrices.dipole[2](0, 0), 0.0, 1e-12, "Shifted s orbital z dipole should vanish");
+
+    require_near(matrices.quadrupole[0](0, 0), 1.25, 1e-12, "Shifted s orbital x^2 moment mismatch");
+    require_near(matrices.quadrupole[3](0, 0), 0.25, 1e-12, "Shifted s orbital y^2 moment mismatch");
+    require_near(matrices.quadrupole[5](0, 0), 0.25, 1e-12, "Shifted s orbital z^2 moment mismatch");
+}
+
+} // namespace
+
+int main()
+{
+    try
+    {
+        test_centered_s_orbital();
+        test_shifted_s_orbital();
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << e.what() << '\n';
+        return 1;
+    }
+
+    return 0;
+}

--- a/visualizer/parser.py
+++ b/visualizer/parser.py
@@ -4,11 +4,14 @@ parser.py — Planck log file parser.
 Reads a saved stdout log from the hartree-fock binary and returns a
 ParsedRun dataclass containing all visualisable data.
 
-Log line anatomy (INFO level):
-    [YYYY-MM-DD HH:MM:SS] [Planck][INF]       <label:30><message>
-    |←    22 chars      →| |← 20 chars →||←  30 chars →||← rest →|
+Log line anatomy:
+    New format:
+        <label:30><message>
+    Legacy format:
+        [YYYY-MM-DD HH:MM:SS] [Planck][INF]       <label:30><message>
+        |←    22 chars      →| |← 20 chars →||←  30 chars →||← rest →|
 
-SCF iteration rows are raw (no timestamp):
+SCF iteration rows are raw:
     {iter:6}{energy:20.10f}{dE:15}{rmsD:15.3e}{maxD:15.3e}
     {diis:15.3e}{damp:12.3f}{t:12.3f}
 
@@ -127,20 +130,21 @@ class ParsedRun:
 # Compiled regexes
 # ---------------------------------------------------------------------------
 
-# Matches any INFO/WARN log line.
-# Layout after "[Planck][INF]": 7 padding spaces, label (30 chars), message.
+# Matches log lines in either the new bare format or the legacy prefixed one.
 _LOG_RE = re.compile(
-    r'^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\] '
+    r'^(?:'
+    r'\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\] '
     r'\[Planck\]\[(?:INF|WARN|ERR|MAT)\]'
     r'.{7}'     # 7 spaces (setw(20) padding after the 13-char prefix)
+    r')?'
     r'(.{30})'  # label field — always 30 chars (may overflow into message)
     r'(.*)$'    # message (may be empty)
 )
 
-# 110-dash separator (SCF table header/footer); no timestamp.
+# 110-dash separator (SCF table header/footer).
 _DASH110_RE = re.compile(r'^-{110}\s*$')
 
-# SCF iteration row (no timestamp).
+# SCF iteration row.
 _SCF_ITER_RE = re.compile(
     r'^\s*(\d+)'
     r'\s+([-\d.]+)'
@@ -198,7 +202,7 @@ _GRAD_MSG_RE = re.compile(
     r'^\s*([-\d.eE+]+)\s+([-\d.eE+]+)\s+([-\d.eE+]+)\s*$'
 )
 
-# Raw energy table lines (no timestamp).
+# Raw energy table lines.
 _ELECTRONIC_ENERGY_RE = re.compile(r'^\s*Electronic Energy\s+([-+\d.eE]+)')
 _NUCLEAR_REPULSION_RE = re.compile(r'^\s*Nuclear Repulsion\s+([-+\d.eE]+)')
 _TOTAL_ENERGY_RE = re.compile(r'^\s*Total Energy\s+([-+\d.eE]+)')
@@ -239,7 +243,7 @@ class _State:
 # ---------------------------------------------------------------------------
 
 def _parse_log_line(raw: str):
-    """Return (label_stripped, message) for an INFO line, or None."""
+    """Return (label_stripped, message) for a structured log line, or None."""
     m = _LOG_RE.match(raw)
     if not m:
         return None


### PR DESCRIPTION
Add Obara-Saika dipole and quadrupole recurrences for one-electron AO property matrices and assemble molecular electronic, nuclear, and total multipole moments from the converged density.

Print component-wise dipole and traceless Cartesian quadrupole tables for both hartree-fock and planck-dft runs, with dipoles reported in atomic units and Debye.

Add a focused multipole integral regression test plus CMake wiring, update README and QUICKSTART to document the new analysis and output blocks, and include the current visualizer parser update for the simplified log format.