### PR TITLE
Implement analytic UMP2 gradients

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -151,7 +151,7 @@ After a converged run, `water.hfchk` is written automatically. Add `guess read` 
 
 ### Gradient only
 
-Set `calculation gradient` to compute the analytic nuclear gradient at the input geometry and stop. The gradient is printed in Ha/Bohr, one row per atom:
+Set `calculation gradient` to compute the analytic nuclear gradient at the input geometry and stop. The gradient is printed in Ha/Bohr, one row per atom. RHF, UHF, RMP2, and UMP2 gradients use this same entry point:
 
 ```
 %begin_control
@@ -403,6 +403,27 @@ After a single-point RMP2 run, Planck automatically diagonalizes the unrelaxed M
 ```
 
 Occupancies close to 2 indicate strongly occupied (nearly HF) natural orbitals; small values (0.01–0.1) indicate correlation-driven occupation of virtual space. This output is useful for selecting an appropriate active space before a CASSCF calculation.
+
+To compute an analytic MP2 gradient, switch the control block to `calculation gradient` and keep the same correlation keyword. Closed-shell references use `correlation rmp2`; open-shell references use `scf_type uhf` with `correlation ump2`:
+
+```
+%begin_control
+    basis       sto-3g
+    calculation gradient
+    verbosity   normal
+    basis_type  cartesian
+%end_control
+
+%begin_scf
+    scf_type      uhf
+    correlation   ump2
+    engine        os
+    level_shift   0.3
+    diis_restart  2.0
+%end_scf
+```
+
+The gradient section reports the correlated MP2 derivative and includes the usual maximum and RMS gradient norms.
 
 ### 9. Coupled cluster
 

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ A quantum chemistry program implementing restricted, unrestricted, and restricte
 - **Level shifting** — virtual orbital energy raising for open-shell convergence
 - **Symmetry detection** — point group via libmsym; standard-orientation coordinates
 - **MO symmetry** — irreducible representation labels assigned to each converged orbital; non-Abelian groups automatically use the largest Abelian subgroup; linear molecules handled separately
-- **Post-HF** — RMP2 and UMP2 correlation energy corrections with natural orbital analysis; RCCSD for canonical closed-shell RHF references; teaching-oriented determinant-space UCCSD/UCCSDT prototypes for small UHF systems; RCCSDT with automatic backend dispatch across three tiers (determinant-space prototype, tensor production solver, tensor-optimized ccgen-driven backend); CASSCF and RASSCF multireference active-space calculations
+- **Post-HF** — RMP2 and UMP2 correlation energy corrections; RMP2 natural orbital analysis; analytic RMP2 and UMP2 nuclear gradients; RCCSD for canonical closed-shell RHF references; teaching-oriented determinant-space UCCSD/UCCSDT prototypes for small UHF systems; RCCSDT with automatic backend dispatch across three tiers (determinant-space prototype, tensor production solver, tensor-optimized ccgen-driven backend); CASSCF and RASSCF multireference active-space calculations
 - **Coupled cluster** — `RCCSD` is an iterative spin-orbital amplitude solver for canonical RHF references. `RCCSDT` automatically selects between (1) a determinant-space teaching prototype (≤12 spin orbitals and ≤1200 determinants), (2) a tensor production backend (dressed-intermediate CCSD + staged T3 amplitude updates), and (3) a tensor-optimized backend that consumes ccgen-generated warm-start kernels for restricted references. The backend can be forced via the `PLANCK_RCCSDT_BACKEND` environment variable (`determinant`, `tensor`, or `optimized`). `UCCSD` and `UCCSDT` currently use determinant-space prototypes aimed at small teaching examples and validation studies.
 - **ccgen — symbolic coupled-cluster equation generator** — a Python package (`python/ccgen/`) that derives spin-orbital CC residual equations at arbitrary truncation order (CCD through CC6) directly from the normal-ordered Hamiltonian via Baker-Campbell-Hausdorff expansion, Wick contraction, canonicalization, and connectivity filtering. Supports algebraic optimizations (orbital-energy denominator collection, permutation-based term grouping, implicit antisymmetry exploitation), intermediate tensor extraction with layout hints, and four tiers of C++ emission including a Planck-specific tensor emitter that targets `Tensor2D`/`Tensor4D`/`Tensor6D` and the production CC infrastructure in `src/post_hf/cc/`. Used to generate the warm-start kernels consumed by the tensor-optimized RCCSDT backend.
 - **RMP2 natural orbitals** — natural orbital occupation numbers and coefficients printed after a single-point RMP2 run
 - **CASSCF** — Complete Active Space SCF with full-CI, state-averaged (SA-CASSCF) roots, matrix-free second-order orbital optimization, and a dedicated active-integral-cache transform for the orbital-gradient/response hot path
 - **RASSCF** — Restricted Active Space SCF extending CASSCF with RAS1/RAS2/RAS3 subspace partitioning and configurable hole/electron occupation restrictions
-- **Analytic nuclear gradients** — RHF and UHF analytic nuclear gradients
+- **Analytic nuclear gradients** — RHF, UHF, RMP2, and UMP2 analytic nuclear gradients
 - **Geometry optimization** — optimizer in Cartesian coordinates or redundant generalized internal coordinates (GIC); optional constraints (fixed bonds, angles, dihedrals, frozen atoms) via `%begin_constraints`
 - **Vibrational frequency analysis** — semi-numerical Hessian from finite differences of analytic gradients; mass-weighted normal mode analysis with translational/rotational projection; frequencies in cm⁻¹ and zero-point energy
 - **Checkpoint system** — binary `.hfchk` files; same-basis restart, full geometry+density restart, and cross-basis density projection; `chkdump` tool can export CASSCF active orbital coefficients as volumetric files
@@ -174,7 +174,7 @@ SCF procedure and convergence settings.
 |---|---|---|---|---|
 | `scf_type` | enum | `rhf`/`rks`, `rohf`, `uhf`/`uks` | `rhf` | Wavefunction type. `rks`/`uks` are aliases for `rhf`/`uhf` when using `planck-dft`. `rohf`: restricted open-shell HF; post-HF and analytic gradients are not yet supported for ROHF. |
 | `engine` | enum | `os` / `obara-saika`, `rys`, `auto` | `os` | Two-electron integral engine. `os`: Obara-Saika algorithm. `rys`: Rys quadrature. `auto`: selects the engine per shell quartet based on angular momentum. |
