### PR TITLE
fix: address bug report stability issues

### DIFF
--- a/docs/BUG_REPORT.md
+++ b/docs/BUG_REPORT.md
@@ -1,0 +1,245 @@
+# Bug Report — Planck Codebase Review
+
+**Date:** 2026-04-08
+**Reviewer:** Claude Code (automated review)
+**Scope:** Full codebase — integrals, SCF, post-HF, CASSCF, gradients, DFT, I/O
+**Branch:** codex/casscf-active-cache-patch1
+
+---
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| Critical | 2 |
+| Major    | 4 |
+| Minor    | 8 |
+| Nitpick  | 3 |
+
+---
+
+## Critical
+
+### C1 — ~1 GB per-thread VRR/HRR scratch buffers cause OOM on multi-threaded runs
+
+**File:** `src/integrals/os.cpp:546–549`
+
+**Description:**
+`_vrr_buf` is declared as `thread_local double[13][13][13][13][13][13][26]` = 125,497,034 doubles = **1.00 GB per thread**. `_hrr_buf` adds another ~38 MB. With a typical OpenMP thread pool of 4–16 threads, this pre-allocates 4–16+ GB just for ERI scratch space, regardless of the actual angular momenta of the molecules being computed. On most workstations this causes an immediate OOM when `MAX_L >= 4` (i.e., any basis with f-functions).
+
+**Reproduction:** Run any calculation with f-function basis (e.g., 6-311G**) with `OMP_NUM_THREADS=8`.
+
+**Fix:** Replace fixed-size `thread_local` arrays with per-quartet heap allocations sized to the actual angular momenta of the quartet: `(lA + lB + lC + lD + 1)^n`. Alternatively, use a `std::vector` resized at the start of each quartet loop.
+
+---
+
+### C2 — Data race in `write_eri_permutations` under OpenMP
+
+**File:** `src/integrals/os.cpp:1553–1601, 1648–1696, 1870–1917`
+
+**Description:**
+The canonical-representative guard prevents redundant computation of each unique quartet, but the 8-fold permutation expansion in `write_eri_permutations` can write to ERI tensor indices that overlap with another thread's 8-fold expansion of a different canonical quartet. Specifically, quartet `(i,j,k,l)` with `i < k` writes `eri[k,l,i,j]`, which is also the primary write target of quartet `(k,l,i,j)` in another thread. Even if both threads write the same value, concurrent writes to a non-atomic location are **undefined behavior in C++** and will produce incorrect results under TSan or aggressive compiler optimization.
+
+**Fix:** Accumulate per-thread partial ERI tensors and reduce at the end of the parallel region, or protect writes with `#pragma omp atomic` / `#pragma omp critical` for the permutation fill.
+
+---
+
+## Major
+
+### M1 — `_bohr_to_angstrom()` return type mismatch
+
+**File:** `src/base/types.h:840–843`
+
+**Description:**
+`_molecule._standard` is `Eigen::MatrixXd` (natoms × 3). The expression `_molecule._standard * 0.529177210903` produces a `MatrixXd`, but the declared return type is `const Eigen::VectorXd`. Eigen does not implicitly convert a multi-column matrix to a vector; depending on Eigen version this either fails to compile or silently returns only the first column.
+
+**Fix:**
+```cpp
+// Before
+const Eigen::VectorXd _bohr_to_angstrom() const { ... }
+
+// After
+Eigen::MatrixXd _bohr_to_angstrom() const { ... }
+```
+
+---
+
+### M2 — `set_max_cycles_auto` and `get_max_cycles` return inconsistent values
+
+**File:** `src/base/types.h:289–306`
+
+**Description:**
+Two functions independently hardcode the max-cycle tier table and disagree on the value for `nbasis > 250`:
+
+| Function | `nbasis > 250` |
+|----------|---------------|
+| `set_max_cycles_auto` | 100 |
+| `get_max_cycles` | 150 |
+
+This means a calculation that calls `set_max_cycles_auto` and then `get_max_cycles` to check the limit will see a different number than what was actually set.
+
+**Fix:** Unify into a single `max_cycles_for_nbasis(int nbasis)` free function called by both.
+
+---
+
+### M3 — Gradient ERI loop is O(N⁴) with no Schwarz screening
+
+**File:** `src/gradient/gradient.cpp:73–77, 142–170` (RHF); `271–275, 336–364` (UHF)
+
+**Description:**
+The gradient code constructs `all_pairs` as the full `nb × nb` Cartesian product of shell pairs and iterates over `all_pairs × all_pairs` with no:
+- Upper-triangle permutation symmetry exploitation
+- Schwarz pre-screening (`|ij| × |kl| < threshold`)
+
+For `nb = 100` shells this produces ~100M ERI derivative evaluations. The ERI build code in `os.cpp` uses screened upper-triangle iteration reaching ~6M evaluations for the same system — a ~17× difference that grows as O(N²) with system size.
+
+**Fix:** Mirror the screened shell-pair iteration from `os.cpp` in the gradient loop. The gradient permutation symmetry is slightly different (factor of 2 rather than 8) but the screening logic is identical.
+
+---
+
+### M4 — `Molecule::nelectrons` is dead code
+
+**File:** `src/base/types.h:169`
+
+**Description:**
+The field `int nelectrons` is declared on `Molecule` but is never populated by the parser and never read by any downstream code. All electron counts are recomputed inline (e.g., from `charge` and atomic numbers). The field misleads readers into thinking it holds a valid count.
+
+**Fix:** Remove the field, or populate and use it consistently.
+
+---
+
+## Minor
+
+### m1 — Fermion operator utilities duplicated across three CASSCF files
+
+**Files:**
+- `src/post_hf/casscf/rdm.cpp:17–41`
+- `src/post_hf/casscf/response.cpp:39–62`
+- `src/post_hf/casscf/strings.cpp:208–225`
+
+**Description:** `FermionOpResult` and the fermion creation/annihilation operator functions are copy-pasted into three separate anonymous namespaces. Any bug fix or behavioral change must be applied in three places.
+
+**Fix:** Extract to a shared `src/post_hf/casscf/casscf_utils.h` internal header.
+
+---
+
+### m2 — `as_single_column_matrix` / `single_weight` helpers duplicated
+
+**Files:**
+- `src/post_hf/casscf/casscf.cpp:238–250`
+- `src/post_hf/casscf/response.cpp:212–224`
+
+**Description:** Same pattern as m1 — identical helper functions duplicated across files.
+
+**Fix:** Move to the shared CASSCF utilities header (see m1).
+
+---
+
+### m3 — Several functions throw exceptions instead of returning `std::expected`
+
+**Files and lines:**
+
+| File | Line | Function | Exception thrown |
+|------|------|----------|-----------------|
+| `src/gradient/gradient.cpp` | 43 | `build_shell_atom_map` | `std::runtime_error` |
+| `src/gradient/gradient.cpp` | 394 | `compute_rmp2_gradient` | (uncaught throw) |
+| `src/io/io.cpp` | 62 | `toBool` | `std::invalid_argument` |
+| `src/io/io.cpp` | 82, 96 | `parse_irrep_count_list` | `std::invalid_argument` |
+| `src/post_hf/casscf/strings.cpp` | 427 | `reorder_mo_coefficients` | `std::invalid_argument` |
+
+**Description:** These functions violate the project-wide convention that all fallible public functions return `std::expected<T, std::string>`. Exceptions escape into callers that expect the `std::expected` protocol, silently bypassing all error-propagation logic.
+
+**Fix:** Convert each to return `std::expected<T, std::string>` and use `std::unexpected(message)` at each current throw site.
+
+---
+
+### m4 — `ShellPair` stores const references, creating lifetime fragility
+
+**File:** `src/base/types.h:498–499`
+
+**Description:**
+`ShellPair` holds `const Shell& A` and `const Shell& B`. If the `vector<Shell>` that owns these shells is ever reallocated (e.g., via `push_back` after `ShellPair` objects are constructed), all existing `ShellPair` references silently dangle. There is currently no lifetime enforcement preventing this.
+
+**Fix:** Store indices into the shell vector instead of references, or ensure `build_shellpairs` is always called after the shell vector is finalized and never modified.
+
+---
+
+### m5 — `_compute_nuclear_repulsion` is `noexcept` but silently produces garbage if called early
+
+**File:** `src/base/types.h:802`
+
+**Description:**
+The function is marked `noexcept` and uses `_molecule._standard` (which must be Bohr). If called before `initialize()` → `detectSymmetry()` sets `_standard`, the result is wrong with no diagnostic. The `noexcept` annotation prevents callers from even considering that the result might be invalid.
+
+**Fix:** Either add a precondition assertion (`assert(_standard_initialized)`), or document clearly in the declaration that this must only be called post-`initialize()`.
+
+---
+
+### m6 — `Molecule::clear()` does not reset `nelectrons`
+
+**File:** `src/base/types.h:175–193`
+
+**Description:**
+`Molecule::clear()` resets atoms, coordinates, charge, multiplicity, and other fields but omits `nelectrons`. If the field is ever populated (fixing M4 above), `clear()` will leave a stale count.
+
+**Fix:** Add `nelectrons = 0;` to the body of `clear()`.
+
+---
+
+### m7 — DFT KS matrix V_xc assembly loop is not parallelized
+
+**File:** `src/dft/ks_matrix.cpp:98–155`
+
+**Description:**
+The V_xc integration loop (sum of `vxc * AO * AO` over grid points) is single-threaded, while the J/K ERI-based portion of the same KS matrix is OpenMP-parallelized. For large grids (UltraFine quality) or large basis sets, V_xc assembly becomes the bottleneck.
+
+**Fix:** Add `#pragma omp parallel for reduction(+:Vxc)` over the grid-point loop; the loop body is embarrassingly parallel.
+
+---
+
+### m8 — `energy_sorted_indices` uses exact floating-point equality
+
+**File:** `src/post_hf/casscf/strings.cpp:76`
+
+**Description:**
+Orbital energies are compared with `==` to detect degeneracies or duplicates. Floating-point orbital energies from the SCF are subject to rounding and will rarely be bitwise-identical even when physically degenerate.
+
+**Fix:** Use a tolerance-based comparison: `std::abs(e_i - e_j) < 1e-10`.
+
+---
+
+## Nitpick
+
+### n1 — Typo: "Hartee-Fock" in comment
+
+**File:** `src/base/types.h:53`
+**Fix:** "Hartee-Fock" → "Hartree-Fock"
+
+---
+
+### n2 — Typo: "Shwartz" in comment
+
+**File:** `src/base/types.h:338`
+**Fix:** "Shwartz" → "Schwarz"
+
+---
+
+### n3 — Unreachable `default` branch throws in `set_output_options`
+
+**File:** `src/base/types.h:478`
+**Description:** The `switch` covers all enum values but includes a `default: throw` branch. This is unreachable and misleading — it implies unknown values are possible when the type system already prevents them.
+**Fix:** Remove the `default` branch (or replace with `__builtin_unreachable()` / `std::unreachable()` in C++23).
+
+---
+
+## Known Bug (pre-existing, tracked separately)
+
+### Per-root total energy display stores CI eigenvalue, not total CASSCF energy
+
+**File:** `src/post_hf/casscf/casscf.cpp:1418`
+**Description:** The per-root energy stored at line 1418 is the CI eigenvalue (active-space energy relative to core), not the full total energy (`E_CI + E_nuc + E_core`). Energies used for convergence gating are correct; this is a display-only bug.
+**Fix:** Replace stored value with `ci_eigenvalue + E_nuc + E_core_one_electron`.
+
+---
+
+*End of report.*

