### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/visualizer/test_molecule3d.py
+++ b/visualizer/test_molecule3d.py
@@ -2,8 +2,10 @@
 test_molecule3d.py — unit tests for molecule3d.py.
 """
 
+import re
 import sys
 from pathlib import Path
+from urllib.parse import urlparse
 
 import numpy as np
 
@@ -153,7 +155,9 @@ def test_viewer_html_is_string():
 def test_viewer_html_contains_3dmol_cdn():
     html = viewer_html(WATER_ATOMS)
     assert "3dmol" in html.lower()
-    assert "cdn.jsdelivr.net" in html
+    script_srcs = re.findall(r'<script[^>]+src=["\\\']([^"\\\']+)["\\\']', html, flags=re.IGNORECASE)
+    hosts = [urlparse(src).hostname for src in script_srcs]
+    assert "cdn.jsdelivr.net" in hosts
 
 
 def test_viewer_html_contains_xyz_data():

--- a/visualizer/test_molecule3d.py
+++ b/visualizer/test_molecule3d.py
@@ -157,7 +157,10 @@ def test_viewer_html_contains_3dmol_cdn():
     assert "3dmol" in html.lower()
     script_srcs = re.findall(r'<script[^>]+src=["\\\']([^"\\\']+)["\\\']', html, flags=re.IGNORECASE)
     hosts = [urlparse(src).hostname for src in script_srcs]
-    assert "cdn.jsdelivr.net" in hosts
+    assert any(
+        host and (host.lower() == "cdn.jsdelivr.net" or host.lower().endswith(".cdn.jsdelivr.net"))
+        for host in hosts
+    )
 
 
 def test_viewer_html_contains_xyz_data():


### PR DESCRIPTION
Potential fix for [https://github.com/HemanthHaridas/planck-refactored/security/code-scanning/2](https://github.com/HemanthHaridas/planck-refactored/security/code-scanning/2)

The best fix is to stop checking for a hostname via substring search in the full HTML and instead extract script URLs from the HTML and validate their parsed hostname with `urllib.parse.urlparse`.

In `visualizer/test_molecule3d.py`, update `test_viewer_html_contains_3dmol_cdn` (around lines 153–157) to:

- keep the `"3dmol" in html.lower()` smoke check,
- extract `<script ... src="...">` URLs,
- parse each URL with `urlparse`,
- assert at least one parsed hostname is exactly `cdn.jsdelivr.net`.

To implement this, add imports for:
- `re` (to extract `src` attributes),
- `urlparse` from `urllib.parse` (to validate URL host).

This preserves existing behavior intent (“viewer HTML includes 3Dmol loaded from jsDelivr CDN”) while removing incomplete substring URL checking.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