-| `correlation` | enum | `rmp2`, `ump2`, `ccsd`, `uccsd`, `ccsdt`, `uccsdt`, `casscf`, `rasscf` | none | Post-HF method. `rmp2`/`ump2`: Møller-Plesset second-order correction. `ccsd`: restricted coupled cluster with singles and doubles for canonical RHF references. `uccsd`: unrestricted coupled cluster with singles and doubles for canonical UHF references; currently implemented as a determinant-space teaching prototype for small systems. `ccsdt`: restricted coupled cluster with singles, doubles, and triples; automatically dispatches to a determinant-space teaching prototype for tiny RHF systems (≤12 spin orbitals and ≤1200 determinants) or to a tensor production backend (dressed-intermediate CCSD followed by staged T3 amplitude updates) for larger systems. A third tensor-optimized backend driven by ccgen-generated warm-start kernels can be forced via the `PLANCK_RCCSDT_BACKEND=optimized` environment variable. `uccsdt`: unrestricted coupled cluster with singles, doubles, and triples for canonical UHF references; currently implemented as a determinant-space teaching prototype for small systems. `casscf`: Complete Active Space SCF (requires `nactele`, `nactorb`). `rasscf`: Restricted Active Space SCF (requires `nactele`, `nactorb`, `nras1`, `nras2`, `nras3`). |
+| `correlation` | enum | `rmp2`, `ump2`, `ccsd`, `uccsd`, `ccsdt`, `uccsdt`, `casscf`, `rasscf` | none | Post-HF method. `rmp2`/`ump2`: Møller-Plesset second-order correction; both support `calculation gradient` for analytic MP2 nuclear gradients (`rmp2` with RHF, `ump2` with UHF). `ccsd`: restricted coupled cluster with singles and doubles for canonical RHF references. `uccsd`: unrestricted coupled cluster with singles and doubles for canonical UHF references; currently implemented as a determinant-space teaching prototype for small systems. `ccsdt`: restricted coupled cluster with singles, doubles, and triples; automatically dispatches to a determinant-space teaching prototype for tiny RHF systems (≤12 spin orbitals and ≤1200 determinants) or to a tensor production backend (dressed-intermediate CCSD followed by staged T3 amplitude updates) for larger systems. A third tensor-optimized backend driven by ccgen-generated warm-start kernels can be forced via the `PLANCK_RCCSDT_BACKEND=optimized` environment variable. `uccsdt`: unrestricted coupled cluster with singles, doubles, and triples for canonical UHF references; currently implemented as a determinant-space teaching prototype for small systems. `casscf`: Complete Active Space SCF (requires `nactele`, `nactorb`). `rasscf`: Restricted Active Space SCF (requires `nactele`, `nactorb`, `nras1`, `nras2`, `nras3`). |
 | `nactele` | int | ≥ 1 | — | Number of active electrons for CASSCF/RASSCF |
 | `nactorb` | int | ≥ 1 | — | Number of active orbitals for CASSCF/RASSCF |
 | `nroots` | int | ≥ 1 | `1` | Number of CI roots for state-averaged CASSCF (SA-CASSCF). `1` = single-state CASSCF. |
@@ -578,6 +578,8 @@ H     0.000000   -0.756950    -0.468703
 
 ### Analytic gradient — water, STO-3G
 
+RHF, UHF, RMP2, and UMP2 gradients use the same `calculation gradient` entry point. Add `correlation rmp2` for a closed-shell MP2 gradient or `correlation ump2` for an open-shell UHF/UMP2 gradient.
+
 ```
 %begin_control
     basis       sto-3g
@@ -605,6 +607,39 @@ H     0.000000   -0.756950    -0.468703
 O     0.000000     0.000000     0.100000
 H     0.800000     0.000000    -0.500000
 H    -0.800000     0.000000    -0.500000
+%end_coords
+```
+
+For an open-shell UMP2 gradient, use a UHF reference and request UMP2 in the SCF block:
+
+```
+%begin_control
+    basis       sto-3g
+    calculation gradient
+    verbosity   normal
+    basis_type  cartesian
+%end_control
+
+%begin_scf
+    scf_type      uhf
+    correlation   ump2
+    engine        os
+    level_shift   0.3
+    diis_restart  2.0
+%end_scf
+
+%begin_geom
+    coord_type  cartesian
+    coord_units angstrom
+    use_symm    .true.
+%end_geom
+
+%begin_coords
+3
+1   2
+O     0.000000    0.000000     0.117176
+H     0.000000    0.756950    -0.468703
+H     0.000000   -0.756950    -0.468703
 %end_coords
 ```
 
@@ -974,7 +1009,7 @@ The program prints a structured log to standard output. Key sections:
 - **Quadrupole Moment** — printed automatically after the dipole block; includes electronic, nuclear, and total components of the traceless Cartesian tensor (`XX`, `XY`, `XZ`, `YY`, `YZ`, `ZZ`) in atomic units
 - **Mulliken Population Analysis** — printed when `print_populations true` or verbosity is `verbose`/`debug`; shows AO gross populations, net atomic charges, and spin populations (UHF/ROHF)
 - **RMP2 Natural Orbitals** — occupation numbers and natural orbital coefficients printed after single-point RMP2
-- **Nuclear Gradient** — printed when `calculation gradient` or `calculation geomopt`; one row per atom showing ∂E/∂x, ∂E/∂y, ∂E/∂z in Ha/Bohr, followed by max and RMS norms
+- **Nuclear Gradient** — printed when `calculation gradient` or `calculation geomopt`; one row per atom showing ∂E/∂x, ∂E/∂y, ∂E/∂z in Ha/Bohr, followed by max and RMS norms. Supported analytic gradients include RHF, UHF, RMP2, and UMP2.
 - **IC System** — when `opt_coords internal`, logs the count of stretches, bends, and torsions in the redundant GIC set
 - **Opt Step N** — per-step log line: energy, max Cartesian gradient, and RMS IC gradient (IC mode) or RMS Cartesian gradient (Cartesian mode)
 - **Optimized Geometry** — final Cartesian coordinates in Bohr after convergence

--- a/docs/PLANCK_TEACHING_GUIDE.md
+++ b/docs/PLANCK_TEACHING_GUIDE.md
@@ -17,8 +17,8 @@ self-consistent field theory. It implements:
 - RMP2 and UMP2 correlation energies with RMP2 natural orbital analysis
 - RCCSD for canonical closed-shell RHF references
 - Small-system determinant-space teaching prototypes for RCCSDT, UCCSD, and UCCSDT
-- Analytic RHF and UHF nuclear gradients
-- Analytic RMP2 nuclear gradients (Z-vector / CPHF)
+- Analytic RHF, UHF, RMP2, and UMP2 nuclear gradients
+- Analytic RMP2 nuclear gradients include Z-vector / CPHF relaxation
 - Geometry optimization in Cartesian and internal coordinates
 - Semi-numerical Hessians and harmonic vibrational analysis
 - CASSCF and RASSCF active-space multiconfigurational SCF
@@ -65,7 +65,7 @@ Input file (.hfinp)
 | `src/scf` | orthogonalizer, initial guess, RHF/UHF SCF loops |
 | `src/symmetry` | libmsym wrapper, SAO basis, MO labeling, integral sym ops |
 | `src/post_hf` | MP2 energy/gradient, RCCSD/UCCSD/RCCSDT/UCCSDT, CASSCF/RASSCF, AO→MO transforms, CPHF |