--- a/src/base/types.h
+++ b/src/base/types.h
@@ -4,6 +4,7 @@
 #include <Eigen/Core>
 #include <Eigen/QR>
 #include <array>
+#include <cassert>
 #include <cmath>
 #include <cstdint>
 #include <deque>
@@ -50,7 +51,7 @@ namespace HartreeFock
 
     enum class SCFType
     {
-        RHF, // Restricted Hartee-Fock
+        RHF, // Restricted Hartree-Fock
         UHF  // Unrestricted Hartree-Fock
     };
 
@@ -166,7 +167,6 @@ namespace HartreeFock
 
         std::size_t natoms = 0;        // Number of atoms
         unsigned int multiplicity = 1; // Spin multiplicity
-        unsigned int nelectrons = 0;   // Number of electrons
         signed int charge = 0;         // Molecular charge
 
         bool _symmetry = false; // Symmetry flag
@@ -239,8 +239,8 @@ namespace HartreeFock
 
     struct Basis
     {
-        std::vector<Shell> _shells;                   // Shells
-        std::vector<ContractedView> _basis_functions; // Basis functions
+        std::vector<Shell> _shells;                  // Shells
+        std::deque<ContractedView> _basis_functions; // Basis functions; deque keeps references stable across push_back
 
         std::size_t nshells() const noexcept
         {
@@ -285,13 +285,17 @@ namespace HartreeFock
         bool _use_DIIS = true;        // Use DIIS (Default is true)
         bool _save_checkpoint = true; // Save checkpoint after convergence
 
+        static unsigned int max_cycles_for_nbasis(std::size_t nbasis) noexcept
+        {
+            return (nbasis > 1000) ? 300 : (nbasis > 500) ? 200
+                                       : (nbasis > 250)   ? 100
+                                                          : 50;
+        }
+
         // Automatic setter based on system size
         void set_max_cycles_auto(std::size_t nbasis) noexcept
         {
-            _max_cycles =
-                (nbasis > 1000) ? 300 : (nbasis > 500) ? 200
-                                    : (nbasis > 250)   ? 100
-                                                       : 50;
+            _max_cycles = max_cycles_for_nbasis(nbasis);
         }
 
         // Getter (auto fallback if still 0)
@@ -300,9 +304,7 @@ namespace HartreeFock
             if (_max_cycles != 0)
                 return _max_cycles;
 
-            return (nbasis > 1000) ? 300 : (nbasis > 500) ? 200
-                                       : (nbasis > 250)   ? 150
-                                                          : 50;
+            return max_cycles_for_nbasis(nbasis);
         }
 
         // Resolve Auto mode based on system size; explicit Conventional/Direct are left unchanged.
@@ -335,7 +337,7 @@ namespace HartreeFock
 
     struct OptionsIntegral
     {
-        double _tol_eri = 1E-10;                             // ERI tolerance for Shwartz screening
+        double _tol_eri = 1E-10;                             // ERI tolerance for Schwarz screening
         IntegralMethod _engine = IntegralMethod::ObaraSaika; // Integral Engine
     };
 
@@ -475,8 +477,6 @@ namespace HartreeFock
                 _write_cube = false;
                 break;
             }
-            default:
-                throw std::runtime_error("Unknown verbosity level");
             }
         }
     };
@@ -801,6 +801,9 @@ namespace HartreeFock
 
         void _compute_nuclear_repulsion() noexcept
         {
+            assert(_molecule._standard.rows() == static_cast<Eigen::Index>(_molecule.natoms) &&
+                   _molecule._standard.cols() == 3 &&
+                   "_compute_nuclear_repulsion requires molecule._standard to be initialized in Bohr");
             const std::size_t N = _molecule.natoms;
             double E_nuc = 0.0;
             for (std::size_t a = 0; a < N; a++)
@@ -837,7 +840,7 @@ namespace HartreeFock
         }
 
         // Getter
-        const Eigen::VectorXd _bohr_to_angstrom() const noexcept
+        Eigen::MatrixXd _bohr_to_angstrom() const noexcept
         {
             return _molecule._standard * 0.529177210903;
         }

--- a/src/dft/ks_matrix.cpp
+++ b/src/dft/ks_matrix.cpp
@@ -95,63 +95,85 @@ namespace DFT
         contribution.alpha = Eigen::MatrixXd::Zero(nbasis, nbasis);
         contribution.beta = Eigen::MatrixXd::Zero(nbasis, nbasis);
 
-        for (Eigen::Index point = 0; point < npoints; ++point)
+        const bool polarized = xc_grid.density.polarized;
+
+#ifdef USE_OPENMP
+#pragma omp parallel
+#endif
         {
-            const double weight = molecular_grid.points(point, 3);
-            if (weight == 0.0)
-                continue;
+            Eigen::MatrixXd alpha_local = Eigen::MatrixXd::Zero(nbasis, nbasis);
+            Eigen::MatrixXd beta_local = Eigen::MatrixXd::Zero(nbasis, nbasis);
 
-            const Eigen::VectorXd phi = ao_grid.values.row(point).transpose();
-
-            if (!xc_grid.density.polarized)
+#ifdef USE_OPENMP
+#pragma omp for nowait schedule(static)
+#endif
+            for (Eigen::Index point = 0; point < npoints; ++point)
             {
-                Eigen::VectorXd gradient_term = Eigen::VectorXd::Zero(nbasis);
-                if (xc_grid.vsigma.cols() == 1)
+                const double weight = molecular_grid.points(point, 3);
+                if (weight == 0.0)
+                    continue;
+
+                const Eigen::VectorXd phi = ao_grid.values.row(point).transpose();
+
+                if (!polarized)
                 {
-                    const Eigen::Vector3d coefficient =
-                        2.0 * xc_grid.vsigma(point, 0) *
-                        density_gradient_at(xc_grid.density.total, point);
-                    gradient_term = gradient_projection(ao_grid, point, coefficient);
+                    Eigen::VectorXd gradient_term = Eigen::VectorXd::Zero(nbasis);
+                    if (xc_grid.vsigma.cols() == 1)
+                    {
+                        const Eigen::Vector3d coefficient =
+                            2.0 * xc_grid.vsigma(point, 0) *
+                            density_gradient_at(xc_grid.density.total, point);
+                        gradient_term = gradient_projection(ao_grid, point, coefficient);
+                    }
+
+                    accumulate_local_potential(
+                        alpha_local,
+                        weight,
+                        xc_grid.vrho(point, 0),
+                        phi,
+                        gradient_term);
+                    continue;
+                }
+
+                Eigen::VectorXd gradient_term_alpha = Eigen::VectorXd::Zero(nbasis);
+                Eigen::VectorXd gradient_term_beta = Eigen::VectorXd::Zero(nbasis);
+
+                if (xc_grid.vsigma.cols() == 3)
+                {
+                    const Eigen::Vector3d grad_alpha = density_gradient_at(xc_grid.density.alpha, point);
+                    const Eigen::Vector3d grad_beta = density_gradient_at(xc_grid.density.beta, point);
+
+                    const Eigen::Vector3d coefficient_alpha =
+                        2.0 * xc_grid.vsigma(point, 0) * grad_alpha + xc_grid.vsigma(point, 1) * grad_beta;
+                    const Eigen::Vector3d coefficient_beta =
+                        xc_grid.vsigma(point, 1) * grad_alpha + 2.0 * xc_grid.vsigma(point, 2) * grad_beta;
+
+                    gradient_term_alpha = gradient_projection(ao_grid, point, coefficient_alpha);
+                    gradient_term_beta = gradient_projection(ao_grid, point, coefficient_beta);
                 }
 
                 accumulate_local_potential(
-                    contribution.alpha,
+                    alpha_local,
                     weight,
                     xc_grid.vrho(point, 0),
                     phi,
-                    gradient_term);
-                continue;
+                    gradient_term_alpha);
+                accumulate_local_potential(
+                    beta_local,
+                    weight,
+                    xc_grid.vrho(point, 1),
+                    phi,
+                    gradient_term_beta);
             }
 
-            Eigen::VectorXd gradient_term_alpha = Eigen::VectorXd::Zero(nbasis);
-            Eigen::VectorXd gradient_term_beta = Eigen::VectorXd::Zero(nbasis);
-
-            if (xc_grid.vsigma.cols() == 3)
+#ifdef USE_OPENMP
+#pragma omp critical
+#endif
             {
-                const Eigen::Vector3d grad_alpha = density_gradient_at(xc_grid.density.alpha, point);
-                const Eigen::Vector3d grad_beta = density_gradient_at(xc_grid.density.beta, point);
-
-                const Eigen::Vector3d coefficient_alpha =
-                    2.0 * xc_grid.vsigma(point, 0) * grad_alpha + xc_grid.vsigma(point, 1) * grad_beta;
-                const Eigen::Vector3d coefficient_beta =
-                    xc_grid.vsigma(point, 1) * grad_alpha + 2.0 * xc_grid.vsigma(point, 2) * grad_beta;
-
-                gradient_term_alpha = gradient_projection(ao_grid, point, coefficient_alpha);
-                gradient_term_beta = gradient_projection(ao_grid, point, coefficient_beta);
+                contribution.alpha.noalias() += alpha_local;
+                if (polarized)
+                    contribution.beta.noalias() += beta_local;
             }
-
-            accumulate_local_potential(
-                contribution.alpha,
-                weight,
-                xc_grid.vrho(point, 0),
-                phi,
-                gradient_term_alpha);
-            accumulate_local_potential(
-                contribution.beta,
-                weight,
-                xc_grid.vrho(point, 1),
-                phi,
-                gradient_term_beta);
         }
 
         contribution.alpha = 0.5 * (contribution.alpha + contribution.alpha.transpose());

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -659,7 +659,13 @@ int main(int argc, const char *argv[])
             HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "Gradient :",
                                          "Using analytic RMP2 gradient (relaxed density + pair density + Z-vector)");
             calculator._total_energy += calculator._correlation_energy;
-            grad = HartreeFock::Gradient::compute_rmp2_gradient(calculator, shellpairs);
+            auto grad_res = HartreeFock::Gradient::compute_rmp2_gradient(calculator, shellpairs);
+            if (!grad_res)
+            {
+                HartreeFock::Logger::logging(HartreeFock::LogLevel::Error, "Gradient :", grad_res.error());
+                return EXIT_FAILURE;
+            }
+            grad = std::move(*grad_res);
         }
         else if (calculator._correlation == HartreeFock::PostHF::UMP2)
         {
@@ -668,9 +674,25 @@ int main(int argc, const char *argv[])
             return EXIT_FAILURE;
         }
         else if (calculator._info._scf.is_uhf)
-            grad = HartreeFock::Gradient::compute_uhf_gradient(calculator, shellpairs);
+        {
+            auto grad_res = HartreeFock::Gradient::compute_uhf_gradient(calculator, shellpairs);
+            if (!grad_res)
+            {
+                HartreeFock::Logger::logging(HartreeFock::LogLevel::Error, "Gradient :", grad_res.error());
+                return EXIT_FAILURE;
+            }
+            grad = std::move(*grad_res);
+        }
         else
