### PR TITLE
Docs: add Cart→Sph MO transformation section; fix basis name case handling

### DIFF
--- a/docs/PLANCK_TEACHING_GUIDE.md
+++ b/docs/PLANCK_TEACHING_GUIDE.md
@@ -2606,7 +2606,7 @@ by projecting each normal mode onto the SAO blocks and determining its irrep.
 
 ## 18. Kohn-Sham Density Functional Theory
 
-### 18.1 The Kohn-Sham Equations
+### The Kohn-Sham Equations
 
 Kohn-Sham DFT maps the interacting many-electron problem onto a fictitious system of non-interacting electrons moving in an effective potential \(v_s(\mathbf r)\) that yields the same ground-state density as the real system. The total electronic energy is:
 
@@ -2622,7 +2622,7 @@ F^{KS}_{\mu\nu} = h_{\mu\nu} + J_{\mu\nu} + V^{xc}_{\mu\nu}
 
 This is identical in structure to the HF Fock matrix, with the HF exchange matrix \(K\) replaced by the XC potential matrix \(V^{xc}\). Planck reuses the HF SCF loop for KS-DFT: the only structural difference is how the two-electron contribution to the Fock matrix is assembled (Coulomb only, no exchange, plus \(V^{xc}\) from numerical integration).
 
-### 18.2 Exchange-Correlation Functional Families
+### Exchange-Correlation Functional Families
 
 #### LDA (Local Density Approximation)
 
@@ -2656,7 +2656,7 @@ GGA functionals satisfy more exact constraints than LDA and generally give bette
 | PW91 (`gga_x_pw91`) | PW91 | PW91 |
 | PBE (`gga_x_pbe`) | PBE (`gga_c_pbe`) | PBE (default) |
 
-### 18.3 Numerical Integration: Molecular Grid
+### Numerical Integration: Molecular Grid
 
 Because \(V^{xc}_{\mu\nu}\) has no analytic closed form, it is evaluated numerically:
 