-| `src/gradient` | analytic RHF, UHF, RMP2 gradients |
+| `src/gradient` | analytic RHF, UHF, RMP2, and UMP2 gradients |
 | `src/opt` | L-BFGS/BFGS optimizer, internal coordinates, constraints |
 | `src/freq` | finite-difference Hessian, vibrational analysis |
 | `src/dft` | Kohn-Sham DFT pipeline: molecular grid, AO evaluation, XC matrix, KS driver |
@@ -1160,7 +1160,7 @@ W_{\mu\nu} = \sum_{i}^{\alpha,occ} \varepsilon^\alpha_i C^\alpha_{\mu i} C^\alph
 
 ## 13. Coupled-Perturbed HF and the MP2 Gradient
 
-### The Z-Vector Method
+### RMP2 Z-Vector Method
 
 The RMP2 energy gradient requires the response of the HF density to a nuclear
 perturbation. Rather than solving the full CPHF equations for every nuclear
@@ -1190,6 +1190,42 @@ where \(\mathbf A\) is the orbital Hessian (also the CPHF matrix) and
 \(\mathbf L\) is the MP2 Lagrangian source term. `build_rhf_cphf_matrix` in
 `src/post_hf/rhf_response.cpp` builds \(\mathbf A\). The final gradient is then
 assembled from the relaxed density and the appropriate derivative integrals.
+
+### UMP2 Gradient Intermediates
+
+The UMP2 gradient starts from canonical UHF orbitals and keeps the MP2
+correction spin-resolved. `build_ump2_gradient_intermediates` in
+`src/post_hf/mp2_gradient.cpp` builds three MO integral blocks:
+
+- \((i^\alpha a^\alpha|j^\alpha b^\alpha)\) for alpha-alpha same-spin pairs
+- \((i^\beta a^\beta|j^\beta b^\beta)\) for beta-beta same-spin pairs
+- \((i^\alpha a^\alpha|j^\beta b^\beta)\) for alpha-beta opposite-spin pairs
+
+Same-spin terms use antisymmetrized amplitudes,
+
+\[
+t^{ab}_{ij,\sigma\sigma} =
+\frac{(ia|jb)_\sigma - (ib|ja)_\sigma}
+{\varepsilon^\sigma_i + \varepsilon^\sigma_j -
+ \varepsilon^\sigma_a - \varepsilon^\sigma_b}
+\]
+
+while opposite-spin terms have no exchange contribution,
+
+\[
+t^{ab}_{ij,\alpha\beta} =
+\frac{(i^\alpha a^\alpha|j^\beta b^\beta)}
+{\varepsilon^\alpha_i + \varepsilon^\beta_j -
+ \varepsilon^\alpha_a - \varepsilon^\beta_b}.
+\]
+
+These amplitudes populate spin-specific occupied/virtual 1-PDM corrections
+\(D^\alpha\) and \(D^\beta\), an AO-space spin-summed energy-weighted density
+\(W\), and an explicit AO pair-density correction \(\Gamma^{MP2}\). The final
+driver entry point, `compute_ump2_gradient` in `src/gradient/gradient.cpp`,
+combines those objects with the UHF reference two-particle density expression
+and reuses the same derivative-integral contraction infrastructure as the RHF,
+UHF, and RMP2 gradients.
 
 ---
 
@@ -3113,7 +3149,14 @@ driver.cpp
       run_casscf()             → E_CASSCF, natural orbitals
 
   if gradient or geomopt or frequency:
-      compute_rhf_gradient()   → _gradient (gradient.cpp)
+      if post_hf == RMP2:
+          compute_rmp2_gradient() → _gradient (gradient.cpp + mp2_gradient.cpp)
+      elif post_hf == UMP2:
+          compute_ump2_gradient() → _gradient (gradient.cpp + mp2_gradient.cpp)
+      elif reference == UHF:
+          compute_uhf_gradient()  → _gradient (gradient.cpp)
+      else:
+          compute_rhf_gradient()  → _gradient (gradient.cpp)
 
   if geomopt:
       run_geomopt()            → optimized geometry (geomopt.cpp)
@@ -3166,6 +3209,7 @@ driver.cpp
 | CC denominators/DIIS | `src/post_hf/cc/amplitudes.cpp`, `src/post_hf/cc/diis.cpp` | `build_denominator_cache`, `AmplitudeDIIS` |
 | CPHF Z-vector | `src/post_hf/rhf_response.cpp` | `build_rhf_cphf_matrix` |
 | RMP2 gradient | `src/post_hf/mp2_gradient.cpp` | `compute_rmp2_gradient` |
+| UMP2 gradient intermediates | `src/post_hf/mp2_gradient.cpp` | `build_ump2_gradient_intermediates` |
 | CI string generation | `src/post_hf/casscf.cpp` | Gosper enumeration |
 | CI solve (Davidson) | `src/post_hf/casscf.cpp` | Davidson solver |
 | 1-RDM, 2-RDM | `src/post_hf/casscf.cpp` | `compute_1rdm`, `compute_2rdm` |
@@ -3173,6 +3217,7 @@ driver.cpp
 | Orbital update | `src/post_hf/casscf.cpp` | Cayley transform |
 | RHF gradient | `src/gradient/gradient.cpp` | `compute_rhf_gradient` |
 | UHF gradient | `src/gradient/gradient.cpp` | `compute_uhf_gradient` |
+| UMP2 gradient | `src/gradient/gradient.cpp` | `compute_ump2_gradient` |
 | Derivative integrals | `src/integrals/os.cpp` | `_compute_1e_deriv_A`, `_compute_eri_deriv_elem` |
 | L-BFGS optimizer | `src/opt/geomopt.cpp` | `run_geomopt` |
 | Internal coordinates | `src/opt/intcoords.cpp` | Wilson B matrix |
@@ -3219,10 +3264,9 @@ driver.cpp
 | Analytic RHF gradient | Complete |
 | Analytic UHF gradient | Complete |
 | Analytic RMP2 gradient (Z-vector) | Complete |
-| UMP2 gradient | Not implemented (throws at runtime) |
+| Analytic UMP2 gradient | Complete |
 | CASSCF / RASSCF | Complete |
-| Geometry optimization (RHF/UHF/RMP2) | Complete |
-| UMP2 geometry optimization | Blocked by missing UMP2 gradient |
+| Geometry optimization (RHF/UHF/RMP2/UMP2) | Complete |
 | Semi-numerical Hessian | Complete |
 | Harmonic vibrational analysis | Complete |
 | Checkpoint save/restart | Complete |

--- a/docs/index.html
+++ b/docs/index.html
@@ -208,7 +208,8 @@
 <li class="toc-level-3"><a href="#derivative-integrals">Derivative Integrals</a></li>
 <li class="toc-level-3"><a href="#uhf-gradient">UHF Gradient</a></li>
 <li class="toc-level-2"><a href="#13-coupled-perturbed-hf-and-the-mp2-gradient">13. Coupled-Perturbed HF and the MP2 Gradient</a></li>