-            grad = HartreeFock::Gradient::compute_rhf_gradient(calculator, shellpairs);
+        {
+            auto grad_res = HartreeFock::Gradient::compute_rhf_gradient(calculator, shellpairs);
+            if (!grad_res)
+            {
+                HartreeFock::Logger::logging(HartreeFock::LogLevel::Error, "Gradient :", grad_res.error());
+                return EXIT_FAILURE;
+            }
+            grad = std::move(*grad_res);
+        }
         calculator._gradient = grad;
 
         HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "Nuclear Gradient (Ha/Bohr) :", "");

--- a/src/freq/hessian.cpp
+++ b/src/freq/hessian.cpp
@@ -82,9 +82,19 @@ static Eigen::MatrixXd _run_sp_gradient_freq_hf(HartreeFock::Calculator &calc)
 
     Eigen::MatrixXd grad;
     if (calc._scf._scf == HartreeFock::SCFType::UHF)
-        grad = HartreeFock::Gradient::compute_uhf_gradient(calc, shell_pairs);
+    {
+        auto grad_res = HartreeFock::Gradient::compute_uhf_gradient(calc, shell_pairs);
+        if (!grad_res)
+            throw std::runtime_error("Hessian UHF gradient failed: " + grad_res.error());
+        grad = std::move(*grad_res);
+    }
     else
-        grad = HartreeFock::Gradient::compute_rhf_gradient(calc, shell_pairs);
+    {
+        auto grad_res = HartreeFock::Gradient::compute_rhf_gradient(calc, shell_pairs);
+        if (!grad_res)
+            throw std::runtime_error("Hessian RHF gradient failed: " + grad_res.error());
+        grad = std::move(*grad_res);
+    }
 
     calc._gradient = grad;
     return grad;

--- a/src/gradient/gradient.cpp
+++ b/src/gradient/gradient.cpp
@@ -1,7 +1,7 @@
 #include "gradient.h"
 
+#include <array>
 #include <cmath>
-#include <stdexcept>
 #include <vector>
 
 #include "basis/basis.h"
@@ -17,7 +17,7 @@
 
 // Build a map: shell index in _shells._shells → atom index in _molecule.
 // Matches shell._center ≈ _molecule._standard.row(a) within 1e-6 Bohr.
-static std::vector<int> build_shell_atom_map(
+static std::expected<std::vector<int>, std::string> build_shell_atom_map(
     const HartreeFock::Calculator &calc)
 {
     const auto &shells = calc._shells._shells;
@@ -40,7 +40,7 @@ static std::vector<int> build_shell_atom_map(
             }
         }
         if (map[s] < 0)
-            throw std::runtime_error("Gradient: shell does not match any atom");
+            return std::unexpected(std::string("Gradient: shell does not match any atom"));
     }
     return map;
 }
@@ -50,8 +50,78 @@ static std::size_t idx_dm2_grad(int p, int q, int r, int s, int nbf)
     return ((static_cast<std::size_t>(p) * nbf + q) * nbf + r) * nbf + s;
 }
 
+static Eigen::MatrixXd build_pair_schwarz_table(
+    const std::vector<HartreeFock::ShellPair> &shell_pairs,
+    std::size_t nbasis)
+{
+    Eigen::MatrixXd Q = Eigen::MatrixXd::Zero(nbasis, nbasis);
+    for (const auto &sp : shell_pairs)
+    {
+        const std::size_t i = sp.A._index;
+        const std::size_t j = sp.B._index;
+        const int lAx = sp.A._cartesian[0], lAy = sp.A._cartesian[1], lAz = sp.A._cartesian[2];
+        const int lBx = sp.B._cartesian[0], lBy = sp.B._cartesian[1], lBz = sp.B._cartesian[2];
+        const double diag = HartreeFock::ObaraSaika::_contracted_eri_elem(
+            sp, sp, lAx, lAy, lAz, lBx, lBy, lBz, lAx, lAy, lAz, lBx, lBy, lBz);
+        const double q = std::sqrt(std::abs(diag));
+        Q(i, j) = q;
+        Q(j, i) = q;
+    }
+    return Q;
+}
+
 template <typename GammaFn>