@@ -2702,7 +2702,7 @@ w_i(\mathbf r) = \frac{P_i(\mathbf r)}{\sum_k P_k(\mathbf r)} \cdot w_i^{radial-
 | `Fine` | 5 | 26 / 194 / 302 / 434 / 302 |
 | `UltraFine` | 6 | 50 / 302 / 434 / 590 / 434 |
 
-### 18.4 AO Evaluation on the Grid
+### AO Evaluation on the Grid
 
 `AOGridEvaluation` (declared in `src/dft/ao_grid.h`) stores the AO values and
 gradients at every grid point in a matrix of shape `(N_grid, N_AO)`. These are
@@ -2710,7 +2710,7 @@ computed once before the KS iteration begins. For each grid point and each AO
 \(\phi_\mu\), the value and Cartesian gradient components are evaluated from the
 contracted shell data in the `Basis` object.
 
-### 18.5 Density and XC Evaluation
+### Density and XC Evaluation
 
 Given the density matrix \(P_{\mu\nu}\), the electron density at grid point \(g\) is:
 
@@ -2726,7 +2726,7 @@ The libxc library (`src/dft/base/wrapper.h`) is then called with the density (an
 E_{xc} = \sum_g w_g\, \rho(\mathbf r_g)\, \varepsilon_{xc}(\mathbf r_g)
 \]
 
-### 18.6 XC Matrix Assembly
+### XC Matrix Assembly
 
 The XC potential matrix element is:
 
@@ -2737,7 +2737,7 @@ V^{xc}_{\mu\nu} = \sum_g w_g\, v_{\rho,g}\, \phi_\mu(\mathbf r_g)\, \phi_\nu(\ma
 
 The second term (present only for GGA) involves the density gradient and the AO gradients on the grid. Both terms are assembled in `assemble_xc_matrix` (`src/dft/ks_matrix.cpp`).
 
-### 18.7 KS-DFT SCF Loop
+### KS-DFT SCF Loop
 
 The KS SCF loop in `DFT::Driver::run` follows the same outer structure as the HF loop:
 
@@ -2752,7 +2752,7 @@ The KS SCF loop in `DFT::Driver::run` follows the same outer structure as the HF
 
 The `KSPotentialMatrices` struct holds the Coulomb, XC-alpha, and XC-beta matrices and their sum (the full KS two-electron+XC potential). For RKS the alpha and beta components are identical; for UKS they differ because \(\rho_\alpha \neq \rho_\beta\).
 
-### 18.8 DFT Code Map
+### DFT Code Map
 
 | Task | File | Function/struct |
 |---|---|---|
@@ -2775,7 +2775,7 @@ The `KSPotentialMatrices` struct holds the Coulomb, XC-alpha, and XC-beta matric
 
 After SCF convergence Planck computes several molecular properties from the converged density matrix.  All are printed automatically (or under `verbosity verbose`) without additional input; no extra keywords are needed.  This section covers the theory behind each property and the code path that evaluates it.
 
-### 19.1 Mulliken Population Analysis
+### Mulliken Population Analysis
 
 **Theory**
 
@@ -2817,7 +2817,7 @@ The function then iterates over `basis._basis_functions`, accumulates `gross[μ]
 
 Population analysis is triggered when `_output._print_populations` is set or `verbosity` is `verbose` / `debug` (see `log_population_report` in `src/driver.cpp:71`).
 
-### 19.2 Electric Dipole Moment
+### Electric Dipole Moment
 
 **Theory**
 
@@ -2851,7 +2851,7 @@ M^{(0)}_{0,0} = S_{00} = \sqrt{\frac{\pi}{\zeta}}\,e^{-\alpha_a\alpha_b|A-B|^2/\
 
 The function `_compute_multipole_matrices` in `os.cpp` assembles the three \(N_b \times N_b\) dipole matrices (one per Cartesian component \(x,y,z\)) and the six independent upper-triangle elements of the raw quadrupole matrix, parallelised over shell pairs with OpenMP.
 
-### 19.3 Traceless Quadrupole Moment
+### Traceless Quadrupole Moment
 
 **Theory**
 
@@ -2882,7 +2882,7 @@ Q_xy = 1.5 * raw_xy;          // off-diagonal scaled by 3/2
 
 Both the dipole and quadrupole moments use the nuclear frame origin \(\mathbf{o} = \mathbf{0}\) (atomic units) as passed by `log_multipole_report` in `src/driver.cpp:52`.
 
-### 19.4 RMP2 Natural Orbitals
+### RMP2 Natural Orbitals
 
 **Theory**
 
@@ -2922,7 +2922,7 @@ For the reference wavefunction alone, \(\gamma_{ii} = 2\) for occupied and \(\ga
 4. Diagonalises via `Eigen::SelfAdjointEigenSolver`; sorts eigenvalues in descending order.
 5. Returns a `NaturalOrbitalResult` containing `occupations` and `coefficients_mo` (the transformation \(U\)) which the logger formats and prints.
 
-### 19.5 MO Symmetry Labels
+### MO Symmetry Labels
 
 **Theory**
 
@@ -2953,6 +2953,70 @@ The irrep with the largest projection coefficient (closest to 1.0) is assigned.
 - **Component-norm ratio**: because different Cartesian functions within the same shell (e.g. \(d_{xx}\) vs \(d_{xy}\)) carry different normalisation constants, each matrix element is corrected by \(\mathtt{norm\_target}/\mathtt{norm\_source}\).
 
 The full assign pipeline (`assign_mo_symmetry` in `mo_symmetry.cpp`) loops over all symmetry operations from libmsym, accumulates the projection coefficients, and returns a `std::vector<std::string>` of irrep labels (one per MO per spin channel).
+
+### Cartesian-to-Spherical MO Transformation
+
+**Why it is needed**
+
+Planck's integral engine and SCF solver work exclusively in the Cartesian Gaussian basis.  For angular momentum \(L\), there are \((L+1)(L+2)/2\) Cartesian basis functions (e.g. 6 for \(d\), 10 for \(f\)) but only \(2L+1\) real spherical harmonics.  libmsym — the external library used to assign irrep labels — requires the basis functions presented to it to be real spherical harmonics.  The MO coefficients that come out of the SCF are therefore in the Cartesian basis and must be transformed before they can be passed to libmsym.
+
+**The transformation matrix**
+
+For each shell of angular momentum \(L\), every real spherical harmonic \(Y_L^m\) with \(m = -L,\ldots,+L\) can be written as a fixed linear combination of the \((L+1)(L+2)/2\) Cartesian monomials:
+
+\[
+Y_L^m(\mathbf r) = \sum_{l_x+l_y+l_z=L} T^{(L)}_{m,\,(l_x l_y l_z)}\; x^{l_x} y^{l_y} z^{l_z} e^{-\alpha r^2}
+\]
+
+These coefficients are purely geometric and tabulated analytically.  For a basis with shells \(s = 1,\ldots,N_{sh}\), the per-shell matrices are assembled into a block-diagonal transformation matrix
+
+\[
+T^+ \in \mathbb{R}^{N_{sph} \times N_{cart}}, \qquad N_{sph} = \sum_s (2L_s+1), \quad N_{cart} = \sum_s \frac{(L_s+1)(L_s+2)}{2}
+\]
+
+where the \(s\)-th diagonal block \(T^+_s \in \mathbb{R}^{(2L_s+1)\times n_{cart,s}}\) is the pseudoinverse \((T_s^\top T_s)^{-1} T_s^\top\) of the Cartesian-to-spherical expansion matrix \(T_s\).  The pseudoinverse discards the "extra" \(r^2\)-contaminated subspace that Cartesian Gaussians span for \(L \geq 2\).
+
+**Applying the transformation**
+
+Given the \(N_{cart} \times N_{MO}\) matrix \(\mathbf C\) of Cartesian MO coefficients, the spherical-basis coefficients are
+
+\[
+\mathbf C_{sph} = T^+\, \mathbf C \qquad (N_{sph} \times N_{MO})
+\]
+
+Each column of \(\mathbf C_{sph}\) is then a set of real-spherical-harmonic expansion coefficients for one MO.
+
+**Where the coefficients come from (hardcoded tables)**
+
+`cart_to_sph_block(L)` in `src/symmetry/mo_symmetry.cpp` (line 499) returns the analytical block for each \(L\):
+
+| \(L\) | Cartesian functions | Spherical harmonics | Extra (discarded) |
+|--------|---------------------|---------------------|-------------------|
+| 0 (S)  | 1                   | 1                   | 0                 |
+| 1 (P)  | 3                   | 3                   | 0                 |
+| 2 (D)  | 6                   | 5                   | 1 (\(r^2\) contamination) |
+| 3 (F)  | 10                  | 7                   | 3                 |
+| 4 (G)  | 15                  | 9                   | 6                 |
+| 5 (H)  | 21                  | 11                  | 10                |
+
+For \(L \leq 1\) the Cartesian and spherical spaces are identical and \(T^+\) is simply a (possibly trivial) reordering matrix.
+
+**Putting it all together: the classify lambda**
+
+`assign_mo_symmetry` (starting at line 1300 of `mo_symmetry.cpp`) defines a `classify` lambda that:
+
+1. Multiplies `T_cs * C` to produce `C_sph` — the spherical-basis MO matrix (line 1305).
+2. Reorders the rows of `C_sph` from Planck's shell ordering into libmsym's internal basis-function ordering using a pre-built `to_internal` index map (lines 1313–1315).
+3. Calls `msymSymmetrySpeciesComponents` with the reordered coefficient vector to obtain, for each MO, a weight per irreducible representation.
+4. Assigns the irrep label corresponding to the largest weight.
+
+**Important: the SCF is unaffected**
+
+This transformation is done only inside `assign_mo_symmetry`, immediately before the libmsym call.  The stored MO coefficients in `SpinChannel._mo_coefficients` remain in the Cartesian basis throughout — the conversion is ephemeral.
+
+**Verification tip**
+
+If \(T^+\) is correct, the inner product \(\mathbf C_{sph}^\top \mathbf C_{sph}\) restricted to the occupied block should equal the identity (orthonormal MOs), and the total norm of each MO column should be preserved.  Any error in the hardcoded \(T^+\) blocks shows up immediately as an MO being assigned to the wrong irrep (or split across two irreps).
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -241,20 +241,21 @@
 <li class="toc-level-3"><a href="#mass-weighting-and-eckart-projection">Mass-Weighting and Eckart Projection</a></li>
 <li class="toc-level-3"><a href="#normal-mode-frequencies">Normal Mode Frequencies</a></li>
 <li class="toc-level-2"><a href="#18-kohn-sham-density-functional-theory">18. Kohn-Sham Density Functional Theory</a></li>
-<li class="toc-level-3"><a href="#18-1-the-kohn-sham-equations">18.1 The Kohn-Sham Equations</a></li>
-<li class="toc-level-3"><a href="#18-2-exchange-correlation-functional-families">18.2 Exchange-Correlation Functional Families</a></li>
-<li class="toc-level-3"><a href="#18-3-numerical-integration-molecular-grid">18.3 Numerical Integration: Molecular Grid</a></li>
-<li class="toc-level-3"><a href="#18-4-ao-evaluation-on-the-grid">18.4 AO Evaluation on the Grid</a></li>
-<li class="toc-level-3"><a href="#18-5-density-and-xc-evaluation">18.5 Density and XC Evaluation</a></li>
-<li class="toc-level-3"><a href="#18-6-xc-matrix-assembly">18.6 XC Matrix Assembly</a></li>
-<li class="toc-level-3"><a href="#18-7-ks-dft-scf-loop">18.7 KS-DFT SCF Loop</a></li>
-<li class="toc-level-3"><a href="#18-8-dft-code-map">18.8 DFT Code Map</a></li>
+<li class="toc-level-3"><a href="#the-kohn-sham-equations">The Kohn-Sham Equations</a></li>
+<li class="toc-level-3"><a href="#exchange-correlation-functional-families">Exchange-Correlation Functional Families</a></li>
+<li class="toc-level-3"><a href="#numerical-integration-molecular-grid">Numerical Integration: Molecular Grid</a></li>
+<li class="toc-level-3"><a href="#ao-evaluation-on-the-grid">AO Evaluation on the Grid</a></li>
+<li class="toc-level-3"><a href="#density-and-xc-evaluation">Density and XC Evaluation</a></li>
+<li class="toc-level-3"><a href="#xc-matrix-assembly">XC Matrix Assembly</a></li>
+<li class="toc-level-3"><a href="#ks-dft-scf-loop">KS-DFT SCF Loop</a></li>
+<li class="toc-level-3"><a href="#dft-code-map">DFT Code Map</a></li>
 <li class="toc-level-2"><a href="#19-molecular-properties">19. Molecular Properties</a></li>
-<li class="toc-level-3"><a href="#19-1-mulliken-population-analysis">19.1 Mulliken Population Analysis</a></li>
-<li class="toc-level-3"><a href="#19-2-electric-dipole-moment">19.2 Electric Dipole Moment</a></li>
-<li class="toc-level-3"><a href="#19-3-traceless-quadrupole-moment">19.3 Traceless Quadrupole Moment</a></li>
-<li class="toc-level-3"><a href="#19-4-rmp2-natural-orbitals">19.4 RMP2 Natural Orbitals</a></li>
-<li class="toc-level-3"><a href="#19-5-mo-symmetry-labels">19.5 MO Symmetry Labels</a></li>
+<li class="toc-level-3"><a href="#mulliken-population-analysis">Mulliken Population Analysis</a></li>
+<li class="toc-level-3"><a href="#electric-dipole-moment">Electric Dipole Moment</a></li>
+<li class="toc-level-3"><a href="#traceless-quadrupole-moment">Traceless Quadrupole Moment</a></li>
+<li class="toc-level-3"><a href="#rmp2-natural-orbitals">RMP2 Natural Orbitals</a></li>
+<li class="toc-level-3"><a href="#mo-symmetry-labels">MO Symmetry Labels</a></li>
+<li class="toc-level-3"><a href="#cartesian-to-spherical-mo-transformation">Cartesian-to-Spherical MO Transformation</a></li>
 <li class="toc-level-2"><a href="#20-checkpoint-and-restart">20. Checkpoint and Restart</a></li>
 <li class="toc-level-3"><a href="#binary-checkpoint-format">Binary Checkpoint Format</a></li>
 <li class="toc-level-3"><a href="#cross-basis-l-wdin-projection">Cross-Basis Löwdin Projection</a></li>
@@ -1647,7 +1648,7 @@ E_{ZPE} = \frac{1}{2}\sum_{k=1}^{3N-6} h\nu_k
 <p>Vibrational symmetry labels are assigned in <code>src/symmetry/vibrational_symmetry.cpp</code> by projecting each normal mode onto the SAO blocks and determining its irrep.</p>
 <hr>
 <h2 id="18-kohn-sham-density-functional-theory">18. Kohn-Sham Density Functional Theory</h2>
-<h3 id="18-1-the-kohn-sham-equations">18.1 The Kohn-Sham Equations</h3>
+<h3 id="the-kohn-sham-equations">The Kohn-Sham Equations</h3>
 <p>Kohn-Sham DFT maps the interacting many-electron problem onto a fictitious system of non-interacting electrons moving in an effective potential <span class="math-inline">\(v_s(\mathbf r)\)</span> that yields the same ground-state density as the real system. The total electronic energy is:</p>
 <p><span class="math-display">\[
 E[P] = T_s[P] + V_{ne}[P] + J[P] + E_{xc}[P] + V_{nn}
@@ -1657,7 +1658,7 @@ E[P] = T_s[P] + V_{ne}[P] + J[P] + E_{xc}[P] + V_{nn}
 F^{KS}_{\mu\nu} = h_{\mu\nu} + J_{\mu\nu} + V^{xc}_{\mu\nu}
 \]</span></p>
 <p>This is identical in structure to the HF Fock matrix, with the HF exchange matrix <span class="math-inline">\(K\)</span> replaced by the XC potential matrix <span class="math-inline">\(V^{xc}\)</span>. Planck reuses the HF SCF loop for KS-DFT: the only structural difference is how the two-electron contribution to the Fock matrix is assembled (Coulomb only, no exchange, plus <span class="math-inline">\(V^{xc}\)</span> from numerical integration).</p>
-<h3 id="18-2-exchange-correlation-functional-families">18.2 Exchange-Correlation Functional Families</h3>
+<h3 id="exchange-correlation-functional-families">Exchange-Correlation Functional Families</h3>
 <h4 id="lda-local-density-approximation">LDA (Local Density Approximation)</h4>
 <p>The XC energy depends only on the local electron density <span class="math-inline">\(\rho(\mathbf r)\)</span>:</p>
 <p><span class="math-display">\[
@@ -1688,7 +1689,7 @@ E_{xc}^{GGA}[\rho] = \int f(\rho(\mathbf r),\, |\nabla\rho(\mathbf r)|^2)\, d\ma
 <tr><td>PW91 (<code>gga_x_pw91</code>)</td><td>PW91</td><td>PW91</td></tr>
 <tr><td>PBE (<code>gga_x_pbe</code>)</td><td>PBE (<code>gga_c_pbe</code>)</td><td>PBE (default)</td></tr>
 </tbody></table></div>
-<h3 id="18-3-numerical-integration-molecular-grid">18.3 Numerical Integration: Molecular Grid</h3>
+<h3 id="numerical-integration-molecular-grid">Numerical Integration: Molecular Grid</h3>
 <p>Because <span class="math-inline">\(V^{xc}_{\mu\nu}\)</span> has no analytic closed form, it is evaluated numerically:</p>
 <p><span class="math-display">\[
 V^{xc}_{\mu\nu} = \int \phi_\mu(\mathbf r)\, v_{xc}(\mathbf r)\, \phi_\nu(\mathbf r)\, d\mathbf r
@@ -1723,9 +1724,9 @@ w_i(\mathbf r) = \frac{P_i(\mathbf r)}{\sum_k P_k(\mathbf r)} \cdot w_i^{radial-
 <tr><td><code>Fine</code></td><td>5</td><td>26 / 194 / 302 / 434 / 302</td></tr>
 <tr><td><code>UltraFine</code></td><td>6</td><td>50 / 302 / 434 / 590 / 434</td></tr>
 </tbody></table></div>
-<h3 id="18-4-ao-evaluation-on-the-grid">18.4 AO Evaluation on the Grid</h3>
+<h3 id="ao-evaluation-on-the-grid">AO Evaluation on the Grid</h3>
 <p><code>AOGridEvaluation</code> (declared in <code>src/dft/ao_grid.h</code>) stores the AO values and gradients at every grid point in a matrix of shape <code>(N_grid, N_AO)</code>. These are computed once before the KS iteration begins. For each grid point and each AO <span class="math-inline">\(\phi_\mu\)</span>, the value and Cartesian gradient components are evaluated from the contracted shell data in the <code>Basis</code> object.</p>
-<h3 id="18-5-density-and-xc-evaluation">18.5 Density and XC Evaluation</h3>
+<h3 id="density-and-xc-evaluation">Density and XC Evaluation</h3>
 <p>Given the density matrix <span class="math-inline">\(P_{\mu\nu}\)</span>, the electron density at grid point <span class="math-inline">\(g\)</span> is:</p>
 <p><span class="math-display">\[
 \rho(\mathbf r_g) = \sum_{\mu\nu} P_{\mu\nu}\, \phi_\mu(\mathbf r_g)\, \phi_\nu(\mathbf r_g)
@@ -1735,21 +1736,21 @@ w_i(\mathbf r) = \frac{P_i(\mathbf r)}{\sum_k P_k(\mathbf r)} \cdot w_i^{radial-
 <p><span class="math-display">\[
 E_{xc} = \sum_g w_g\, \rho(\mathbf r_g)\, \varepsilon_{xc}(\mathbf r_g)
 \]</span></p>
-<h3 id="18-6-xc-matrix-assembly">18.6 XC Matrix Assembly</h3>
+<h3 id="xc-matrix-assembly">XC Matrix Assembly</h3>
 <p>The XC potential matrix element is:</p>
 <p><span class="math-display">\[
 V^{xc}_{\mu\nu} = \sum_g w_g\, v_{\rho,g}\, \phi_\mu(\mathbf r_g)\, \phi_\nu(\mathbf r_g)
 + 2\sum_g w_g\, \mathbf v_{\sigma,g} \cdot \nabla\rho_g \cdot \left[\phi_\mu \nabla\phi_\nu + \phi_\nu \nabla\phi_\mu\right]_g
 \]</span></p>
 <p>The second term (present only for GGA) involves the density gradient and the AO gradients on the grid. Both terms are assembled in <code>assemble_xc_matrix</code> (<code>src/dft/ks_matrix.cpp</code>).</p>
-<h3 id="18-7-ks-dft-scf-loop">18.7 KS-DFT SCF Loop</h3>
+<h3 id="ks-dft-scf-loop">KS-DFT SCF Loop</h3>
 <p>The KS SCF loop in <code>DFT::Driver::run</code> follows the same outer structure as the HF loop:</p>
 <ol>
 <li>Compute 1e integrals (<span class="math-inline">\(S\)</span>, <span class="math-inline">\(T\)</span>, <span class="math-inline">\(V_{ne}\)</span>), build orthogonalizer, form initial guess</li>
 <li>At each iteration: a. Build the Coulomb matrix <span class="math-inline">\(J[P]\)</span> using the standard ERI or direct path b. Evaluate the density <span class="math-inline">\(\rho\)</span> and gradient <span class="math-inline">\(\nabla\rho\)</span> on the molecular grid c. Call libxc to get <span class="math-inline">\(\varepsilon_{xc}\)</span>, <span class="math-inline">\(v_\rho\)</span>, <span class="math-inline">\(v_\sigma\)</span> on the grid d. Assemble <span class="math-inline">\(V^{xc}_{\mu\nu}\)</span> by numerical quadrature e. Form the KS Fock matrix <span class="math-inline">\(F^{KS} = h + J + V^{xc}\)</span> f. Solve the KS secular equation, update <span class="math-inline">\(P\)</span>, check convergence</li>
 </ol>
 <p>The <code>KSPotentialMatrices</code> struct holds the Coulomb, XC-alpha, and XC-beta matrices and their sum (the full KS two-electron+XC potential). For RKS the alpha and beta components are identical; for UKS they differ because <span class="math-inline">\(\rho_\alpha \neq \rho_\beta\)</span>.</p>
-<h3 id="18-8-dft-code-map">18.8 DFT Code Map</h3>
+<h3 id="dft-code-map">DFT Code Map</h3>
 <div class="table-wrap"><table>
 <thead><tr>
 <th>Task</th>
@@ -1773,7 +1774,7 @@ V^{xc}_{\mu\nu} = \sum_g w_g\, v_{\rho,g}\, \phi_\mu(\mathbf r_g)\, \phi_\nu(\ma
 <hr>
 <h2 id="19-molecular-properties">19. Molecular Properties</h2>
 <p>After SCF convergence Planck computes several molecular properties from the converged density matrix.  All are printed automatically (or under <code>verbosity verbose</code>) without additional input; no extra keywords are needed.  This section covers the theory behind each property and the code path that evaluates it.</p>
-<h3 id="19-1-mulliken-population-analysis">19.1 Mulliken Population Analysis</h3>
+<h3 id="mulliken-population-analysis">Mulliken Population Analysis</h3>
 <p><strong>Theory</strong></p>
 <p>The Mulliken gross population of AO <span class="math-inline">\(\mu\)</span> is</p>
 <p><span class="math-display">\[
@@ -1799,7 +1800,7 @@ Eigen::VectorXd gross = (density.array() * overlap.array()).rowwise().sum();
 </code></pre>
 <p>The function then iterates over <code>basis._basis_functions</code>, accumulates <code>gross[μ]</code> into the correct atom bucket via <code>cv._shell-&gt;_atom_index</code>, and fills an <code>AtomicPopulation</code> struct.  When a <code>spin_density_ptr</code> is provided the same loop runs a second time over <span class="math-inline">\(\Delta P\)</span>.</p>
 <p>Population analysis is triggered when <code>_output._print_populations</code> is set or <code>verbosity</code> is <code>verbose</code> / <code>debug</code> (see <code>log_population_report</code> in <code>src/driver.cpp:71</code>).</p>
-<h3 id="19-2-electric-dipole-moment">19.2 Electric Dipole Moment</h3>
+<h3 id="electric-dipole-moment">Electric Dipole Moment</h3>
 <p><strong>Theory</strong></p>
 <p>The electronic contribution to the electric dipole moment is</p>
 <p><span class="math-display">\[
@@ -1820,7 +1821,7 @@ M^{(n)}_{i,j} = (P_\alpha - A_\alpha)\,M^{(n)}_{i-1,j} + \frac{j}{2\zeta}\,M^{(n
 M^{(0)}_{0,0} = S_{00} = \sqrt{\frac{\pi}{\zeta}}\,e^{-\alpha_a\alpha_b|A-B|^2/\zeta}, \qquad M^{(n\ge1)}_{0,0} = \frac{n}{2\zeta}\,M^{(n-1)}_{0,0}
 \]</span></p>
 <p>The function <code>_compute_multipole_matrices</code> in <code>os.cpp</code> assembles the three <span class="math-inline">\(N_b \times N_b\)</span> dipole matrices (one per Cartesian component <span class="math-inline">\(x,y,z\)</span>) and the six independent upper-triangle elements of the raw quadrupole matrix, parallelised over shell pairs with OpenMP.</p>
-<h3 id="19-3-traceless-quadrupole-moment">19.3 Traceless Quadrupole Moment</h3>
+<h3 id="traceless-quadrupole-moment">Traceless Quadrupole Moment</h3>
 <p><strong>Theory</strong></p>
 <p>The raw second-moment tensor is</p>
 <p><span class="math-display">\[
@@ -1840,7 +1841,7 @@ Q_xy = 1.5 * raw_xy;          // off-diagonal scaled by 3/2
 // ... (analogously for all components)
 </code></pre>
 <p>Both the dipole and quadrupole moments use the nuclear frame origin <span class="math-inline">\(\mathbf{o} = \mathbf{0}\)</span> (atomic units) as passed by <code>log_multipole_report</code> in <code>src/driver.cpp:52</code>.</p>
-<h3 id="19-4-rmp2-natural-orbitals">19.4 RMP2 Natural Orbitals</h3>
+<h3 id="rmp2-natural-orbitals">RMP2 Natural Orbitals</h3>
 <p><strong>Theory</strong></p>
 <p>Natural orbitals (NOs) diagonalise the one-particle density matrix (1-PDM).  For RMP2, the unrelaxed 1-PDM in the MO basis has two non-trivial blocks.</p>
 <p><em>Occupied–occupied block</em> (correlation-induced depopulation of occupied MOs):</p>
@@ -1867,7 +1868,7 @@ Q_xy = 1.5 * raw_xy;          // off-diagonal scaled by 3/2
 <li>Diagonalises via <code>Eigen::SelfAdjointEigenSolver</code>; sorts eigenvalues in descending order.</li>
 <li>Returns a <code>NaturalOrbitalResult</code> containing <code>occupations</code> and <code>coefficients_mo</code> (the transformation <span class="math-inline">\(U\)</span>) which the logger formats and prints.</li>
 </ol>
-<h3 id="19-5-mo-symmetry-labels">19.5 MO Symmetry Labels</h3>
+<h3 id="mo-symmetry-labels">MO Symmetry Labels</h3>
 <p><strong>Theory</strong></p>
 <p>When point-group symmetry is active, each MO is labelled with an irreducible representation (irrep) of the molecule&#x27;s point group.  The assignment exploits the fact that an MO <span class="math-inline">\(\phi_p = \sum_\mu C_{\mu p}\chi_\mu\)</span> belongs to irrep <span class="math-inline">\(\Gamma\)</span> if and only if</p>
 <p><span class="math-display">\[
@@ -1892,6 +1893,55 @@ c_\Gamma^{(p)} = \frac{1}{|G|}\sum_R \chi_\Gamma(R)^*\,(D^R_{MO})_{pp}
 <li><strong>Component-norm ratio</strong>: because different Cartesian functions within the same shell (e.g. <span class="math-inline">\(d_{xx}\)</span> vs <span class="math-inline">\(d_{xy}\)</span>) carry different normalisation constants, each matrix element is corrected by <span class="math-inline">\(\mathtt{norm\_target}/\mathtt{norm\_source}\)</span>.</li>
 </ul>
 <p>The full assign pipeline (<code>assign_mo_symmetry</code> in <code>mo_symmetry.cpp</code>) loops over all symmetry operations from libmsym, accumulates the projection coefficients, and returns a <code>std::vector&lt;std::string&gt;</code> of irrep labels (one per MO per spin channel).</p>
+<h3 id="cartesian-to-spherical-mo-transformation">Cartesian-to-Spherical MO Transformation</h3>
+<p><strong>Why it is needed</strong></p>
+<p>Planck&#x27;s integral engine and SCF solver work exclusively in the Cartesian Gaussian basis.  For angular momentum <span class="math-inline">\(L\)</span>, there are <span class="math-inline">\((L+1)(L+2)/2\)</span> Cartesian basis functions (e.g. 6 for <span class="math-inline">\(d\)</span>, 10 for <span class="math-inline">\(f\)</span>) but only <span class="math-inline">\(2L+1\)</span> real spherical harmonics.  libmsym — the external library used to assign irrep labels — requires the basis functions presented to it to be real spherical harmonics.  The MO coefficients that come out of the SCF are therefore in the Cartesian basis and must be transformed before they can be passed to libmsym.</p>
+<p><strong>The transformation matrix</strong></p>
+<p>For each shell of angular momentum <span class="math-inline">\(L\)</span>, every real spherical harmonic <span class="math-inline">\(Y_L^m\)</span> with <span class="math-inline">\(m = -L,\ldots,+L\)</span> can be written as a fixed linear combination of the <span class="math-inline">\((L+1)(L+2)/2\)</span> Cartesian monomials:</p>
+<p><span class="math-display">\[
+Y_L^m(\mathbf r) = \sum_{l_x+l_y+l_z=L} T^{(L)}_{m,\,(l_x l_y l_z)}\; x^{l_x} y^{l_y} z^{l_z} e^{-\alpha r^2}
+\]</span></p>
+<p>These coefficients are purely geometric and tabulated analytically.  For a basis with shells <span class="math-inline">\(s = 1,\ldots,N_{sh}\)</span>, the per-shell matrices are assembled into a block-diagonal transformation matrix</p>
+<p><span class="math-display">\[
+T^+ \in \mathbb{R}^{N_{sph} \times N_{cart}}, \qquad N_{sph} = \sum_s (2L_s+1), \quad N_{cart} = \sum_s \frac{(L_s+1)(L_s+2)}{2}
+\]</span></p>
+<p>where the <span class="math-inline">\(s\)</span>-th diagonal block <span class="math-inline">\(T^+_s \in \mathbb{R}^{(2L_s+1)\times n_{cart,s}}\)</span> is the pseudoinverse <span class="math-inline">\((T_s^\top T_s)^{-1} T_s^\top\)</span> of the Cartesian-to-spherical expansion matrix <span class="math-inline">\(T_s\)</span>.  The pseudoinverse discards the &quot;extra&quot; <span class="math-inline">\(r^2\)</span>-contaminated subspace that Cartesian Gaussians span for <span class="math-inline">\(L \geq 2\)</span>.</p>
+<p><strong>Applying the transformation</strong></p>
+<p>Given the <span class="math-inline">\(N_{cart} \times N_{MO}\)</span> matrix <span class="math-inline">\(\mathbf C\)</span> of Cartesian MO coefficients, the spherical-basis coefficients are</p>
+<p><span class="math-display">\[
+\mathbf C_{sph} = T^+\, \mathbf C \qquad (N_{sph} \times N_{MO})
+\]</span></p>
+<p>Each column of <span class="math-inline">\(\mathbf C_{sph}\)</span> is then a set of real-spherical-harmonic expansion coefficients for one MO.</p>
+<p><strong>Where the coefficients come from (hardcoded tables)</strong></p>
+<p><code>cart_to_sph_block(L)</code> in <code>src/symmetry/mo_symmetry.cpp</code> (line 499) returns the analytical block for each <span class="math-inline">\(L\)</span>:</p>
+<div class="table-wrap"><table>
+<thead><tr>
+<th><span class="math-inline">\(L\)</span></th>
+<th>Cartesian functions</th>
+<th>Spherical harmonics</th>
+<th>Extra (discarded)</th>
+</tr></thead>
+<tbody>
+<tr><td>0 (S)</td><td>1</td><td>1</td><td>0</td></tr>
+<tr><td>1 (P)</td><td>3</td><td>3</td><td>0</td></tr>
+<tr><td>2 (D)</td><td>6</td><td>5</td><td>1 (<span class="math-inline">\(r^2\)</span> contamination)</td></tr>
+<tr><td>3 (F)</td><td>10</td><td>7</td><td>3</td></tr>
+<tr><td>4 (G)</td><td>15</td><td>9</td><td>6</td></tr>
+<tr><td>5 (H)</td><td>21</td><td>11</td><td>10</td></tr>
+</tbody></table></div>
+<p>For <span class="math-inline">\(L \leq 1\)</span> the Cartesian and spherical spaces are identical and <span class="math-inline">\(T^+\)</span> is simply a (possibly trivial) reordering matrix.</p>
+<p><strong>Putting it all together: the classify lambda</strong></p>
+<p><code>assign_mo_symmetry</code> (starting at line 1300 of <code>mo_symmetry.cpp</code>) defines a <code>classify</code> lambda that:</p>
+<ol>
+<li>Multiplies <code>T_cs * C</code> to produce <code>C_sph</code> — the spherical-basis MO matrix (line 1305).</li>
+<li>Reorders the rows of <code>C_sph</code> from Planck&#x27;s shell ordering into libmsym&#x27;s internal basis-function ordering using a pre-built <code>to_internal</code> index map (lines 1313–1315).</li>
+<li>Calls <code>msymSymmetrySpeciesComponents</code> with the reordered coefficient vector to obtain, for each MO, a weight per irreducible representation.</li>
+<li>Assigns the irrep label corresponding to the largest weight.</li>
+</ol>
+<p><strong>Important: the SCF is unaffected</strong></p>
+<p>This transformation is done only inside <code>assign_mo_symmetry</code>, immediately before the libmsym call.  The stored MO coefficients in <code>SpinChannel._mo_coefficients</code> remain in the Cartesian basis throughout — the conversion is ephemeral.</p>
+<p><strong>Verification tip</strong></p>
+<p>If <span class="math-inline">\(T^+\)</span> is correct, the inner product <span class="math-inline">\(\mathbf C_{sph}^\top \mathbf C_{sph}\)</span> restricted to the occupied block should equal the identity (orthonormal MOs), and the total norm of each MO column should be preserved.  Any error in the hardcoded <span class="math-inline">\(T^+\)</span> blocks shows up immediately as an MO being assigned to the wrong irrep (or split across two irreps).</p>
 <hr>
 <h2 id="20-checkpoint-and-restart">20. Checkpoint and Restart</h2>
 <h3 id="binary-checkpoint-format">Binary Checkpoint Format</h3>

--- a/src/basis/gaussian.cpp
+++ b/src/basis/gaussian.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <fstream>
 #include <iostream>
 
@@ -179,8 +180,31 @@ HartreeFock::Basis HartreeFock::BasisFunctions::read_gbs_basis(const std::string
         throw std::runtime_error("Spherical Harmonics are not supported. Only Cartesian basis functions are currently supported");
     }
 
-    // Create input file stream
+    // Try the path as given first; if that fails, retry with the filename
+    // component lowercased (supports both case-preserving names like
+    // "cc-pVDZ" and the all-lowercase convention used by built-in bases).
+    auto make_lowercase_path = [](const std::string &path) -> std::string {
+        const auto sep = path.rfind('/');
+        if (sep == std::string::npos)
+        {
+            std::string lower = path;
+            std::transform(lower.begin(), lower.end(), lower.begin(),
+                           [](unsigned char c) { return std::tolower(c); });
+            return lower;
+        }
+        std::string name = path.substr(sep + 1);
+        std::transform(name.begin(), name.end(), name.begin(),
+                       [](unsigned char c) { return std::tolower(c); });
+        return path.substr(0, sep + 1) + name;
+    };
+
     std::ifstream file(file_name);
+    if (!file)
+    {
+        const std::string lower_path = make_lowercase_path(file_name);
+        if (lower_path != file_name)
+            file.open(lower_path);
+    }
     if (!file)
     {
         throw std::runtime_error("Cannot open basis file: " + file_name);

--- a/src/io/io.cpp
+++ b/src/io/io.cpp
@@ -371,7 +371,7 @@ namespace HartreeFock::IO
         // (key, value) pairs
         const std::unordered_map<std::string, std::function<void(const std::string &)>> _control_map =
         {
-            {"basis",       [&basis](const std::string &value)          { basis._basis_name = toLower(value); }},
+            {"basis",       [&basis](const std::string &value)          { basis._basis_name = value; }},
             {"basis_type",  [&basis](const std::string &value)          { basis._basis      = map_string_enum<HartreeFock::BasisType>(value); }},
             {"calculation", [&calculation](const std::string &value)    { calculation       = map_string_enum<HartreeFock::CalculationType>(value); }},
             {"verbosity",   [&output](const std::string &value)         { output._verbosity = map_string_enum<HartreeFock::Verbosity>(value); }},

--- a/src/io/logging.h
+++ b/src/io/logging.h
@@ -299,23 +299,23 @@ namespace HartreeFock
             const double E_ccsd = E_hf + E_ccsd_corr;
             const double E_ccsdt = E_hf + E_ccsdt_corr;
 
-            std::cout << std::setw(LW) << std::left << "  HF Energy"
+            std::cout << std::setw(LW) << std::left << "[INF]  HF Energy"
                       << std::fixed << std::setprecision(10)
                       << std::setw(VW) << std::right << E_hf
                       << std::setw(VW) << std::right << E_hf * HARTREE_TO_EV
                       << std::setw(VW) << std::right << E_hf * HARTREE_TO_KCALMOL
                       << "\n"
-                      << std::setw(LW) << std::left << ("  " + ccsd_label + " Energy")
+                      << std::setw(LW) << std::left << ("[INF]  " + ccsd_label + " Energy")
                       << std::setw(VW) << std::right << E_ccsd
                       << std::setw(VW) << std::right << E_ccsd * HARTREE_TO_EV
                       << std::setw(VW) << std::right << E_ccsd * HARTREE_TO_KCALMOL
                       << "\n"
-                      << std::setw(LW) << std::left << ("  " + ccsdt_label + " Energy")
+                      << std::setw(LW) << std::left << ("[INF]  " + ccsdt_label + " Energy")
                       << std::setw(VW) << std::right << E_ccsdt
                       << std::setw(VW) << std::right << E_ccsdt * HARTREE_TO_EV
                       << std::setw(VW) << std::right << E_ccsdt * HARTREE_TO_KCALMOL
                       << "\n"
-                      << std::setw(LW) << std::left << ("  " + ccsdt_label + " Correlation")
+                      << std::setw(LW) << std::left << ("[INF]  " + ccsdt_label + " Correlation")
                       << std::setw(VW) << std::right << E_ccsdt_corr
                       << std::setw(VW) << std::right << E_ccsdt_corr * HARTREE_TO_EV
                       << std::setw(VW) << std::right << E_ccsdt_corr * HARTREE_TO_KCALMOL


### PR DESCRIPTION
### Teaching guide

• Added new section "Cartesian-to-Spherical MO Transformation" (formerly §19.6) to PLANCK_TEACHING_GUIDE.md immediately after the MO symmetry labels section.  The section explains:
    - Why the transformation is needed: libmsym requires real spherical harmonics, but all SCF/integral machinery uses Cartesian Gaussians, so MO coefficients must be projected before irrep assignment.
    - Construction of the block-diagonal pseudoinverse T⁺ ∈ R^{N_sph×N_cart} from per-shell analytical Cart→Sph tables (cart_to_sph_block in src/symmetry/mo_symmetry.cpp:499).
    - The single matrix multiply C_sph = T⁺ · C (mo_symmetry.cpp:1305).
    - The subsequent reindexing step that maps Planck's shell ordering into libmsym's internal basis-function ordering.
    - The fact that the transformation is ephemeral — stored MO coefficients in SpinChannel._mo_coefficients are never modified.
    - A verification tip: the occupied-block inner product C_sph^T C_sph should equal the identity; any wrong T⁺ block causes immediate irrep misassignment.
    - A per-L table (S through H) showing Cartesian count, spherical count, and the number of r²-contaminated functions discarded by the pseudoinverse. • Removed numeric subsection identifiers (18.1–18.8 and 19.1–19.6) from all headings in sections 18 and 19.  Plain descriptive titles are more robust when sections are added/reordered and render better in the TOC.
• Regenerated docs/index.html to reflect both changes (updated TOC anchors and added the new section in rendered HTML).

### Basis file lookup (src/basis/gaussian.cpp)

• read_gbs_basis now retries with a lowercased filename component when the initial open fails.  This lets users write "basis cc-pVDZ" in their input without requiring the filename on disk to match case exactly, while still supporting mixed-case basis names for display purposes.

### Basis name preservation (src/io/io.cpp)

• The "basis" keyword handler no longer calls toLower() on the parsed value. The original case (e.g. "cc-pVDZ", "6-31G*") is now preserved in basis._basis_name, which is used for checkpoint tagging and log output. Case-insensitive file lookup is handled at the filesystem level (see above).

### CCSDT energy summary logging (src/io/logging.h)

• Prefixed the four CCSDT energy-summary output lines (HF, CCSD, CCSDT, correlation) with "[INF]" for consistency with the rest of the logging framework's INFO-level output style.