-<li class="toc-level-3"><a href="#the-z-vector-method">The Z-Vector Method</a></li>
+<li class="toc-level-3"><a href="#rmp2-z-vector-method">RMP2 Z-Vector Method</a></li>
+<li class="toc-level-3"><a href="#ump2-gradient-intermediates">UMP2 Gradient Intermediates</a></li>
 <li class="toc-level-2"><a href="#14-coupled-cluster-in-planck">14. Coupled Cluster in Planck</a></li>
 <li class="toc-level-3"><a href="#rccsd">RCCSD</a></li>
 <li class="toc-level-3"><a href="#worked-example-a-singles-residual-term">Worked Example: a Singles-Residual Term</a></li>
@@ -279,8 +280,8 @@
 <li>RMP2 and UMP2 correlation energies with RMP2 natural orbital analysis</li>
 <li>RCCSD for canonical closed-shell RHF references</li>
 <li>Small-system determinant-space teaching prototypes for RCCSDT, UCCSD, and UCCSDT</li>
-<li>Analytic RHF and UHF nuclear gradients</li>
-<li>Analytic RMP2 nuclear gradients (Z-vector / CPHF)</li>
+<li>Analytic RHF, UHF, RMP2, and UMP2 nuclear gradients</li>
+<li>Analytic RMP2 nuclear gradients include Z-vector / CPHF relaxation</li>
 <li>Geometry optimization in Cartesian and internal coordinates</li>
 <li>Semi-numerical Hessians and harmonic vibrational analysis</li>
 <li>CASSCF and RASSCF active-space multiconfigurational SCF</li>
@@ -321,7 +322,7 @@ Input file (.hfinp)
 <tr><td><code>src/scf</code></td><td>orthogonalizer, initial guess, RHF/UHF SCF loops</td></tr>
 <tr><td><code>src/symmetry</code></td><td>libmsym wrapper, SAO basis, MO labeling, integral sym ops</td></tr>
 <tr><td><code>src/post_hf</code></td><td>MP2 energy/gradient, RCCSD/UCCSD/RCCSDT/UCCSDT, CASSCF/RASSCF, AO→MO transforms, CPHF</td></tr>
-<tr><td><code>src/gradient</code></td><td>analytic RHF, UHF, RMP2 gradients</td></tr>
+<tr><td><code>src/gradient</code></td><td>analytic RHF, UHF, RMP2, and UMP2 gradients</td></tr>
 <tr><td><code>src/opt</code></td><td>L-BFGS/BFGS optimizer, internal coordinates, constraints</td></tr>
 <tr><td><code>src/freq</code></td><td>finite-difference Hessian, vibrational analysis</td></tr>
 <tr><td><code>src/dft</code></td><td>Kohn-Sham DFT pipeline: molecular grid, AO evaluation, XC matrix, KS driver</td></tr>
@@ -934,7 +935,7 @@ W_{\mu\nu} = \sum_{i}^{\alpha,occ} \varepsilon^\alpha_i C^\alpha_{\mu i} C^\alph
 \]</span></p>
 <hr>
 <h2 id="13-coupled-perturbed-hf-and-the-mp2-gradient">13. Coupled-Perturbed HF and the MP2 Gradient</h2>