-static Eigen::MatrixXd compute_closed_shell_gradient_from_density(
+static void accumulate_eri_gradient_permutations(
+    Eigen::MatrixXd &grad,
+    const std::array<double, 12> &dI,
+    GammaFn &&gamma_fn,
+    std::size_t ii,
+    std::size_t jj,
+    std::size_t kk,
+    std::size_t ll,
+    int atom_A,
+    int atom_B,
+    int atom_C,
+    int atom_D)
+{
+    const auto accumulate_perm = [&](double gamma,
+                                     bool swap_ab,
+                                     bool swap_cd)
+    {
+        if (std::abs(gamma) < 1e-14)
+            return;
+
+        const int deriv_a = swap_ab ? 1 : 0;
+        const int deriv_b = swap_ab ? 0 : 1;
+        const int deriv_c = swap_cd ? 3 : 2;
+        const int deriv_d = swap_cd ? 2 : 3;
+
+        const int atom_a = swap_ab ? atom_B : atom_A;
+        const int atom_b = swap_ab ? atom_A : atom_B;
+        const int atom_c = swap_cd ? atom_D : atom_C;
+        const int atom_d = swap_cd ? atom_C : atom_D;
+
+        const double fac = 0.25 * gamma;
+        for (int q = 0; q < 3; ++q)
+        {
+            grad(atom_a, q) += fac * dI[deriv_a * 3 + q];
+            grad(atom_b, q) += fac * dI[deriv_b * 3 + q];
+            grad(atom_c, q) += fac * dI[deriv_c * 3 + q];
+            grad(atom_d, q) += fac * dI[deriv_d * 3 + q];
+        }
+    };
+
+    accumulate_perm(gamma_fn(ii, jj, kk, ll), false, false);
+    if (kk != ll)
+        accumulate_perm(gamma_fn(ii, jj, ll, kk), false, true);
+    if (ii != jj)
+        accumulate_perm(gamma_fn(jj, ii, kk, ll), true, false);
+    if (ii != jj && kk != ll)
+        accumulate_perm(gamma_fn(jj, ii, ll, kk), true, true);
+}
+
+template <typename GammaFn>
+static std::expected<Eigen::MatrixXd, std::string> compute_closed_shell_gradient_from_density(
     const HartreeFock::Calculator &calc,
     const std::vector<HartreeFock::ShellPair> &shell_pairs,
     const Eigen::MatrixXd &P,
@@ -65,16 +135,14 @@ static Eigen::MatrixXd compute_closed_shell_gradient_from_density(
 
     Eigen::MatrixXd grad = Eigen::MatrixXd::Zero(natoms, 3);
 
-    const std::vector<int> shell_atom = build_shell_atom_map(calc);
+    auto shell_atom_res = build_shell_atom_map(calc);
+    if (!shell_atom_res)
+        return std::unexpected(shell_atom_res.error());
+    const std::vector<int> shell_atom = std::move(*shell_atom_res);
     const auto &shells = basis._shells;
     const auto &bfs = basis._basis_functions;
     const std::size_t nshells = shells.size();
-
-    std::vector<HartreeFock::ShellPair> all_pairs;
-    all_pairs.reserve(nb * nb);
-    for (std::size_t ii = 0; ii < nb; ++ii)
-        for (std::size_t jj = 0; jj < nb; ++jj)
-            all_pairs.emplace_back(bfs[ii], bfs[jj]);
+    const Eigen::MatrixXd schwarz_q = build_pair_schwarz_table(shell_pairs, nb);
 
     std::vector<int> bf_shell(nb, -1);
     for (std::size_t s = 0; s < nshells; ++s)
@@ -139,33 +207,36 @@ static Eigen::MatrixXd compute_closed_shell_gradient_from_density(
         }
     }
 
-    for (const auto &spAB : all_pairs)
+    for (const auto &spAB : shell_pairs)
     {
         const std::size_t ii = spAB.A._index;
         const std::size_t jj = spAB.B._index;
         const int atom_A = shell_atom[bf_shell[ii]];
         const int atom_B = shell_atom[bf_shell[jj]];
 
-        for (const auto &spCD : all_pairs)
+        for (const auto &spCD : shell_pairs)
         {
             const std::size_t kk = spCD.A._index;
             const std::size_t ll = spCD.B._index;
             const int atom_C = shell_atom[bf_shell[kk]];
             const int atom_D = shell_atom[bf_shell[ll]];
 
-            const double Gamma = gamma_fn(ii, jj, kk, ll);
-            if (std::abs(Gamma) < 1e-14)
+            if (schwarz_q(ii, jj) * schwarz_q(kk, ll) < calc._integral._tol_eri)
                 continue;
 
             const auto dI = HartreeFock::ObaraSaika::_compute_eri_deriv_elem(spAB, spCD);
-            const double fac = 0.25 * Gamma;
-            for (int q = 0; q < 3; ++q)
-            {
-                grad(atom_A, q) += fac * dI[0 * 3 + q];
-                grad(atom_B, q) += fac * dI[1 * 3 + q];
-                grad(atom_C, q) += fac * dI[2 * 3 + q];
-                grad(atom_D, q) += fac * dI[3 * 3 + q];
-            }
+            accumulate_eri_gradient_permutations(
+                grad,
+                dI,
+                gamma_fn,
+                ii,
+                jj,
+                kk,
+                ll,
+                atom_A,
+                atom_B,
+                atom_C,
+                atom_D);
         }
     }
 
@@ -200,7 +271,7 @@ static Eigen::MatrixXd compute_closed_shell_gradient_from_density(
 //        - 2 Σ_{μ∈A,ν}  W_μν dS_μν/dA_x                   [Pulay]
 //        + Σ_{B≠A}      Z_A Z_B (R_A-R_B)/|R_A-R_B|³      [nuclear repulsion]
 
-Eigen::MatrixXd HartreeFock::Gradient::compute_rhf_gradient(
+std::expected<Eigen::MatrixXd, std::string> HartreeFock::Gradient::compute_rhf_gradient(
     const HartreeFock::Calculator &calc,
     const std::vector<HartreeFock::ShellPair> &shell_pairs)
 {
@@ -223,7 +294,7 @@ Eigen::MatrixXd HartreeFock::Gradient::compute_rhf_gradient(
 
 // ─── UHF Gradient ─────────────────────────────────────────────────────────────
 
-Eigen::MatrixXd HartreeFock::Gradient::compute_uhf_gradient(
+std::expected<Eigen::MatrixXd, std::string> HartreeFock::Gradient::compute_uhf_gradient(
     const HartreeFock::Calculator &calc,
     const std::vector<HartreeFock::ShellPair> &shell_pairs)
 {
@@ -256,23 +327,20 @@ Eigen::MatrixXd HartreeFock::Gradient::compute_uhf_gradient(
 
     Eigen::MatrixXd grad = Eigen::MatrixXd::Zero(natoms, 3);
 
-    const std::vector<int> shell_atom = build_shell_atom_map(calc);
+    auto shell_atom_res = build_shell_atom_map(calc);
+    if (!shell_atom_res)
+        return std::unexpected(shell_atom_res.error());
+    const std::vector<int> shell_atom = std::move(*shell_atom_res);
     const auto &shells = basis._shells;
     const auto &bfs = basis._basis_functions;
     const std::size_t nshells = shells.size();
+    const Eigen::MatrixXd schwarz_q = build_pair_schwarz_table(shell_pairs, nb);
 
     std::vector<int> bf_shell(nb, -1);
     for (std::size_t s = 0; s < nshells; ++s)
         for (std::size_t mu = 0; mu < nb; ++mu)
             if (bfs[mu]._shell == &shells[s])
                 bf_shell[mu] = static_cast<int>(s);
-
-    // All (ii,jj) basis-function pairs for the ERI gradient loop (see RHF notes)
-    std::vector<HartreeFock::ShellPair> all_pairs;
-    all_pairs.reserve(nb * nb);
-    for (std::size_t ii = 0; ii < nb; ++ii)
-        for (std::size_t jj = 0; jj < nb; ++jj)
-            all_pairs.emplace_back(bfs[ii], bfs[jj]);
 
     // ── Term 1+Pulay (same structure as RHF but using P_t and W) ─────────────
     for (const auto &sp : shell_pairs)
@@ -333,34 +401,44 @@ Eigen::MatrixXd HartreeFock::Gradient::compute_uhf_gradient(
 
     // ── Term 3: ERI gradient ──────────────────────────────────────────────────
     // Γ_μνλσ = 2*P_t_μν*P_t_λσ - 2*P_a_μλ*P_a_νσ - 2*P_b_μλ*P_b_νσ
-    for (const auto &spAB : all_pairs)
+    auto gamma_fn = [&P_t, &P_a, &P_b](std::size_t ii, std::size_t jj,
+                                       std::size_t kk, std::size_t ll) -> double
+    {
+        return 2.0 * P_t(ii, jj) * P_t(kk, ll) -
+               2.0 * P_a(ii, kk) * P_a(jj, ll) -
+               2.0 * P_b(ii, kk) * P_b(jj, ll);
+    };
+
+    for (const auto &spAB : shell_pairs)
     {
         const std::size_t ii = spAB.A._index;
         const std::size_t jj = spAB.B._index;
         const int atom_A = shell_atom[bf_shell[ii]];
         const int atom_B = shell_atom[bf_shell[jj]];
 
-        for (const auto &spCD : all_pairs)
+        for (const auto &spCD : shell_pairs)
         {
             const std::size_t kk = spCD.A._index;
             const std::size_t ll = spCD.B._index;
             const int atom_C = shell_atom[bf_shell[kk]];
             const int atom_D = shell_atom[bf_shell[ll]];
 
-            const double Gamma = 2.0 * P_t(ii, jj) * P_t(kk, ll) - 2.0 * P_a(ii, kk) * P_a(jj, ll) - 2.0 * P_b(ii, kk) * P_b(jj, ll);
-            if (std::abs(Gamma) < 1e-14)
+            if (schwarz_q(ii, jj) * schwarz_q(kk, ll) < calc._integral._tol_eri)
                 continue;
 
             const auto dI = HartreeFock::ObaraSaika::_compute_eri_deriv_elem(spAB, spCD);
-
-            const double fac = 0.25 * Gamma;
-            for (int q = 0; q < 3; ++q)
-            {
-                grad(atom_A, q) += fac * dI[0 * 3 + q];
-                grad(atom_B, q) += fac * dI[1 * 3 + q];
-                grad(atom_C, q) += fac * dI[2 * 3 + q];
-                grad(atom_D, q) += fac * dI[3 * 3 + q];
-            }
+            accumulate_eri_gradient_permutations(
+                grad,
+                dI,
+                gamma_fn,
+                ii,
+                jj,
+                kk,
+                ll,
+                atom_A,
+                atom_B,
+                atom_C,
+                atom_D);
         }
     }
 
@@ -386,18 +464,18 @@ Eigen::MatrixXd HartreeFock::Gradient::compute_uhf_gradient(
     return grad;
 }
 
-Eigen::MatrixXd HartreeFock::Gradient::compute_rmp2_gradient(
+std::expected<Eigen::MatrixXd, std::string> HartreeFock::Gradient::compute_rmp2_gradient(
     HartreeFock::Calculator &calc,
     const std::vector<HartreeFock::ShellPair> &shell_pairs)
 {
     if (calc._correlation != HartreeFock::PostHF::RMP2)
-        throw std::runtime_error("RMP2 gradient requested without correlation = RMP2");
+        return std::unexpected(std::string("RMP2 gradient requested without correlation = RMP2"));
     if (calc._scf._scf != HartreeFock::SCFType::RHF || calc._info._scf.is_uhf)
-        throw std::runtime_error("RMP2 gradient requires an RHF reference");
+        return std::unexpected(std::string("RMP2 gradient requires an RHF reference"));
 
     auto grad_res = HartreeFock::Correlation::build_rmp2_gradient_intermediates(calc, shell_pairs);
     if (!grad_res)
-        throw std::runtime_error("RMP2 gradient build failed: " + grad_res.error());
+        return std::unexpected(std::string("RMP2 gradient build failed: ") + grad_res.error());
     const auto &grad_data = *grad_res;
 
     const Eigen::MatrixXd &P_ref = calc._info._scf.alpha.density;

--- a/src/gradient/gradient.h
+++ b/src/gradient/gradient.h
@@ -11,20 +11,23 @@ namespace HartreeFock
         // Analytic RHF nuclear gradient.
         // Returns natoms×3 matrix in Ha/Bohr.
         // Requires a converged RHF wavefunction in calc._info._scf.
-        Eigen::MatrixXd compute_rhf_gradient(const HartreeFock::Calculator &calc,
-                                             const std::vector<HartreeFock::ShellPair> &shell_pairs);
+        std::expected<Eigen::MatrixXd, std::string> compute_rhf_gradient(
+            const HartreeFock::Calculator &calc,
+            const std::vector<HartreeFock::ShellPair> &shell_pairs);
 
         // Analytic UHF nuclear gradient.
         // Returns natoms×3 matrix in Ha/Bohr.
-        Eigen::MatrixXd compute_uhf_gradient(const HartreeFock::Calculator &calc,
-                                             const std::vector<HartreeFock::ShellPair> &shell_pairs);
+        std::expected<Eigen::MatrixXd, std::string> compute_uhf_gradient(
+            const HartreeFock::Calculator &calc,
+            const std::vector<HartreeFock::ShellPair> &shell_pairs);
 
         // Analytic RMP2 nuclear gradient from the relaxed MP2 density and
         // Z-vector response.
         // Returns natoms×3 matrix in Ha/Bohr.
         // Requires a converged RHF reference and correlation = RMP2.
-        Eigen::MatrixXd compute_rmp2_gradient(HartreeFock::Calculator &calc,
-                                              const std::vector<HartreeFock::ShellPair> &shell_pairs);
+        std::expected<Eigen::MatrixXd, std::string> compute_rmp2_gradient(
+            HartreeFock::Calculator &calc,
+            const std::vector<HartreeFock::ShellPair> &shell_pairs);
     } // namespace Gradient
 } // namespace HartreeFock
 

--- a/src/integrals/os.cpp
+++ b/src/integrals/os.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <vector>
 
 namespace
 {
@@ -132,15 +133,105 @@ namespace
                                        std::size_t k, std::size_t l,
                                        double val)
     {
-        eri[i * nb3 + j * nb2 + k * nb + l] = val;
-        eri[j * nb3 + i * nb2 + k * nb + l] = val;
-        eri[i * nb3 + j * nb2 + l * nb + k] = val;
-        eri[j * nb3 + i * nb2 + l * nb + k] = val;
-        eri[k * nb3 + l * nb2 + i * nb + j] = val;
-        eri[l * nb3 + k * nb2 + i * nb + j] = val;
-        eri[k * nb3 + l * nb2 + j * nb + i] = val;
-        eri[l * nb3 + k * nb2 + j * nb + i] = val;
+        auto write_slot = [&](std::size_t idx)
+        {
+#ifdef USE_OPENMP
+#pragma omp atomic write
+#endif
+            eri[idx] = val;
+        };
+
+        write_slot(i * nb3 + j * nb2 + k * nb + l);
+        write_slot(j * nb3 + i * nb2 + k * nb + l);
+        write_slot(i * nb3 + j * nb2 + l * nb + k);
+        write_slot(j * nb3 + i * nb2 + l * nb + k);
+        write_slot(k * nb3 + l * nb2 + i * nb + j);
+        write_slot(l * nb3 + k * nb2 + i * nb + j);
+        write_slot(k * nb3 + l * nb2 + j * nb + i);
+        write_slot(l * nb3 + k * nb2 + j * nb + i);
     }
+
+    struct EriScratch
+    {
+        int ax_dim = 0;
+        int ay_dim = 0;
+        int az_dim = 0;
+        int cx_dim = 0;
+        int cy_dim = 0;
+        int cz_dim = 0;
+        int m_dim = 0;
+        std::vector<double> vrr;
+        std::vector<double> hrr;
+
+        void resize_for_quartet(
+            int lABx, int lABy, int lABz,
+            int lCDx, int lCDy, int lCDz,
+            int mmax)
+        {
+            ax_dim = lABx + 1;
+            ay_dim = lABy + 1;
+            az_dim = lABz + 1;
+            cx_dim = lCDx + 1;
+            cy_dim = lCDy + 1;
+            cz_dim = lCDz + 1;
+            m_dim = mmax + 1;
+
+            const std::size_t spatial =
+                static_cast<std::size_t>(ax_dim) * ay_dim * az_dim *
+                cx_dim * cy_dim * cz_dim;
+            vrr.assign(spatial * static_cast<std::size_t>(m_dim), 0.0);
+            hrr.resize(spatial);
+        }
+
+        std::size_t spatial_index(
+            int ax, int ay, int az,
+            int cx, int cy, int cz) const
+        {
+            std::size_t idx = static_cast<std::size_t>(ax);
+            idx = idx * static_cast<std::size_t>(ay_dim) + static_cast<std::size_t>(ay);
+            idx = idx * static_cast<std::size_t>(az_dim) + static_cast<std::size_t>(az);
+            idx = idx * static_cast<std::size_t>(cx_dim) + static_cast<std::size_t>(cx);
+            idx = idx * static_cast<std::size_t>(cy_dim) + static_cast<std::size_t>(cy);
+            idx = idx * static_cast<std::size_t>(cz_dim) + static_cast<std::size_t>(cz);
+            return idx;
+        }
+
+        double &v(
+            int ax, int ay, int az,
+            int cx, int cy, int cz,
+            int m)
+        {
+            return vrr[spatial_index(ax, ay, az, cx, cy, cz) *
+                           static_cast<std::size_t>(m_dim) +
+                       static_cast<std::size_t>(m)];
+        }
+
+        const double &v(
+            int ax, int ay, int az,
+            int cx, int cy, int cz,
+            int m) const
+        {
+            return vrr[spatial_index(ax, ay, az, cx, cy, cz) *
+                           static_cast<std::size_t>(m_dim) +
+                       static_cast<std::size_t>(m)];
+        }
+
+        double &h(
+            int ax, int ay, int az,
+            int cx, int cy, int cz)
+        {
+            return hrr[spatial_index(ax, ay, az, cx, cy, cz)];
+        }
+
+        const double &h(
+            int ax, int ay, int az,
+            int cx, int cy, int cz) const
+        {
+            return hrr[spatial_index(ax, ay, az, cx, cy, cz)];
+        }
+    };
+
+    static thread_local EriScratch _eri_scratch;
 } // namespace
 
 inline double HartreeFock::ObaraSaika::_os_1d(const double gamma, const double distPA, const double distPB, const int lA, const int lB)
@@ -535,18 +626,10 @@ std::tuple<double, double> HartreeFock::ObaraSaika::_compute_3d_overlap_kinetic(
 // Complexity: O(L^3 * (bx+by+bz))  vs  O(2^(bx+by+bz)) for the
 // recursive version.
 // VRR spatial dimension: each axis of the VRR table runs from 0 to
-// lAx+lBx (or y,z equivalents).  lAx can be MAX_L and lBx can be
-// MAX_L independently, so the table needs 2*MAX_L+1 entries per axis.
-static constexpr int VRR_DIM = 2 * MAX_L + 1; // = 13; per-axis bound for 1-pair VRR
-static constexpr int MMAX_4C = 4 * MAX_L + 2; // = 26; Boys m upper bound for 4-center ERI
-
-// Thread-local scratch buffers for 4-center ERI (too large for the stack).
-// VRR buffer: V[ax][ay][az][cx][cy][cz][m]
-// HRR buffer: W[ax][ay][az][cx][cy][cz]  (m=0 slice used during HRR)
-static thread_local double _vrr_buf[VRR_DIM][VRR_DIM][VRR_DIM]
-                                   [VRR_DIM][VRR_DIM][VRR_DIM][MMAX_4C];
-static thread_local double _hrr_buf[VRR_DIM][VRR_DIM][VRR_DIM]
-                                   [VRR_DIM][VRR_DIM][VRR_DIM];
+// lAx+lBx (or y,z equivalents). The fixed-size helpers below still use
+// VRR_DIM-sized stack buffers where the footprint is modest, but the 4-center
+// ERI scratch itself is allocated dynamically per quartet in `_eri_scratch`.
+static constexpr int VRR_DIM = 2 * MAX_L + 1; // = 13; per-axis bound for compact stack helpers
 
 static double _nuclear_hrr(
     const double V0[VRR_DIM][VRR_DIM][VRR_DIM],
@@ -794,7 +877,7 @@ static void _eri_vrr(
     const HartreeFock::PrimitivePair &ppCD,
     const int lABx, const int lABy, const int lABz,
     const int lCDx, const int lCDy, const int lCDz,
-    double V[VRR_DIM][VRR_DIM][VRR_DIM][VRR_DIM][VRR_DIM][VRR_DIM][MMAX_4C])
+    EriScratch &scratch)
 {
     const double zetaAB = ppAB.zeta;
     const double zetaCD = ppCD.zeta;
@@ -832,7 +915,7 @@ static void _eri_vrr(
 
     // ── Seed ─────────────────────────────────────────────────────────────────
     for (int m = 0; m <= MMAX; ++m)
-        V[0][0][0][0][0][0][m] = prefac * HartreeFock::Lookup::boys(m, T);
+        scratch.v(0, 0, 0, 0, 0, 0, m) = prefac * HartreeFock::Lookup::boys(m, T);
 
     // ── A-VRR: x-axis ─────────────────────────────────────────────────────
     for (int ax = 1; ax <= lABx; ++ax)
@@ -840,12 +923,14 @@ static void _eri_vrr(
         const int mlim = MMAX - ax;
         for (int m = 0; m <= mlim; ++m)
         {
-            V[ax][0][0][0][0][0][m] =
-                PAx * V[ax - 1][0][0][0][0][0][m] + WPx * V[ax - 1][0][0][0][0][0][m + 1];
+            scratch.v(ax, 0, 0, 0, 0, 0, m) =
+                PAx * scratch.v(ax - 1, 0, 0, 0, 0, 0, m) +
+                WPx * scratch.v(ax - 1, 0, 0, 0, 0, 0, m + 1);
             if (ax > 1)
-                V[ax][0][0][0][0][0][m] +=
+                scratch.v(ax, 0, 0, 0, 0, 0, m) +=
                     (ax - 1) * inv_2_zetaAB *
-                    (V[ax - 2][0][0][0][0][0][m] - rho_over_zetaAB * V[ax - 2][0][0][0][0][0][m + 1]);
+                    (scratch.v(ax - 2, 0, 0, 0, 0, 0, m) -
+                     rho_over_zetaAB * scratch.v(ax - 2, 0, 0, 0, 0, 0, m + 1));
         }
     }
 
@@ -859,12 +944,14 @@ static void _eri_vrr(
                 continue;
             for (int m = 0; m <= mlim; ++m)
             {
-                V[ax][ay][0][0][0][0][m] =
-                    PAy * V[ax][ay - 1][0][0][0][0][m] + WPy * V[ax][ay - 1][0][0][0][0][m + 1];
+                scratch.v(ax, ay, 0, 0, 0, 0, m) =
+                    PAy * scratch.v(ax, ay - 1, 0, 0, 0, 0, m) +
+                    WPy * scratch.v(ax, ay - 1, 0, 0, 0, 0, m + 1);
                 if (ay > 1)
-                    V[ax][ay][0][0][0][0][m] +=
+                    scratch.v(ax, ay, 0, 0, 0, 0, m) +=
                         (ay - 1) * inv_2_zetaAB *
-                        (V[ax][ay - 2][0][0][0][0][m] - rho_over_zetaAB * V[ax][ay - 2][0][0][0][0][m + 1]);
+                        (scratch.v(ax, ay - 2, 0, 0, 0, 0, m) -
+                         rho_over_zetaAB * scratch.v(ax, ay - 2, 0, 0, 0, 0, m + 1));
             }
         }
     }
@@ -881,12 +968,14 @@ static void _eri_vrr(
                     continue;
                 for (int m = 0; m <= mlim; ++m)
                 {
-                    V[ax][ay][az][0][0][0][m] =
-                        PAz * V[ax][ay][az - 1][0][0][0][m] + WPz * V[ax][ay][az - 1][0][0][0][m + 1];
+                    scratch.v(ax, ay, az, 0, 0, 0, m) =
+                        PAz * scratch.v(ax, ay, az - 1, 0, 0, 0, m) +
+                        WPz * scratch.v(ax, ay, az - 1, 0, 0, 0, m + 1);
                     if (az > 1)
-                        V[ax][ay][az][0][0][0][m] +=
+                        scratch.v(ax, ay, az, 0, 0, 0, m) +=
                             (az - 1) * inv_2_zetaAB *
-                            (V[ax][ay][az - 2][0][0][0][m] - rho_over_zetaAB * V[ax][ay][az - 2][0][0][0][m + 1]);
+                            (scratch.v(ax, ay, az - 2, 0, 0, 0, m) -
+                             rho_over_zetaAB * scratch.v(ax, ay, az - 2, 0, 0, 0, m + 1));
                 }
             }
         }
@@ -906,15 +995,17 @@ static void _eri_vrr(
                         continue;
                     for (int m = 0; m <= mlim; ++m)
                     {
-                        V[ax][ay][az][cx][0][0][m] =
-                            QCx * V[ax][ay][az][cx - 1][0][0][m] + WQx * V[ax][ay][az][cx - 1][0][0][m + 1];
+                        scratch.v(ax, ay, az, cx, 0, 0, m) =
+                            QCx * scratch.v(ax, ay, az, cx - 1, 0, 0, m) +
+                            WQx * scratch.v(ax, ay, az, cx - 1, 0, 0, m + 1);
                         if (cx > 1)
-                            V[ax][ay][az][cx][0][0][m] +=
+                            scratch.v(ax, ay, az, cx, 0, 0, m) +=
                                 (cx - 1) * inv_2_zetaCD *
-                                (V[ax][ay][az][cx - 2][0][0][m] - rho_over_zetaCD * V[ax][ay][az][cx - 2][0][0][m + 1]);
+                                (scratch.v(ax, ay, az, cx - 2, 0, 0, m) -
+                                 rho_over_zetaCD * scratch.v(ax, ay, az, cx - 2, 0, 0, m + 1));
                         if (ax > 0)
-                            V[ax][ay][az][cx][0][0][m] +=
-                                ax * inv_2_delta * V[ax - 1][ay][az][cx - 1][0][0][m + 1];
+                            scratch.v(ax, ay, az, cx, 0, 0, m) +=
+                                ax * inv_2_delta * scratch.v(ax - 1, ay, az, cx - 1, 0, 0, m + 1);
                     }
                 }
             }
@@ -937,15 +1028,17 @@ static void _eri_vrr(
                             continue;
                         for (int m = 0; m <= mlim; ++m)
                         {
-                            V[ax][ay][az][cx][cy][0][m] =
-                                QCy * V[ax][ay][az][cx][cy - 1][0][m] + WQy * V[ax][ay][az][cx][cy - 1][0][m + 1];
+                            scratch.v(ax, ay, az, cx, cy, 0, m) =
+                                QCy * scratch.v(ax, ay, az, cx, cy - 1, 0, m) +
+                                WQy * scratch.v(ax, ay, az, cx, cy - 1, 0, m + 1);
                             if (cy > 1)
-                                V[ax][ay][az][cx][cy][0][m] +=
+                                scratch.v(ax, ay, az, cx, cy, 0, m) +=
                                     (cy - 1) * inv_2_zetaCD *
-                                    (V[ax][ay][az][cx][cy - 2][0][m] - rho_over_zetaCD * V[ax][ay][az][cx][cy - 2][0][m + 1]);
+                                    (scratch.v(ax, ay, az, cx, cy - 2, 0, m) -
+                                     rho_over_zetaCD * scratch.v(ax, ay, az, cx, cy - 2, 0, m + 1));
                             if (ay > 0)
-                                V[ax][ay][az][cx][cy][0][m] +=
-                                    ay * inv_2_delta * V[ax][ay - 1][az][cx][cy - 1][0][m + 1];
+                                scratch.v(ax, ay, az, cx, cy, 0, m) +=
+                                    ay * inv_2_delta * scratch.v(ax, ay - 1, az, cx, cy - 1, 0, m + 1);
                         }
                     }
                 }
@@ -971,15 +1064,17 @@ static void _eri_vrr(
                                 continue;
                             for (int m = 0; m <= mlim; ++m)
                             {
-                                V[ax][ay][az][cx][cy][cz][m] =
-                                    QCz * V[ax][ay][az][cx][cy][cz - 1][m] + WQz * V[ax][ay][az][cx][cy][cz - 1][m + 1];
+                                scratch.v(ax, ay, az, cx, cy, cz, m) =
+                                    QCz * scratch.v(ax, ay, az, cx, cy, cz - 1, m) +
+                                    WQz * scratch.v(ax, ay, az, cx, cy, cz - 1, m + 1);
                                 if (cz > 1)
-                                    V[ax][ay][az][cx][cy][cz][m] +=
+                                    scratch.v(ax, ay, az, cx, cy, cz, m) +=
                                         (cz - 1) * inv_2_zetaCD *
-                                        (V[ax][ay][az][cx][cy][cz - 2][m] - rho_over_zetaCD * V[ax][ay][az][cx][cy][cz - 2][m + 1]);
+                                        (scratch.v(ax, ay, az, cx, cy, cz - 2, m) -
+                                         rho_over_zetaCD * scratch.v(ax, ay, az, cx, cy, cz - 2, m + 1));
                                 if (az > 0)
-                                    V[ax][ay][az][cx][cy][cz][m] +=
-                                        az * inv_2_delta * V[ax][ay][az - 1][cx][cy][cz - 1][m + 1];
+                                    scratch.v(ax, ay, az, cx, cy, cz, m) +=
+                                        az * inv_2_delta * scratch.v(ax, ay, az - 1, cx, cy, cz - 1, m + 1);
                             }
                         }
                     }
@@ -997,7 +1092,7 @@ static void _eri_vrr(
 //
 // After this call, W[lAx][lAy][lAz][cx][cy][cz] = (lA lB | cx cy cz 0).
 static void _eri_hrr_ab(
-    double W[VRR_DIM][VRR_DIM][VRR_DIM][VRR_DIM][VRR_DIM][VRR_DIM],
+    EriScratch &scratch,
     const int lAx, const int lAy, const int lAz,
     const int lBx, const int lBy, const int lBz,
     const int lCDx, const int lCDy, const int lCDz,
@@ -1011,8 +1106,9 @@ static void _eri_hrr_ab(
                     for (int cx = 0; cx <= lCDx; ++cx)
                         for (int cy = 0; cy <= lCDy; ++cy)
                             for (int cz = 0; cz <= lCDz; ++cz)
-                                W[ax][ay][az][cx][cy][cz] =
-                                    W[ax][ay][az + 1][cx][cy][cz] + ABz * W[ax][ay][az][cx][cy][cz];
+                                scratch.h(ax, ay, az, cx, cy, cz) =
+                                    scratch.h(ax, ay, az + 1, cx, cy, cz) +
+                                    ABz * scratch.h(ax, ay, az, cx, cy, cz);
 
     // Phase 2: transfer lBy quanta (az range now [0, lAz])
     for (int ky = 0; ky < lBy; ++ky)
@@ -1022,8 +1118,9 @@ static void _eri_hrr_ab(
                     for (int cx = 0; cx <= lCDx; ++cx)
                         for (int cy = 0; cy <= lCDy; ++cy)
                             for (int cz = 0; cz <= lCDz; ++cz)
-                                W[ax][ay][az][cx][cy][cz] =
-                                    W[ax][ay + 1][az][cx][cy][cz] + ABy * W[ax][ay][az][cx][cy][cz];
+                                scratch.h(ax, ay, az, cx, cy, cz) =
+                                    scratch.h(ax, ay + 1, az, cx, cy, cz) +
+                                    ABy * scratch.h(ax, ay, az, cx, cy, cz);
 
     // Phase 3: transfer lBx quanta (ay range now [0, lAy])
     for (int kx = 0; kx < lBx; ++kx)
@@ -1033,8 +1130,9 @@ static void _eri_hrr_ab(
                     for (int cx = 0; cx <= lCDx; ++cx)
                         for (int cy = 0; cy <= lCDy; ++cy)
                             for (int cz = 0; cz <= lCDz; ++cz)
-                                W[ax][ay][az][cx][cy][cz] =
-                                    W[ax + 1][ay][az][cx][cy][cz] + ABx * W[ax][ay][az][cx][cy][cz];
+                                scratch.h(ax, ay, az, cx, cy, cz) =
+                                    scratch.h(ax + 1, ay, az, cx, cy, cz) +
+                                    ABx * scratch.h(ax, ay, az, cx, cy, cz);
 }
 
 // ─── 4-center ERI: single primitive quartet ──────────────────────────────────
@@ -1050,19 +1148,13 @@ static double _os_eri_primitive(
 {
     const int lABx = lAx + lBx, lABy = lAy + lBy, lABz = lAz + lBz;
     const int lCDx = lCx + lDx, lCDy = lCy + lDy, lCDz = lCz + lDz;
+    const int mmax = lABx + lABy + lABz + lCDx + lCDy + lCDz;
 
-    // Zero the needed sub-region of the thread-local VRR buffer
-    for (int ax = 0; ax <= lABx; ++ax)
-        for (int ay = 0; ay <= lABy; ++ay)
-            for (int az = 0; az <= lABz; ++az)
-                for (int cx = 0; cx <= lCDx; ++cx)
-                    for (int cy = 0; cy <= lCDy; ++cy)
-                        for (int cz = 0; cz <= lCDz; ++cz)
-                            for (int m = 0; m < MMAX_4C; ++m)
-                                _vrr_buf[ax][ay][az][cx][cy][cz][m] = 0.0;
+    EriScratch &scratch = _eri_scratch;
+    scratch.resize_for_quartet(lABx, lABy, lABz, lCDx, lCDy, lCDz, mmax);
 
-    // Build VRR table
-    _eri_vrr(ppAB, ppCD, lABx, lABy, lABz, lCDx, lCDy, lCDz, _vrr_buf);
+    // Build the quartet-sized VRR table in thread-local dynamic scratch.
+    _eri_vrr(ppAB, ppCD, lABx, lABy, lABz, lCDx, lCDy, lCDz, scratch);
 
     // Extract m=0 slice into HRR buffer and zero unused entries
     for (int ax = 0; ax <= lABx; ++ax)
@@ -1071,17 +1163,18 @@ static double _os_eri_primitive(
                 for (int cx = 0; cx <= lCDx; ++cx)
                     for (int cy = 0; cy <= lCDy; ++cy)
                         for (int cz = 0; cz <= lCDz; ++cz)
-                            _hrr_buf[ax][ay][az][cx][cy][cz] = _vrr_buf[ax][ay][az][cx][cy][cz][0];
+                            scratch.h(ax, ay, az, cx, cy, cz) =
+                                scratch.v(ax, ay, az, cx, cy, cz, 0);
 
-    // A→B HRR: modifies _hrr_buf in-place
-    _eri_hrr_ab(_hrr_buf, lAx, lAy, lAz, lBx, lBy, lBz, lCDx, lCDy, lCDz, ABx, ABy, ABz);
+    // A→B HRR: modifies the quartet-sized HRR scratch in-place.
+    _eri_hrr_ab(scratch, lAx, lAy, lAz, lBx, lBy, lBz, lCDx, lCDy, lCDz, ABx, ABy, ABz);
 
     // Extract C-side slice at (lAx, lAy, lAz) for C→D HRR
     double V0_CD[VRR_DIM][VRR_DIM][VRR_DIM] = {};
     for (int cx = 0; cx <= lCDx; ++cx)
         for (int cy = 0; cy <= lCDy; ++cy)
             for (int cz = 0; cz <= lCDz; ++cz)
-                V0_CD[cx][cy][cz] = _hrr_buf[lAx][lAy][lAz][cx][cy][cz];
+                V0_CD[cx][cy][cz] = scratch.h(lAx, lAy, lAz, cx, cy, cz);
 
     // C→D HRR reusing the existing _nuclear_hrr (same 3-phase sweep)
     return _nuclear_hrr(V0_CD, lCx, lCy, lCz, lDx, lDy, lDz, CDx, CDy, CDz);
@@ -1548,8 +1641,8 @@ Eigen::MatrixXd HartreeFock::ObaraSaika::_compute_2e_fock(
 
     const std::size_t npairs = shell_pairs.size();
 
-    // Disjoint writes per (p,q) pair → lock-free parallelism.
-    // thread_local _vrr_buf / _hrr_buf give each thread private scratch space.
+    // The contracted ERI kernel uses thread-local quartet-sized scratch, while
+    // permutation scattering uses atomic stores to keep the shared tensor race-free.
 #pragma omp parallel for schedule(dynamic)
     for (std::size_t p = 0; p < npairs; ++p)
     {
@@ -1865,8 +1958,8 @@ std::vector<double> HartreeFock::ObaraSaika::_compute_2e(
 
     const std::size_t npairs = shell_pairs.size();
 
-    // Disjoint writes per (p,q) pair → lock-free parallelism.
-    // thread_local _vrr_buf / _hrr_buf give each thread private scratch space.
+    // The contracted ERI kernel uses thread-local quartet-sized scratch, while
+    // permutation scattering uses atomic stores to keep the shared tensor race-free.
 #pragma omp parallel for schedule(dynamic)
     for (std::size_t p = 0; p < npairs; ++p)
     {

--- a/src/io/io.cpp
+++ b/src/io/io.cpp
@@ -45,7 +45,7 @@ namespace HartreeFock::IO
         return line;
     }
 
-    static bool toBool(const std::string &parsedString)
+    static std::expected<bool, std::string> toBool(const std::string &parsedString)
     {
         std::string key = toLower(parsedString);
 
@@ -59,10 +59,10 @@ namespace HartreeFock::IO
             return false;
         }
 
-        throw std::invalid_argument("Invalid boolean value: " + parsedString);
+        return std::unexpected("Invalid boolean value: " + parsedString);
     }
 
-    static std::vector<HartreeFock::IrrepCount> parse_irrep_count_list(
+    static std::expected<std::vector<HartreeFock::IrrepCount>, std::string> parse_irrep_count_list(
         std::istringstream &iss,
         const std::string &keyword)
     {
@@ -79,43 +79,60 @@ namespace HartreeFock::IO
                 irrep = token.substr(0, sep);
                 count_text = token.substr(sep + 1);
                 if (irrep.empty() || count_text.empty())
-                    throw std::invalid_argument(keyword + " expects irrep/count pairs");
+                    return std::unexpected(keyword + " expects irrep/count pairs");
             }
             else
             {
                 irrep = token;
                 if (!(iss >> count_text))
-                    throw std::invalid_argument(keyword + " expects irrep/count pairs");
+                    return std::unexpected(keyword + " expects irrep/count pairs");
             }
 
             trim(irrep);
             trim(count_text);
             if (irrep.empty() || count_text.empty())
-                throw std::invalid_argument(keyword + " expects irrep/count pairs");
+                return std::unexpected(keyword + " expects irrep/count pairs");
 
-            const int count = std::stoi(count_text);
+            int count = 0;
+            try
+            {
+                count = std::stoi(count_text);
+            }
+            catch (const std::exception &)
+            {
+                return std::unexpected(keyword + " counts must be integers");
+            }
             if (count < 0)
-                throw std::invalid_argument(keyword + " counts must be non-negative");
+                return std::unexpected(keyword + " counts must be non-negative");
 
             counts.push_back({irrep, count});
         }
 
         if (counts.empty())
-            throw std::invalid_argument(keyword + " requires at least one irrep/count pair");
+            return std::unexpected(keyword + " requires at least one irrep/count pair");
         return counts;
     }
 
-    static std::vector<int> parse_int_list(
+    static std::expected<std::vector<int>, std::string> parse_int_list(
         std::istringstream &iss,
         const std::string &keyword)
     {
         std::vector<int> values;
-        int value = 0;
-        while (iss >> value)
-            values.push_back(value);
+        std::string token;
+        while (iss >> token)
+        {
+            try
+            {
+                values.push_back(std::stoi(token));
+            }
+            catch (const std::exception &)
+            {
+                return std::unexpected(keyword + " requires integer values");
+            }
+        }
 
         if (values.empty())
-            throw std::invalid_argument(keyword + " requires at least one integer");
+            return std::unexpected(keyword + " requires at least one integer");
         return values;
     }
 
@@ -502,8 +519,6 @@ namespace HartreeFock::IO
             {
                 {"scf_type", [&scf](const std::string &value)
                  { scf._scf = map_string_enum<HartreeFock::SCFType>(value); }},
-                {"use_diis", [&scf](const std::string &value)
-                 { scf._use_DIIS = toBool(value); }},
                 {"diis_dim", [&scf](const std::string &value)
                  { scf._DIIS_dim = std::stoi(value); }},
                 {"max_cycles", [&scf](const std::string &value)
@@ -523,8 +538,6 @@ namespace HartreeFock::IO
                  { integral._tol_eri = std::stod(value); }},
                 {"guess", [&scf](const std::string &value)
                  { scf._guess = map_string_enum<HartreeFock::SCFGuess>(value); }},
-                {"save_checkpoint", [&scf](const std::string &value)
-                 { scf._save_checkpoint = toBool(value); }},
                 {"level_shift", [&scf](const std::string &value)
                  { scf._level_shift = std::stod(value); }},
                 {"diis_restart", [&scf](const std::string &value)
@@ -549,10 +562,6 @@ namespace HartreeFock::IO
                  { active_space.max_holes = std::stoi(v); }},
                 {"max_elec", [&active_space](const std::string &v)
                  { active_space.max_elec = std::stoi(v); }},
-                {"mcscf_debug_numeric_newton", [&active_space](const std::string &v)
-                 { active_space.mcscf_debug_numeric_newton = toBool(v); }},
-                {"mcscf_debug_commutator_rhs", [&active_space](const std::string &v)
-                 { active_space.mcscf_debug_commutator_rhs = toBool(v); }},
                 {"mcscf_max_iter", [&active_space](const std::string &v)
                  { active_space.mcscf_max_iter = static_cast<unsigned int>(std::stoi(v)); }},
                 {"mcscf_micro_per_macro", [&active_space](const std::string &v)
@@ -590,48 +599,55 @@ namespace HartreeFock::IO
 
             if (key == "core_irrep_counts")
             {
-                try
-                {
-                    auto parsed = parse_irrep_count_list(_iss, key);
-                    active_space.core_irrep_counts.insert(
-                        active_space.core_irrep_counts.end(),
-                        parsed.begin(),
-                        parsed.end());
-                }
-                catch (const std::exception &e)
-                {
-                    return std::unexpected(std::string("Error parsing scf '") + key + "': " + e.what());
-                }
+                auto parsed = parse_irrep_count_list(_iss, key);
+                if (!parsed)
+                    return std::unexpected(std::string("Error parsing scf '") + key + "': " + parsed.error());
+                active_space.core_irrep_counts.insert(
+                    active_space.core_irrep_counts.end(),
+                    parsed->begin(),
+                    parsed->end());
                 continue;
             }
 
             if (key == "active_irrep_counts")
             {
-                try
-                {
-                    auto parsed = parse_irrep_count_list(_iss, key);
-                    active_space.active_irrep_counts.insert(
-                        active_space.active_irrep_counts.end(),
-                        parsed.begin(),
-                        parsed.end());
-                }
-                catch (const std::exception &e)
-                {
-                    return std::unexpected(std::string("Error parsing scf '") + key + "': " + e.what());
-                }
+                auto parsed = parse_irrep_count_list(_iss, key);
+                if (!parsed)
+                    return std::unexpected(std::string("Error parsing scf '") + key + "': " + parsed.error());
+                active_space.active_irrep_counts.insert(
+                    active_space.active_irrep_counts.end(),
+                    parsed->begin(),
+                    parsed->end());
                 continue;
             }
 
             if (key == "mo_permutation")
             {
-                try
-                {
-                    active_space.mo_permutation = parse_int_list(_iss, key);
-                }
-                catch (const std::exception &e)
-                {
-                    return std::unexpected(std::string("Error parsing scf '") + key + "': " + e.what());
-                }
+                auto parsed = parse_int_list(_iss, key);
+                if (!parsed)
+                    return std::unexpected(std::string("Error parsing scf '") + key + "': " + parsed.error());
+                active_space.mo_permutation = std::move(*parsed);
+                continue;
+            }
+
+            if (key == "use_diis" || key == "save_checkpoint" ||
+                key == "mcscf_debug_numeric_newton" || key == "mcscf_debug_commutator_rhs")
+            {
+                if (!(_iss >> value))
+                    return std::unexpected("Missing value for scf keyword: " + key);
+
+                auto parsed = toBool(value);
+                if (!parsed)
+                    return std::unexpected(std::string("Error parsing scf '") + key + "': " + parsed.error());
+
+                if (key == "use_diis")
+                    scf._use_DIIS = *parsed;
+                else if (key == "save_checkpoint")
+                    scf._save_checkpoint = *parsed;
+                else if (key == "mcscf_debug_numeric_newton")
+                    active_space.mcscf_debug_numeric_newton = *parsed;
+                else
+                    active_space.mcscf_debug_commutator_rhs = *parsed;
                 continue;
             }
 
@@ -696,18 +712,6 @@ namespace HartreeFock::IO
                  {
                      dft._correlation = HartreeFock::XCCorrelationFunctional::Custom;
                      dft._correlation_id = std::stoi(value);
-                 }},
-                {"use_sao_blocking", [&dft](const std::string &value)
-                 {
-                     dft._use_sao_blocking = toBool(value);
-                 }},
-                {"print_grid_summary", [&dft](const std::string &value)
-                 {
-                     dft._print_grid_summary = toBool(value);
-                 }},
-                {"save_checkpoint", [&dft](const std::string &value)
-                 {
-                     dft._save_checkpoint = toBool(value);
                  }}};
 
         for (const std::string &line : lines)
@@ -719,6 +723,21 @@ namespace HartreeFock::IO
                 return std::unexpected("Missing value for dft keyword: " + key);
 
             key = toLower(key);
+
+            if (key == "use_sao_blocking" || key == "print_grid_summary" || key == "save_checkpoint")
+            {
+                auto parsed = toBool(value);
+                if (!parsed)
+                    return std::unexpected(std::string("Error parsing dft '") + key + "': " + parsed.error());
+
+                if (key == "use_sao_blocking")
+                    dft._use_sao_blocking = *parsed;
+                else if (key == "print_grid_summary")
+                    dft._print_grid_summary = *parsed;
+                else
+                    dft._save_checkpoint = *parsed;
+                continue;
+            }
 
             if (auto it = _dft_map.find(key); it != _dft_map.end())
             {
@@ -784,8 +803,6 @@ namespace HartreeFock::IO
                  { geom._type = map_string_enum<HartreeFock::CoordType>(value); }},
                 {"coord_units", [&geom](const std::string &value)
                  { geom._units = map_string_enum<HartreeFock::Units>(value); }},
-                {"use_symm", [&geom](const std::string &value)
-                 { geom._use_symm = toBool(value); }},
                 {"opt_coords", [&opt_coords](const std::string &value)
                  { opt_coords = map_string_enum<HartreeFock::OptCoords>(value); }},
                 {"imag_follow_step", [&imag_follow_step](const std::string &value)
@@ -802,6 +819,15 @@ namespace HartreeFock::IO
             }
 
             key = toLower(key);
+
+            if (key == "use_symm")
+            {
+                auto parsed = toBool(value);
+                if (!parsed)
+                    return std::unexpected(std::string("Error parsing geom '") + key + "': " + parsed.error());
+                geom._use_symm = *parsed;
+                continue;
+            }
 
             // Find the (key, value) pair
             if (auto it = _geom_map.find(key); it != _geom_map.end())
@@ -1029,9 +1055,6 @@ namespace HartreeFock::IO
             }
         }
 
-        molecule.nelectrons = std::accumulate(molecule.atomic_numbers.begin(),
-                                              molecule.atomic_numbers.end(), 0) -
-                              molecule.charge;
         return {};
     }
 
@@ -1099,9 +1122,6 @@ namespace HartreeFock::IO
             molecule.coordinates(i, 1) = _y;
             molecule.coordinates(i, 2) = _z;
         }
-
-        // Now set other variables
-        molecule.nelectrons = std::accumulate(molecule.atomic_numbers.begin(), molecule.atomic_numbers.end(), 0) - molecule.charge;
 
         return {};
     }

--- a/src/opt/geomopt.cpp
+++ b/src/opt/geomopt.cpp
@@ -97,16 +97,29 @@ static Eigen::VectorXd _run_sp_gradient_hf(HartreeFock::Calculator &calc)
         if (auto corr_res = HartreeFock::Correlation::run_rmp2(calc, shell_pairs); !corr_res)
             throw std::runtime_error("GeomOpt RMP2 failed: " + corr_res.error());
         calc._total_energy += calc._correlation_energy;
-        grad_mat = HartreeFock::Gradient::compute_rmp2_gradient(calc, shell_pairs);
+        auto grad_res = HartreeFock::Gradient::compute_rmp2_gradient(calc, shell_pairs);
+        if (!grad_res)
+            throw std::runtime_error("GeomOpt RMP2 gradient failed: " + grad_res.error());
+        grad_mat = std::move(*grad_res);
     }
     else if (calc._correlation == HartreeFock::PostHF::UMP2)
     {
         throw std::runtime_error("GeomOpt UMP2 gradient is not implemented");
     }
     else if (calc._scf._scf == HartreeFock::SCFType::UHF)
-        grad_mat = HartreeFock::Gradient::compute_uhf_gradient(calc, shell_pairs);
+    {
+        auto grad_res = HartreeFock::Gradient::compute_uhf_gradient(calc, shell_pairs);
+        if (!grad_res)
+            throw std::runtime_error("GeomOpt UHF gradient failed: " + grad_res.error());
+        grad_mat = std::move(*grad_res);
+    }
     else
-        grad_mat = HartreeFock::Gradient::compute_rhf_gradient(calc, shell_pairs);
+    {
+        auto grad_res = HartreeFock::Gradient::compute_rhf_gradient(calc, shell_pairs);
+        if (!grad_res)
+            throw std::runtime_error("GeomOpt RHF gradient failed: " + grad_res.error());
+        grad_mat = std::move(*grad_res);
+    }
 
     calc._gradient = grad_mat;
 

--- a/src/post_hf/casscf/casscf.cpp
+++ b/src/post_hf/casscf/casscf.cpp
@@ -3,6 +3,7 @@
 #include "io/logging.h"
 #include "post_hf/casscf.h"
 #include "post_hf/casscf/ci.h"
+#include "post_hf/casscf/casscf_utils.h"
 #include "post_hf/casscf/orbital.h"
 #include "post_hf/casscf/rdm.h"
 #include "post_hf/casscf/response.h"
@@ -233,20 +234,6 @@ namespace
         for (int i = 0; i < n; ++i)
             delta = std::max(delta, std::abs(current(i) - previous.energies(i)));
         return delta;
-    }
-
-    Eigen::MatrixXd as_single_column_matrix(const Eigen::VectorXd &vec)
-    {
-        Eigen::MatrixXd mat(vec.size(), 1);
-        mat.col(0) = vec;
-        return mat;
-    }
-
-    Eigen::VectorXd single_weight(double weight)
-    {
-        Eigen::VectorXd weights(1);
-        weights(0) = weight;
-        return weights;
     }
 
     void accumulate_weighted_tensor(
@@ -603,7 +590,10 @@ namespace HartreeFock::Correlation::CASSCF
                     break;
                 }
 
-            C = reorder_mo_coefficients(C, selection->permutation);
+            auto reordered = reorder_mo_coefficients(C, selection->permutation);
+            if (!reordered)
+                return std::unexpected(reordered.error());
+            C = std::move(*reordered);
             if (!all_mo_irr.empty())
             {
                 std::vector<int> permuted_irr(all_mo_irr.size());

--- a/src/post_hf/casscf/casscf_utils.h
+++ b/src/post_hf/casscf/casscf_utils.h
@@ -1,0 +1,23 @@
+#ifndef HF_POSTHF_CASSCF_UTILS_H
+#define HF_POSTHF_CASSCF_UTILS_H
+
+#include <Eigen/Core>
+
+namespace HartreeFock::Correlation::CASSCF
+{
+    inline Eigen::MatrixXd as_single_column_matrix(const Eigen::VectorXd &vec)
+    {
+        Eigen::MatrixXd mat(vec.size(), 1);
+        mat.col(0) = vec;
+        return mat;
+    }
+
+    inline Eigen::VectorXd single_weight(double weight)
+    {
+        Eigen::VectorXd weights(1);
+        weights(0) = weight;
+        return weights;
+    }
+} // namespace HartreeFock::Correlation::CASSCF
+
+#endif // HF_POSTHF_CASSCF_UTILS_H

--- a/src/post_hf/casscf/rdm.cpp
+++ b/src/post_hf/casscf/rdm.cpp
@@ -9,36 +9,10 @@ namespace
 
     using HartreeFock::Correlation::CASSCF::build_det_lookup;
     using HartreeFock::Correlation::CASSCF::build_spin_dets;
-    using HartreeFock::Correlation::CASSCF::count_occupied_below;
+    using HartreeFock::Correlation::CASSCF::apply_annihilation;
+    using HartreeFock::Correlation::CASSCF::apply_creation;
     using HartreeFock::Correlation::CASSCFInternal::CIString;
     using HartreeFock::Correlation::CASSCFInternal::low_bit_mask;
-    using HartreeFock::Correlation::CASSCFInternal::single_bit_mask;
-
-    struct FermionOpResult
-    {
-        CIString det = 0;
-        double phase = 0.0;
-        bool valid = false;
-    };
-
-    // These helpers carry the fermionic phase from the number of occupied orbitals
-    // below the operator index, matching the determinant ordering used everywhere
-    // else in the CASSCF string utilities.
-    inline FermionOpResult apply_annihilation(CIString det, int orb)
-    {
-        const CIString bit = single_bit_mask(orb);
-        if (!(det & bit))
-            return {};
-        return {det ^ bit, (count_occupied_below(det, orb) % 2 == 0) ? 1.0 : -1.0, true};
-    }
-
-    inline FermionOpResult apply_creation(CIString det, int orb)
-    {
-        const CIString bit = single_bit_mask(orb);
-        if (det & bit)
-            return {};
-        return {det | bit, (count_occupied_below(det, orb) % 2 == 0) ? 1.0 : -1.0, true};
-    }
 
     template <typename Fn>
     void for_each_set_bit(CIString bits, Fn &&fn)

--- a/src/post_hf/casscf/response.cpp
+++ b/src/post_hf/casscf/response.cpp
@@ -1,6 +1,7 @@
 #include "post_hf/casscf/response.h"
 
 #include "post_hf/casscf/ci.h"
+#include "post_hf/casscf/casscf_utils.h"
 #include "post_hf/casscf/orbital.h"
 #include "post_hf/casscf/rdm.h"
 #include "post_hf/casscf/strings.h"
@@ -17,6 +18,7 @@ namespace
     using HartreeFock::Correlation::CASSCF::build_det_lookup;
     using HartreeFock::Correlation::CASSCF::build_spin_dets;
     using HartreeFock::Correlation::CASSCF::build_ci_orbital_gradient_correction;
+    using HartreeFock::Correlation::CASSCF::as_single_column_matrix;
     using HartreeFock::Correlation::CASSCF::compute_2rdm_bilinear;
     using HartreeFock::Correlation::CASSCF::compute_Q_matrix;
     using HartreeFock::Correlation::CASSCF::count_occupied_below;
@@ -27,6 +29,7 @@ namespace
     using HartreeFock::Correlation::CASSCF::ResponseRHSMode;
     using HartreeFock::Correlation::CASSCF::RotPair;
     using HartreeFock::Correlation::CASSCF::StateAveragedCoupledRoot;
+    using HartreeFock::Correlation::CASSCF::single_weight;
     using HartreeFock::Correlation::CASSCF::CIDeterminantSpace;
     using HartreeFock::Correlation::CASSCF::CISigmaApplier;
     using HartreeFock::Correlation::CASSCF::OrbitalHessianContext;
@@ -35,31 +38,6 @@ namespace
     using HartreeFock::Correlation::CASSCFInternal::single_bit_mask;
     using HartreeFock::Correlation::CASSCFInternal::CIString;
     using HartreeFock::Correlation::CASSCFInternal::ActiveIntegralCache;
-
-    struct FermionOpResult
-    {
-        HartreeFock::Correlation::CASSCFInternal::CIString det = 0;
-        double phase = 0.0;
-        bool valid = false;
-    };
-
-    // These mirror the string-layer operators so the response code uses the same
-    // determinant phase convention as the sigma and RDM builders.
-    inline FermionOpResult apply_annihilation(HartreeFock::Correlation::CASSCFInternal::CIString det, int orb)
-    {
-        const auto bit = single_bit_mask(orb);
-        if (!(det & bit))
-            return {};
-        return {det ^ bit, (count_occupied_below(det, orb) % 2 == 0) ? 1.0 : -1.0, true};
-    }
-
-    inline FermionOpResult apply_creation(HartreeFock::Correlation::CASSCFInternal::CIString det, int orb)
-    {
-        const auto bit = single_bit_mask(orb);
-        if (det & bit)
-            return {};
-        return {det | bit, (count_occupied_below(det, orb) % 2 == 0) ? 1.0 : -1.0, true};
-    }
 
     std::size_t idx4(int p, int q, int r, int s, int n_act)
     {
@@ -207,20 +185,6 @@ namespace
         // (H - E0) c1 + Q sigma = 0, with Q enforcing orthogonality to c0.
         const Eigen::VectorXd rhs = -project_orthogonal(sigma, c0);
         return project_orthogonal(rhs - (hc1 - E0 * c1), c0);
-    }
-
-    Eigen::MatrixXd as_single_column_matrix(const Eigen::VectorXd &vec)
-    {
-        Eigen::MatrixXd mat(vec.size(), 1);
-        mat.col(0) = vec;
-        return mat;
-    }
-
-    Eigen::VectorXd single_weight(double weight)
-    {
-        Eigen::VectorXd weights(1);
-        weights(0) = weight;
-        return weights;
     }
 
     struct CoupledResidualEvaluation

--- a/src/post_hf/casscf/strings.cpp
+++ b/src/post_hf/casscf/strings.cpp
@@ -65,6 +65,7 @@ namespace HartreeFock::Correlation::CASSCF
             int begin,
             int end)
         {
+            constexpr double energy_tie_tol = 1e-10;
             std::vector<int> order;
             order.reserve(static_cast<std::size_t>(std::max(0, end - begin)));
             for (int i = begin; i < end; ++i)
@@ -73,7 +74,7 @@ namespace HartreeFock::Correlation::CASSCF
             {
                 const double ea = mo_energies(a);
                 const double eb = mo_energies(b);
-                if (ea != eb)
+                if (std::abs(ea - eb) >= energy_tie_tol)
                     return ea < eb;
                 return a < b;
             });
@@ -416,21 +417,21 @@ namespace HartreeFock::Correlation::CASSCF
         return selection;
     }
 
-    Eigen::MatrixXd reorder_mo_coefficients(
+    std::expected<Eigen::MatrixXd, std::string> reorder_mo_coefficients(
         const Eigen::MatrixXd &mo_coefficients,
         const std::vector<int> &permutation)
     {
         if (mo_coefficients.cols() == 0 || permutation.empty())
             return mo_coefficients;
         if (static_cast<int>(permutation.size()) != mo_coefficients.cols())
-            throw std::invalid_argument("MO permutation size does not match the coefficient matrix");
+            return std::unexpected(std::string("MO permutation size does not match the coefficient matrix"));
 
         Eigen::MatrixXd reordered(mo_coefficients.rows(), mo_coefficients.cols());
         for (int i = 0; i < static_cast<int>(permutation.size()); ++i)
         {
             const int src = permutation[static_cast<std::size_t>(i)];
             if (src < 0 || src >= mo_coefficients.cols())
-                throw std::invalid_argument("MO permutation contains an out-of-range index");
+                return std::unexpected(std::string("MO permutation contains an out-of-range index"));
             reordered.col(i) = mo_coefficients.col(src);
         }
         return reordered;

--- a/src/post_hf/casscf/strings.h
+++ b/src/post_hf/casscf/strings.h
@@ -64,7 +64,7 @@ namespace HartreeFock::Correlation::CASSCF
         const std::vector<int> &mo_permutation = {});
 
     // Apply a column permutation to the MO coefficient matrix.
-    Eigen::MatrixXd reorder_mo_coefficients(
+    std::expected<Eigen::MatrixXd, std::string> reorder_mo_coefficients(
         const Eigen::MatrixXd &mo_coefficients,
         const std::vector<int> &permutation);
 

--- a/src/scf/sad.cpp
+++ b/src/scf/sad.cpp
@@ -300,8 +300,6 @@ namespace
         atom._molecule._is_bohr     = true;
         atom._molecule.charge       = 0;
         atom._molecule.multiplicity = mult;
-        atom._molecule.nelectrons   = static_cast<unsigned int>(Z);
-
         // Basis
         atom._shells = atomic_basis;
 


### PR DESCRIPTION
Resolve the major and minor issues from docs/BUG_REPORT.md across the integrals, gradient, parser, CASSCF, and DFT paths.

Integral and core model fixes:

- Replace the large fixed thread-local ERI scratch arrays with dynamically sized per-thread scratch storage.
- Protect ERI permutation writes with OpenMP atomic updates to avoid concurrent non-atomic stores.
- Correct _bohr_to_angstrom() to return a matrix and add a post-initialization assertion for nuclear repulsion.
- Remove the unused Molecule::nelectrons field and its stale assignments.
- Share the SCF max-cycle tier table between automatic setup and fallback lookup.

Gradient and parser fixes:

- Convert the flagged fallible gradient and parser helpers to std::expected-based error propagation.
- Update gradient callers in the driver, geometry optimizer, and Hessian code to handle expected failures explicitly.
- Add Schwarz screening and canonical shell-pair permutation folding to the RHF/UHF/RMP2 ERI gradient loops.

CASSCF and DFT cleanup:

- Move shared CASSCF single-root helpers into casscf_utils.h and reuse the shared fermionic operator utilities.
- Return std::expected from reorder_mo_coefficients and use tolerance-based orbital-energy tie handling.
- Parallelize the DFT Vxc grid accumulation with thread-local alpha/beta matrices.
- Stabilize basis-function view storage and clean up the bug-report nitpicks.

Verification:

- cmake --build build --target hartree-fock
- cmake --build build --target planck-casscf-internal
- ./build/planck-casscf-internal
- OMP_NUM_THREADS=4 h2_cas22_sto3g and water_cas44_sto3g CASSCF regressions matched normalized references
- OMP_NUM_THREADS=1 water_rhf_gradient and h2_rmp2_gradient completed
- cmake --build build --target CMakeFiles/planck-dft.dir/src/dft/ks_matrix.cpp.o
- git diff --cached --check