-<h3 id="the-z-vector-method">The Z-Vector Method</h3>
+<h3 id="rmp2-z-vector-method">RMP2 Z-Vector Method</h3>
 <p>The RMP2 energy gradient requires the response of the HF density to a nuclear perturbation. Rather than solving the full CPHF equations for every nuclear displacement (which would scale as <span class="math-inline">\(O(3N \cdot n_b^3)\)</span>), the Z-vector method (Handy and Schaefer, 1984) collapses the response into a single solve.</p>
 <p>The unrelaxed MP2 one-particle density is:</p>
 <p><span class="math-display">\[
@@ -949,6 +950,28 @@ t_{ij}^{ab} = \frac{(ia|jb)}{\varepsilon_i + \varepsilon_j - \varepsilon_a - \va
 \sum_{bj} A_{ai,bj} Z_{bj} = L_{ai}
 \]</span></p>
 <p>where <span class="math-inline">\(\mathbf A\)</span> is the orbital Hessian (also the CPHF matrix) and <span class="math-inline">\(\mathbf L\)</span> is the MP2 Lagrangian source term. <code>build_rhf_cphf_matrix</code> in <code>src/post_hf/rhf_response.cpp</code> builds <span class="math-inline">\(\mathbf A\)</span>. The final gradient is then assembled from the relaxed density and the appropriate derivative integrals.</p>
+<h3 id="ump2-gradient-intermediates">UMP2 Gradient Intermediates</h3>
+<p>The UMP2 gradient starts from canonical UHF orbitals and keeps the MP2 correction spin-resolved. <code>build_ump2_gradient_intermediates</code> in <code>src/post_hf/mp2_gradient.cpp</code> builds three MO integral blocks:</p>
+<ul>
+<li><span class="math-inline">\((i^\alpha a^\alpha|j^\alpha b^\alpha)\)</span> for alpha-alpha same-spin pairs</li>
+<li><span class="math-inline">\((i^\beta a^\beta|j^\beta b^\beta)\)</span> for beta-beta same-spin pairs</li>
+<li><span class="math-inline">\((i^\alpha a^\alpha|j^\beta b^\beta)\)</span> for alpha-beta opposite-spin pairs</li>
+</ul>
+<p>Same-spin terms use antisymmetrized amplitudes,</p>
+<p><span class="math-display">\[
+t^{ab}_{ij,\sigma\sigma} =
+\frac{(ia|jb)_\sigma - (ib|ja)_\sigma}
+{\varepsilon^\sigma_i + \varepsilon^\sigma_j -
+ \varepsilon^\sigma_a - \varepsilon^\sigma_b}
+\]</span></p>
+<p>while opposite-spin terms have no exchange contribution,</p>
+<p><span class="math-display">\[
+t^{ab}_{ij,\alpha\beta} =
+\frac{(i^\alpha a^\alpha|j^\beta b^\beta)}
+{\varepsilon^\alpha_i + \varepsilon^\beta_j -
+ \varepsilon^\alpha_a - \varepsilon^\beta_b}.
+\]</span></p>
+<p>These amplitudes populate spin-specific occupied/virtual 1-PDM corrections <span class="math-inline">\(D^\alpha\)</span> and <span class="math-inline">\(D^\beta\)</span>, an AO-space spin-summed energy-weighted density <span class="math-inline">\(W\)</span>, and an explicit AO pair-density correction <span class="math-inline">\(\Gamma^{MP2}\)</span>. The final driver entry point, <code>compute_ump2_gradient</code> in <code>src/gradient/gradient.cpp</code>, combines those objects with the UHF reference two-particle density expression and reuses the same derivative-integral contraction infrastructure as the RHF, UHF, and RMP2 gradients.</p>
 <hr>
 <h2 id="14-coupled-cluster-in-planck">14. Coupled Cluster in Planck</h2>
 <p>Planck currently contains four coupled-cluster paths:</p>
@@ -2020,7 +2043,14 @@ driver.cpp
       run_casscf()             → E_CASSCF, natural orbitals
 
   if gradient or geomopt or frequency:
-      compute_rhf_gradient()   → _gradient (gradient.cpp)
+      if post_hf == RMP2:
+          compute_rmp2_gradient() → _gradient (gradient.cpp + mp2_gradient.cpp)
+      elif post_hf == UMP2:
+          compute_ump2_gradient() → _gradient (gradient.cpp + mp2_gradient.cpp)
+      elif reference == UHF:
+          compute_uhf_gradient()  → _gradient (gradient.cpp)
+      else:
+          compute_rhf_gradient()  → _gradient (gradient.cpp)
 
   if geomopt:
       run_geomopt()            → optimized geometry (geomopt.cpp)
@@ -2075,6 +2105,7 @@ driver.cpp
 <tr><td>CC denominators/DIIS</td><td><code>src/post_hf/cc/amplitudes.cpp</code>, <code>src/post_hf/cc/diis.cpp</code></td><td><code>build_denominator_cache</code>, <code>AmplitudeDIIS</code></td></tr>
 <tr><td>CPHF Z-vector</td><td><code>src/post_hf/rhf_response.cpp</code></td><td><code>build_rhf_cphf_matrix</code></td></tr>
 <tr><td>RMP2 gradient</td><td><code>src/post_hf/mp2_gradient.cpp</code></td><td><code>compute_rmp2_gradient</code></td></tr>
+<tr><td>UMP2 gradient intermediates</td><td><code>src/post_hf/mp2_gradient.cpp</code></td><td><code>build_ump2_gradient_intermediates</code></td></tr>
 <tr><td>CI string generation</td><td><code>src/post_hf/casscf.cpp</code></td><td>Gosper enumeration</td></tr>
 <tr><td>CI solve (Davidson)</td><td><code>src/post_hf/casscf.cpp</code></td><td>Davidson solver</td></tr>
 <tr><td>1-RDM, 2-RDM</td><td><code>src/post_hf/casscf.cpp</code></td><td><code>compute_1rdm</code>, <code>compute_2rdm</code></td></tr>
@@ -2082,6 +2113,7 @@ driver.cpp
 <tr><td>Orbital update</td><td><code>src/post_hf/casscf.cpp</code></td><td>Cayley transform</td></tr>
 <tr><td>RHF gradient</td><td><code>src/gradient/gradient.cpp</code></td><td><code>compute_rhf_gradient</code></td></tr>
 <tr><td>UHF gradient</td><td><code>src/gradient/gradient.cpp</code></td><td><code>compute_uhf_gradient</code></td></tr>
+<tr><td>UMP2 gradient</td><td><code>src/gradient/gradient.cpp</code></td><td><code>compute_ump2_gradient</code></td></tr>
 <tr><td>Derivative integrals</td><td><code>src/integrals/os.cpp</code></td><td><code>_compute_1e_deriv_A</code>, <code>_compute_eri_deriv_elem</code></td></tr>
 <tr><td>L-BFGS optimizer</td><td><code>src/opt/geomopt.cpp</code></td><td><code>run_geomopt</code></td></tr>
 <tr><td>Internal coordinates</td><td><code>src/opt/intcoords.cpp</code></td><td>Wilson B matrix</td></tr>
@@ -2130,10 +2162,9 @@ driver.cpp
 <tr><td>Analytic RHF gradient</td><td>Complete</td></tr>
 <tr><td>Analytic UHF gradient</td><td>Complete</td></tr>
 <tr><td>Analytic RMP2 gradient (Z-vector)</td><td>Complete</td></tr>
-<tr><td>UMP2 gradient</td><td>Not implemented (throws at runtime)</td></tr>
+<tr><td>Analytic UMP2 gradient</td><td>Complete</td></tr>
 <tr><td>CASSCF / RASSCF</td><td>Complete</td></tr>
-<tr><td>Geometry optimization (RHF/UHF/RMP2)</td><td>Complete</td></tr>
-<tr><td>UMP2 geometry optimization</td><td>Blocked by missing UMP2 gradient</td></tr>
+<tr><td>Geometry optimization (RHF/UHF/RMP2/UMP2)</td><td>Complete</td></tr>
 <tr><td>Semi-numerical Hessian</td><td>Complete</td></tr>
 <tr><td>Harmonic vibrational analysis</td><td>Complete</td></tr>
 <tr><td>Checkpoint save/restart</td><td>Complete</td></tr>

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -843,9 +843,17 @@ int main(int argc, const char *argv[])
         }
         else if (calculator._correlation == HartreeFock::PostHF::UMP2)
         {
-            HartreeFock::Logger::logging(HartreeFock::LogLevel::Error, "Gradient :",
-                                         "UMP2 gradient is not implemented");
-            return EXIT_FAILURE;
+            HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "Gradient :",
+                                         "Using analytic UMP2 gradient (spin-resolved density + pair density)");
+            calculator._correlated_total_energy = calculator._total_energy + calculator._correlation_energy;
+            calculator._have_correlated_total_energy = true;
+            auto grad_res = HartreeFock::Gradient::compute_ump2_gradient(calculator, shellpairs);
+            if (!grad_res)
+            {
+                HartreeFock::Logger::logging(HartreeFock::LogLevel::Error, "Gradient :", grad_res.error());
+                return EXIT_FAILURE;
+            }
+            grad = std::move(*grad_res);
         }
         else if (calculator._correlation == HartreeFock::PostHF::RCCSD ||
                  calculator._correlation == HartreeFock::PostHF::UCCSD ||

--- a/src/gradient/gradient.cpp
+++ b/src/gradient/gradient.cpp
@@ -511,3 +511,48 @@ std::expected<Eigen::MatrixXd, std::string> HartreeFock::Gradient::compute_rmp2_
     return compute_closed_shell_gradient_from_density(calc, shell_pairs,
                                                       grad_data.P_ao, grad_data.W_ao, gamma_fn);
 }
+
+std::expected<Eigen::MatrixXd, std::string> HartreeFock::Gradient::compute_ump2_gradient(
+    HartreeFock::Calculator &calc,
+    const std::vector<HartreeFock::ShellPair> &shell_pairs)
+{
+    if (calc._correlation != HartreeFock::PostHF::UMP2)
+        return std::unexpected(std::string("UMP2 gradient requested without correlation = UMP2"));
+    if (calc._scf._scf != HartreeFock::SCFType::UHF || !calc._info._scf.is_uhf)
+        return std::unexpected(std::string("UMP2 gradient requires a UHF reference"));
+
+    auto grad_res = HartreeFock::Correlation::build_ump2_gradient_intermediates(calc, shell_pairs);
+    if (!grad_res)
+        return std::unexpected(std::string("UMP2 gradient build failed: ") + grad_res.error());
+    const auto &grad_data = *grad_res;
+
+    const Eigen::MatrixXd &Pa_ref = calc._info._scf.alpha.density;
+    const Eigen::MatrixXd &Pb_ref = calc._info._scf.beta.density;
+    const Eigen::MatrixXd Pt_ref = Pa_ref + Pb_ref;
+    const Eigen::MatrixXd &dPa = grad_data.P_alpha_corr_ao;
+    const Eigen::MatrixXd &dPb = grad_data.P_beta_corr_ao;
+    const Eigen::MatrixXd dPt = dPa + dPb;
+    const int nb = static_cast<int>(calc._shells.nbasis());
+    const auto &gamma_pair = grad_data.Gamma_pair_ao;
+
+    auto gamma_fn = [&Pa_ref, &Pb_ref, &Pt_ref, &dPa, &dPb, &dPt, &gamma_pair, nb](std::size_t ii, std::size_t jj,
+                                                                                   std::size_t kk, std::size_t ll) -> double
+    {
+        const double ref =
+            2.0 * Pt_ref(ii, jj) * Pt_ref(kk, ll) -
+            2.0 * Pa_ref(ii, kk) * Pa_ref(jj, ll) -
+            2.0 * Pb_ref(ii, kk) * Pb_ref(jj, ll);
+
+        const double linear =
+            2.0 * (dPt(ii, jj) * Pt_ref(kk, ll) + Pt_ref(ii, jj) * dPt(kk, ll)) -
+            2.0 * (dPa(ii, kk) * Pa_ref(jj, ll) + Pa_ref(ii, kk) * dPa(jj, ll)) -
+            2.0 * (dPb(ii, kk) * Pb_ref(jj, ll) + Pb_ref(ii, kk) * dPb(jj, ll));
+
+        return ref + linear +
+               gamma_pair[idx_dm2_grad(static_cast<int>(ii), static_cast<int>(jj),
+                                       static_cast<int>(kk), static_cast<int>(ll), nb)];
+    };
+
+    return compute_closed_shell_gradient_from_density(
+        calc, shell_pairs, grad_data.P_total_ao, grad_data.W_ao, gamma_fn);
+}

--- a/src/gradient/gradient.h
+++ b/src/gradient/gradient.h
@@ -28,6 +28,14 @@ namespace HartreeFock
         std::expected<Eigen::MatrixXd, std::string> compute_rmp2_gradient(
             HartreeFock::Calculator &calc,
             const std::vector<HartreeFock::ShellPair> &shell_pairs);
+
+        // Analytic UMP2 nuclear gradient from spin-resolved UMP2 density and
+        // pair-density intermediates.
+        // Returns natoms×3 matrix in Ha/Bohr.
+        // Requires a converged UHF reference and correlation = UMP2.
+        std::expected<Eigen::MatrixXd, std::string> compute_ump2_gradient(
+            HartreeFock::Calculator &calc,
+            const std::vector<HartreeFock::ShellPair> &shell_pairs);
     } // namespace Gradient
 } // namespace HartreeFock
 

--- a/src/post_hf/mp2_gradient.cpp
+++ b/src/post_hf/mp2_gradient.cpp
@@ -1,5 +1,6 @@
 #include "mp2_gradient.h"
 
+#include <cmath>
 #include <format>
 
 #include "integrals/base.h"
@@ -82,6 +83,75 @@ namespace
             calculator._integral._engine,
             calculator._integral._tol_eri,
             calculator._use_integral_symmetry ? &calculator._integral_symmetry_ops : nullptr);
+    }
+
+    struct UMP2Counts
+    {
+        int n_alpha = 0;
+        int n_beta = 0;
+        int nva = 0;
+        int nvb = 0;
+    };
+
+    std::expected<UMP2Counts, std::string> get_ump2_counts(
+        const HartreeFock::Calculator &calculator,
+        int nb)
+    {
+        int n_electrons = 0;
+        for (auto Z : calculator._molecule.atomic_numbers)
+            n_electrons += static_cast<int>(Z);
+        n_electrons -= calculator._molecule.charge;
+
+        const int n_unpaired = static_cast<int>(calculator._molecule.multiplicity) - 1;
+        UMP2Counts counts;
+        counts.n_alpha = (n_electrons + n_unpaired) / 2;
+        counts.n_beta = (n_electrons - n_unpaired) / 2;
+        counts.nva = nb - counts.n_alpha;
+        counts.nvb = nb - counts.n_beta;
+
+        if (counts.n_alpha <= 0 || counts.nva <= 0)
+            return std::unexpected("UMP2 gradient: no alpha occupied or virtual orbitals.");
+        if (counts.n_beta <= 0 || counts.nvb <= 0)
+            return std::unexpected("UMP2 gradient: no beta occupied or virtual orbitals.");
+        return counts;
+    }
+
+    void add_rank4_mo_to_ao(
+        std::vector<double> &dm2_ao,
+        int nao,
+        const Eigen::MatrixXd &C1,
+        int p,
+        const Eigen::MatrixXd &C2,
+        int q,
+        const Eigen::MatrixXd &C3,
+        int r,
+        const Eigen::MatrixXd &C4,
+        int s,
+        double coeff)
+    {
+        if (std::abs(coeff) < 1e-14)
+            return;
+
+        for (int mu = 0; mu < nao; ++mu)
+        {
+            const double c1 = C1(mu, p);
+            if (std::abs(c1) < 1e-14)
+                continue;
+            for (int nu = 0; nu < nao; ++nu)
+            {
+                const double c12 = c1 * C2(nu, q);
+                if (std::abs(c12) < 1e-14)
+                    continue;
+                for (int la = 0; la < nao; ++la)
+                {
+                    const double c123 = c12 * C3(la, r);
+                    if (std::abs(c123) < 1e-14)
+                        continue;
+                    for (int si = 0; si < nao; ++si)
+                        dm2_ao[idx_dm2(mu, nu, la, si, nao)] += coeff * c123 * C4(si, s);
+                }
+            }
+        }
     }
 
 } // namespace
@@ -458,6 +528,156 @@ namespace HartreeFock::Correlation
         out.vhf_s1occ_ao = std::move(vhf_s1occ);
         out.Gamma_pair_ao = pair_dm2_ao;
         out.pair_dm2_ao = pair_dm2_ao;
+        return out;
+    }
+
+    std::expected<UMP2GradientIntermediates, std::string> build_ump2_gradient_intermediates(
+        HartreeFock::Calculator &calculator,
+        const std::vector<HartreeFock::ShellPair> &shell_pairs)
+    {
+        if (!calculator._info._scf.is_uhf ||
+            calculator._scf._scf != HartreeFock::SCFType::UHF)
+            return std::unexpected("build_ump2_gradient_intermediates: UHF reference required.");
+        if (!calculator._info._is_converged)
+            return std::unexpected("build_ump2_gradient_intermediates: SCF not converged.");
+
+        const int nb = static_cast<int>(calculator._shells.nbasis());
+        auto counts_res = get_ump2_counts(calculator, nb);
+        if (!counts_res)
+            return std::unexpected(counts_res.error());
+        const auto counts = *counts_res;
+
+        const Eigen::MatrixXd &Ca = calculator._info._scf.alpha.mo_coefficients;
+        const Eigen::MatrixXd &Cb = calculator._info._scf.beta.mo_coefficients;
+        const Eigen::VectorXd &epsa = calculator._info._scf.alpha.mo_energies;
+        const Eigen::VectorXd &epsb = calculator._info._scf.beta.mo_energies;
+
+        const Eigen::MatrixXd Ca_occ = Ca.leftCols(counts.n_alpha);
+        const Eigen::MatrixXd Ca_virt = Ca.middleCols(counts.n_alpha, counts.nva);
+        const Eigen::MatrixXd Cb_occ = Cb.leftCols(counts.n_beta);
+        const Eigen::MatrixXd Cb_virt = Cb.middleCols(counts.n_beta, counts.nvb);
+
+        std::vector<double> eri_local;
+        const std::vector<double> &eri = ensure_eri(
+            calculator, shell_pairs, eri_local, "UMP2 Gradient :");
+
+        const auto mo_aa = transform_eri(eri, nb, Ca_occ, Ca_virt, Ca_occ, Ca_virt);
+        const auto mo_bb = transform_eri(eri, nb, Cb_occ, Cb_virt, Cb_occ, Cb_virt);
+        const auto mo_ab = transform_eri(eri, nb, Ca_occ, Ca_virt, Cb_occ, Cb_virt);
+
+        Eigen::MatrixXd Da_occ = Eigen::MatrixXd::Zero(counts.n_alpha, counts.n_alpha);
+        Eigen::MatrixXd Da_virt = Eigen::MatrixXd::Zero(counts.nva, counts.nva);
+        Eigen::MatrixXd Db_occ = Eigen::MatrixXd::Zero(counts.n_beta, counts.n_beta);
+        Eigen::MatrixXd Db_virt = Eigen::MatrixXd::Zero(counts.nvb, counts.nvb);
+
+        std::vector<double> pair_dm2_ao(static_cast<std::size_t>(nb) * nb * nb * nb, 0.0);
+
+        auto idx_aa = [nva = counts.nva, na = counts.n_alpha](int i, int a, int j, int b) -> std::size_t
+        {
+            return ((static_cast<std::size_t>(i) * nva + a) * na + j) * nva + b;
+        };
+        auto idx_bb = [nvb = counts.nvb, nbeta = counts.n_beta](int i, int a, int j, int b) -> std::size_t
+        {
+            return ((static_cast<std::size_t>(i) * nvb + a) * nbeta + j) * nvb + b;
+        };
+        auto idx_ab = [nva = counts.nva, nbeta = counts.n_beta, nvb = counts.nvb](int i, int a, int j, int b) -> std::size_t
+        {
+            return ((static_cast<std::size_t>(i) * nva + a) * nbeta + j) * nvb + b;
+        };
+
+        for (int i = 0; i < counts.n_alpha; ++i)
+            for (int j = 0; j < counts.n_alpha; ++j)
+                for (int a = 0; a < counts.nva; ++a)
+                    for (int b = 0; b < counts.nva; ++b)
+                    {
+                        const double iajb = mo_aa[idx_aa(i, a, j, b)];
+                        const double ibja = mo_aa[idx_aa(i, b, j, a)];
+                        const double denom = epsa(i) + epsa(j) -
+                                             epsa(counts.n_alpha + a) -
+                                             epsa(counts.n_alpha + b);
+                        const double t = (iajb - ibja) / denom;
+                        Da_occ(i, i) -= 0.25 * t * t;
+                        Da_occ(j, j) -= 0.25 * t * t;
+                        Da_virt(a, a) += 0.25 * t * t;
+                        Da_virt(b, b) += 0.25 * t * t;
+                        add_rank4_mo_to_ao(pair_dm2_ao, nb, Ca_occ, i, Ca_virt, a, Ca_occ, j, Ca_virt, b, t);
+                        add_rank4_mo_to_ao(pair_dm2_ao, nb, Ca_virt, a, Ca_occ, i, Ca_virt, b, Ca_occ, j, t);
+                    }
+
+        for (int i = 0; i < counts.n_beta; ++i)
+            for (int j = 0; j < counts.n_beta; ++j)
+                for (int a = 0; a < counts.nvb; ++a)
+                    for (int b = 0; b < counts.nvb; ++b)
+                    {
+                        const double iajb = mo_bb[idx_bb(i, a, j, b)];
+                        const double ibja = mo_bb[idx_bb(i, b, j, a)];
+                        const double denom = epsb(i) + epsb(j) -
+                                             epsb(counts.n_beta + a) -
+                                             epsb(counts.n_beta + b);
+                        const double t = (iajb - ibja) / denom;
+                        Db_occ(i, i) -= 0.25 * t * t;
+                        Db_occ(j, j) -= 0.25 * t * t;
+                        Db_virt(a, a) += 0.25 * t * t;
+                        Db_virt(b, b) += 0.25 * t * t;
+                        add_rank4_mo_to_ao(pair_dm2_ao, nb, Cb_occ, i, Cb_virt, a, Cb_occ, j, Cb_virt, b, t);
+                        add_rank4_mo_to_ao(pair_dm2_ao, nb, Cb_virt, a, Cb_occ, i, Cb_virt, b, Cb_occ, j, t);
+                    }
+
+        for (int i = 0; i < counts.n_alpha; ++i)
+            for (int j = 0; j < counts.n_beta; ++j)
+                for (int a = 0; a < counts.nva; ++a)
+                    for (int b = 0; b < counts.nvb; ++b)
+                    {
+                        const double iajb = mo_ab[idx_ab(i, a, j, b)];
+                        const double denom = epsa(i) + epsb(j) -
+                                             epsa(counts.n_alpha + a) -
+                                             epsb(counts.n_beta + b);
+                        const double t = iajb / denom;
+                        Da_occ(i, i) -= t * t;
+                        Db_occ(j, j) -= t * t;
+                        Da_virt(a, a) += t * t;
+                        Db_virt(b, b) += t * t;
+                        add_rank4_mo_to_ao(pair_dm2_ao, nb, Ca_occ, i, Ca_virt, a, Cb_occ, j, Cb_virt, b, 2.0 * t);
+                        add_rank4_mo_to_ao(pair_dm2_ao, nb, Ca_virt, a, Ca_occ, i, Cb_virt, b, Cb_occ, j, 2.0 * t);
+                    }
+
+        const Eigen::MatrixXd Pa_corr =
+            Ca_occ * Da_occ * Ca_occ.transpose() +
+            Ca_virt * Da_virt * Ca_virt.transpose();
+        const Eigen::MatrixXd Pb_corr =
+            Cb_occ * Db_occ * Cb_occ.transpose() +
+            Cb_virt * Db_virt * Cb_virt.transpose();
+
+        Eigen::MatrixXd Wa_corr = Eigen::MatrixXd::Zero(nb, nb);
+        for (int i = 0; i < counts.n_alpha; ++i)
+            for (int j = 0; j < counts.n_alpha; ++j)
+                Wa_corr += 0.5 * (epsa(i) + epsa(j)) * Da_occ(i, j) *
+                           (Ca_occ.col(i) * Ca_occ.col(j).transpose());
+        for (int a = 0; a < counts.nva; ++a)
+            for (int b = 0; b < counts.nva; ++b)
+                Wa_corr += 0.5 * (epsa(counts.n_alpha + a) + epsa(counts.n_alpha + b)) * Da_virt(a, b) *
+                           (Ca_virt.col(a) * Ca_virt.col(b).transpose());
+
+        Eigen::MatrixXd Wb_corr = Eigen::MatrixXd::Zero(nb, nb);
+        for (int i = 0; i < counts.n_beta; ++i)
+            for (int j = 0; j < counts.n_beta; ++j)
+                Wb_corr += 0.5 * (epsb(i) + epsb(j)) * Db_occ(i, j) *
+                           (Cb_occ.col(i) * Cb_occ.col(j).transpose());
+        for (int a = 0; a < counts.nvb; ++a)
+            for (int b = 0; b < counts.nvb; ++b)
+                Wb_corr += 0.5 * (epsb(counts.n_beta + a) + epsb(counts.n_beta + b)) * Db_virt(a, b) *
+                           (Cb_virt.col(a) * Cb_virt.col(b).transpose());
+
+        UMP2GradientIntermediates out;
+        out.P_alpha_corr_ao = Pa_corr;
+        out.P_beta_corr_ao = Pb_corr;
+        out.P_alpha_ao = calculator._info._scf.alpha.density + Pa_corr;
+        out.P_beta_ao = calculator._info._scf.beta.density + Pb_corr;
+        out.P_total_ao = out.P_alpha_ao + out.P_beta_ao;
+        out.W_ao = Ca_occ * epsa.head(counts.n_alpha).asDiagonal() * Ca_occ.transpose() +
+                   Cb_occ * epsb.head(counts.n_beta).asDiagonal() * Cb_occ.transpose() +
+                   Wa_corr + Wb_corr;
+        out.Gamma_pair_ao = std::move(pair_dm2_ao);
         return out;
     }
 

--- a/src/post_hf/mp2_gradient.h
+++ b/src/post_hf/mp2_gradient.h
@@ -54,6 +54,17 @@ namespace HartreeFock::Correlation
         std::vector<double> pair_dm2_ao;   // explicit MP2 pair-density correction
     };
 
+    struct UMP2GradientIntermediates
+    {
+        Eigen::MatrixXd P_alpha_ao;        // alpha HF + correlated first-order density
+        Eigen::MatrixXd P_beta_ao;         // beta HF + correlated first-order density
+        Eigen::MatrixXd P_alpha_corr_ao;   // alpha correlated density correction
+        Eigen::MatrixXd P_beta_corr_ao;    // beta correlated density correction
+        Eigen::MatrixXd P_total_ao;        // spin-summed HF + correlated first-order density
+        Eigen::MatrixXd W_ao;              // spin-summed energy-weighted density
+        std::vector<double> Gamma_pair_ao; // explicit UMP2 pair-density correction
+    };
+
     std::expected<RMP2AmplitudeData, std::string> build_rmp2_amplitudes(
         HartreeFock::Calculator &calculator,
         const std::vector<HartreeFock::ShellPair> &shell_pairs);
@@ -108,6 +119,14 @@ namespace HartreeFock::Correlation
     // the first-order densities used in the one- and two-electron terms, the
     // correlated overlap/Lagrangian objects, and the explicit pair density.
     std::expected<RMP2GradientIntermediates, std::string> build_rmp2_gradient_intermediates(
+        HartreeFock::Calculator &calculator,
+        const std::vector<HartreeFock::ShellPair> &shell_pairs);
+
+    // Build unrestricted MP2 analytic-gradient intermediates in spin-resolved
+    // form. The current implementation includes the explicit UMP2 pair density
+    // and spin-block unrelaxed 1PDM contributions; it is intended for canonical
+    // UHF references.
+    std::expected<UMP2GradientIntermediates, std::string> build_ump2_gradient_intermediates(
         HartreeFock::Calculator &calculator,
         const std::vector<HartreeFock::ShellPair> &shell_pairs);
 } // namespace HartreeFock::Correlation

--- a/tests/inputs/regression/open_shell/water_radical_cation_uhf_ump2_gradient_sto3g.hfinp
+++ b/tests/inputs/regression/open_shell/water_radical_cation_uhf_ump2_gradient_sto3g.hfinp
@@ -1,0 +1,31 @@
+%begin_control
+    basis       sto-3g
+    calculation gradient
+    print_populations .true.
+    verbosity   normal
+    basis_type  cartesian
+%end_control
+
+%begin_scf
+    scf_type      uhf
+    correlation   ump2
+    use_diis      .true.
+    diis_dim      8
+    engine        os
+    level_shift   0.3
+    diis_restart  2.0
+%end_scf
+
+%begin_geom
+    coord_type  cartesian
+    coord_units angstrom
+    use_symm    .true.
+%end_geom
+
+%begin_coords
+3
+1   2
+O     0.000000    0.000000     0.117176
+H     0.000000    0.756950    -0.468703
+H     0.000000   -0.756950    -0.468703
+%end_coords

--- a/tests/regression_cases.json
+++ b/tests/regression_cases.json
@@ -169,6 +169,21 @@
       ]
     },
     {
+      "id": "water_radical_cation_ump2_gradient_smoke",
+      "input": "tests/inputs/regression/open_shell/water_radical_cation_uhf_ump2_gradient_sto3g.hfinp",
+      "tags": ["extended"],
+      "expected_exit_code": 0,
+      "contains": [
+        "Using analytic UMP2 gradient (spin-resolved density + pair density)",
+        "Nuclear Gradient (Ha/Bohr) :"
+      ],
+      "checks": [
+        {"type": "metric_present", "metric": "gradient_max"},
+        {"type": "metric_present", "metric": "gradient_rms"},
+        {"type": "metric_eq", "metric": "gradient_atom_lines", "expected": 3}
+      ]
+    },
+    {
       "id": "h2_rccsdt_sto3g",
       "input": "tests/inputs/regression/post_hf/h2_rccsdt_sto3g.hfinp",
       "tags": ["smoke", "extended"],


### PR DESCRIPTION
Add spin-resolved UMP2 gradient intermediates for canonical UHF references, including same-spin and opposite-spin MP2 amplitude handling, correlated alpha/beta density corrections, spin-summed energy-weighted density, and explicit AO pair-density contributions.

Wire the new UMP2 gradient path into the gradient driver so correlation ump2 with calculation gradient now produces the correlated nuclear gradient instead of exiting as unimplemented.

Document UMP2 gradient support in README, QUICKSTART, and the Planck teaching guide, then regenerate docs/index.html from the updated teaching guide.

Add an open-shell water radical cation UMP2 gradient regression input and manifest smoke case. Verified with cmake --build build -j 4 and python3 tests/run_regressions.py --case water_radical_cation_ump2_gradient_smoke --case h2_rmp2_gradient_smoke --suite all.