### PR TITLE
Add initial TDDFT, Löwdin/Mayer analyses, open-shell SAD, PySCF harness

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -507,6 +507,24 @@ if(BUILD_TESTING)
 endif()
 
 if(BUILD_TESTING AND Python3_Interpreter_FOUND)
+    set(PLANCK_PYSCF_PYTHON "" CACHE FILEPATH
+        "Python interpreter with PySCF installed for tests/pyscf")
+    set(_planck_pyscf_default "${CMAKE_SOURCE_DIR}/tests/pyscf/.venv/bin/python")
+    if(NOT PLANCK_PYSCF_PYTHON)
+        if(EXISTS "${_planck_pyscf_default}")
+            set(PLANCK_PYSCF_PYTHON "${_planck_pyscf_default}")
+        else()
+            set(PLANCK_PYSCF_PYTHON "${Python3_EXECUTABLE}")
+        endif()
+    endif()
+
+    execute_process(
+        COMMAND ${PLANCK_PYSCF_PYTHON} -c "import pyscf"
+        RESULT_VARIABLE PLANCK_PYSCF_IMPORT_RESULT
+        OUTPUT_QUIET
+        ERROR_QUIET
+    )
+
     add_test(
         NAME planck-regression-smoke
         COMMAND ${Python3_EXECUTABLE}
@@ -567,6 +585,27 @@ if(BUILD_TESTING AND Python3_Interpreter_FOUND)
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         USES_TERMINAL
     )
+
+    if(PLANCK_PYSCF_IMPORT_RESULT EQUAL 0)
+        add_test(
+            NAME planck-pyscf-equivalence
+            COMMAND ${PLANCK_PYSCF_PYTHON}
+                    ${CMAKE_SOURCE_DIR}/tests/pyscf/run_all.py
+                    --python ${PLANCK_PYSCF_PYTHON}
+        )
+
+        add_custom_target(pyscf-equivalence
+            COMMAND ${PLANCK_PYSCF_PYTHON}
+                    ${CMAKE_SOURCE_DIR}/tests/pyscf/run_all.py
+                    --python ${PLANCK_PYSCF_PYTHON}
+            DEPENDS hartree-fock
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            USES_TERMINAL
+        )
+    else()
+        message(STATUS
+            "PySCF tests : skipped (set PLANCK_PYSCF_PYTHON to a Python with PySCF installed)")
+    endif()
 endif()
 
 # ── Basis set fetcher ─────────────────────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A quantum chemistry program implementing restricted, unrestricted, and restricte
 
 - **RHF / ROHF / UHF** — closed-shell, restricted open-shell, and unrestricted Hartree-Fock; ROHF uses a Roothaan-type effective Fock construction with aufbau orbital reordering and DIIS convergence
 - **RKS / UKS (Kohn-Sham DFT)** — closed-shell and open-shell Kohn-Sham SCF via the `planck-dft` executable; LDA, GGA, and global hybrid exchange-correlation functionals through libxc; four grid quality presets (Coarse/Normal/Fine/UltraFine); arbitrary libxc functionals via integer ID
+- **Initial TDDFT / linear response** — closed-shell RKS excited-state roots via a TDA-style singlet response build on top of converged KS orbitals, with transition dipoles and oscillator strengths. The current implementation includes Hartree and global-hybrid exact-exchange coupling, but does not yet include semilocal XC kernels or UKS response.
 - **Two integral engines** — Obara-Saika for low angular momentum; Rys quadrature for high angular momentum; automatic engine selection per shell quartet (`engine auto`)
 - **Electric multipole moments** — dipole and quadrupole moment analysis after SCF convergence for both `hartree-fock` and `planck-dft`
 - **Mulliken population analysis** — atomic gross populations, net charges, and (for UHF/ROHF) spin populations; printed when `print_populations true` or verbosity is `verbose`/`debug`
@@ -159,7 +160,7 @@ General calculation settings.
 |---|---|---|---|---|
 | `basis` | string | `sto-3g`, `3-21g`, `6-31g`, `6-31g*` | — | Basis set name |
 | `basis_type` | enum | `cartesian`, `spherical` | `cartesian` | Angular function type. Only Cartesian is fully supported. |
-| `calculation` | enum | `energy`/`sp`, `gradient`/`grad`, `geomopt`/`opt`, `freq`/`frequency`, `optfreq`/`geomoptfreq`/`geomopt+freq`, `imagfollow`/`imag_follow`/`irc_follow` | — | Calculation type. `gradient` computes the analytic nuclear gradient and stops. `geomopt` optimizes the geometry. `freq` computes the semi-numerical Hessian and vibrational frequencies. `optfreq` performs geometry optimization followed by frequency analysis. `imagfollow` follows the lowest imaginary frequency mode downhill. |
+| `calculation` | enum | `energy`/`sp`, `gradient`/`grad`, `geomopt`/`opt`, `freq`/`frequency`, `optfreq`/`geomoptfreq`/`geomopt+freq`, `imagfollow`/`imag_follow`/`irc_follow`, `tddft`/`td-dft`/`linearresponse`/`linear_response`/`lr` | — | Calculation type. `gradient` computes the analytic nuclear gradient and stops. `geomopt` optimizes the geometry. `freq` computes the semi-numerical Hessian and vibrational frequencies. `optfreq` performs geometry optimization followed by frequency analysis. `imagfollow` follows the lowest imaginary frequency mode downhill. `tddft` runs the initial closed-shell linear-response excited-state solver in `planck-dft`. |
 | `verbosity` | enum | `silent`, `minimal`, `normal`, `verbose`, `debug` | `minimal` | Output level |
 | `basis_path` | string | filesystem path | compiled-in | Override the basis set search directory |
 | `print_populations` | bool | `.true.`, `.false.` | `.false.` | Print Mulliken population analysis after SCF convergence. Enabled automatically when `verbosity verbose` or `verbosity debug`. |
@@ -216,6 +217,7 @@ Kohn-Sham DFT settings. Only read by `planck-dft`; ignored by `hartree-fock`. Th
 | `correlation` | enum | `vwn`/`vwn5`, `lyp`, `p86`, `pw91`, `pbe` | `pbe` | Correlation functional |
 | `exchange_id` | int | any libxc integer ID | — | Use an arbitrary libxc exchange functional by its integer identifier. Overrides `exchange`. |
 | `correlation_id` | int | any libxc integer ID | — | Use an arbitrary libxc correlation functional by its integer identifier. Overrides `correlation`. |
+| `lr_nstates` / `tddft_nstates` / `nstates` | int | ≥ 1 | `5` | Number of singlet excited states to report for `calculation tddft` / `linearresponse`. |
 | `use_sao_blocking` | bool | `.true.`, `.false.` | `.true.` | Enable symmetry-adapted AO blocking for the Coulomb matrix assembly. |
 | `print_grid_summary` | bool | `.true.`, `.false.` | `.true.` | Print a per-atom grid point count summary before the KS iterations. |
 | `save_checkpoint` | bool | `.true.`, `.false.` | `.false.` | Write a `.dftchk` checkpoint file after successful convergence. |

--- a/docs/PLANCK_TEACHING_GUIDE.md
+++ b/docs/PLANCK_TEACHING_GUIDE.md
@@ -2805,11 +2805,95 @@ The `KSPotentialMatrices` struct holds the Coulomb, XC-alpha, and XC-beta matric
 | KS-DFT main loop | `src/dft/driver.cpp` | `DFT::Driver::run` |
 | DFT entry point | `src/dft/main.cpp` | `main` |
 
+### Initial TD-DFT / Linear Response
+
+**What is implemented**
+
+Planck currently provides an initial excited-state solver for `planck-dft` via
+`calculation tddft` (aliases: `td-dft`, `linearresponse`, `lr`).  The present
+implementation is intentionally narrow and teaching-oriented:
+
+- closed-shell **RKS only**
+- singlet excitations only
+- **TDA-style** response build (the Hermitian \(A\) matrix is diagonalized; no
+  full Casida \(A/B\) non-Hermitian solve yet)
+- Hartree coupling is included
+- global-hybrid exact exchange is included through the functional's exact
+  exchange coefficient
+- semilocal XC response kernels \(f_{xc}\) are **not** yet included
+- UKS/open-shell response is not yet implemented
+
+So, despite the user-facing `tddft` keyword, the current method is best thought
+of as a first linear-response / TDA excited-state module layered on top of the
+converged Kohn-Sham orbitals.
+
+**Theory**
+
+For a closed-shell reference with occupied orbitals \(i,j\) and virtual
+orbitals \(a,b\), Planck forms the orbital-rotation excitation basis
+\(| i \rightarrow a \rangle\) and builds the TDA matrix
+
+\[
+A_{ia,jb} = \delta_{ij}\delta_{ab}(\varepsilon_a - \varepsilon_i)
+          + 2(ia|jb)
+          - c_x (ij|ab)
+\]
+
+where \(c_x\) is the global-hybrid exact-exchange fraction.  In this initial
+implementation the semilocal XC kernel contribution is omitted, so the response
+matrix contains only the orbital-energy gap term, the Coulomb coupling, and the
+hybrid exchange correction.
+
+Diagonalizing \(A\) gives the excitation energies \(\omega_k\) and the
+excitation amplitudes \(X^{(k)}_{ia}\).  Transition dipoles are then evaluated
+from the occupied-virtual dipole blocks:
+
+\[
+\boldsymbol{\mu}^{(k)}_{\mathrm{tr}}
+= \sqrt{2}\sum_{ia} X^{(k)}_{ia}\,\langle i|\hat{\mathbf r}|a\rangle
+\]
+
+and the oscillator strength is reported as
+
+\[
+f_k = \frac{2}{3}\,\omega_k\,\left|\boldsymbol{\mu}^{(k)}_{\mathrm{tr}}\right|^2
+\]
+
+with \(\omega_k\) in Hartree and \(\boldsymbol{\mu}_{\mathrm{tr}}\) in atomic
+units.
+
+**Code path**
+
+`src/dft/driver.cpp` — `run_linear_response_tda()`
+
+The solver reuses the converged KS reference already built by the SCF scaffold:
+
+1. confirm the reference is converged, closed-shell, and restricted
+2. split the MO coefficient matrix into occupied and virtual blocks
+3. transform AO ERIs into the \(ovov\) and \(oovv\) blocks needed by the
+   response kernel
+4. assemble the dense TDA matrix \(A\)
+5. diagonalize \(A\) with `Eigen::SelfAdjointEigenSolver`
+6. build transition dipoles from AO dipole integrals transformed to the
+   occupied-virtual MO basis
+7. sort and print the dominant occupied \(\rightarrow\) virtual configurations
+   for each root
+
+The report printed by `print_linear_response_report()` includes the root index,
+excitation energy in Hartree and eV, oscillator strength, Cartesian transition
+dipole components, the dipole norm in Debye, and the three largest
+configuration weights.
+
 ---
 
 ## 19. Molecular Properties
 
-After SCF convergence Planck computes several molecular properties from the converged density matrix.  All are printed automatically (or under `verbosity verbose`) without additional input; no extra keywords are needed.  This section covers the theory behind each property and the code path that evaluates it.
+After SCF convergence Planck can compute several molecular properties from the
+converged density matrix. Dipole and quadrupole moments are printed
+automatically; population and bond-order reports are printed when
+`print_populations true` or the output `verbosity` is `verbose` / `debug`.
+This section covers the theory behind each property and the code path that
+evaluates it.
 
 ### Mulliken Population Analysis
 
@@ -2852,6 +2936,110 @@ Eigen::VectorXd gross = (density.array() * overlap.array()).rowwise().sum();
 The function then iterates over `basis._basis_functions`, accumulates `gross[μ]` into the correct atom bucket via `cv._shell->_atom_index`, and fills an `AtomicPopulation` struct.  When a `spin_density_ptr` is provided the same loop runs a second time over \(\Delta P\).
 
 Population analysis is triggered when `_output._print_populations` is set or `verbosity` is `verbose` / `debug` (see `log_population_report` in `src/driver.cpp:71`).
+
+### Löwdin Population Analysis
+
+**Theory**
+
+Mulliken populations depend directly on the AO overlap partitioning.  Löwdin
+analysis instead first orthogonalizes the AO basis with the symmetric overlap
+square root:
+
+\[
+\mathbf S = \mathbf U\,\mathbf s\,\mathbf U^\mathrm T,
+\qquad
+\mathbf S^{1/2} = \mathbf U\,\mathbf s^{1/2}\,\mathbf U^\mathrm T
+\]
+
+The density matrix is then transformed into the orthogonal Löwdin AO basis:
+
+\[
+\widetilde{\mathbf P} = \mathbf S^{1/2}\mathbf P \mathbf S^{1/2}
+\]
+
+The AO populations are simply the diagonal elements of this orthogonalized
+density,
+
+\[
+q_\mu^{\mathrm{L\ddot owdin}} = \widetilde P_{\mu\mu}
+\]
+
+and atomic populations are obtained by summing over the AOs on each atom:
+
+\[
+N_A^{\mathrm{L\ddot owdin}} = \sum_{\mu \in A} \widetilde P_{\mu\mu}
+\]
+
+For open-shell references the same transformation is applied to the spin-density
+matrix \(\Delta P = P^\alpha - P^\beta\), giving
+
+\[
+\widetilde{\Delta P} = \mathbf S^{1/2}\Delta\mathbf P\,\mathbf S^{1/2}
+\]
+
+and the atomic spin population is the sum of the diagonal entries belonging to
+that atom.
+
+**Code path**
+
+`src/scf/population.cpp` — `lowdin_population_analysis()`
+
+The implementation diagonalizes the AO overlap with
+`Eigen::SelfAdjointEigenSolver`, clips tiny eigenvalues with a numerical
+threshold, reconstructs the symmetric square root \(\mathbf S^{1/2}\), and
+forms the orthogonalized density and spin-density matrices.  The atomic
+accumulation step is then shared with Mulliken analysis through
+`accumulate_atomic_populations()`, so the printed report has the same table
+layout: per-atom electron population, net charge, and optional spin population.
+
+### Mayer Bond Orders
+
+**Theory**
+
+Mayer bond orders are built from the AO population matrix
+
+\[
+\mathbf{PS} = \mathbf P \mathbf S
+\]
+
+For atoms \(A\) and \(B\), the closed-shell Mayer bond order is
+
+\[
+B_{AB}^{\mathrm{Mayer}} =
+\sum_{\mu \in A}\sum_{\nu \in B}
+(\mathbf{PS})_{\mu\nu}(\mathbf{PS})_{\nu\mu}
+\]
+
+This measures how strongly the AO subspaces on atoms \(A\) and \(B\) mix
+through the occupied density in a non-orthogonal basis.
+
+For open-shell references Planck uses the spin-resolved form, summing separate
+\(\alpha\) and \(\beta\) contributions:
+
+\[
+B_{AB}^{\mathrm{Mayer}} =
+\sum_{\mu \in A}\sum_{\nu \in B}
+\left[
+(\mathbf P^\alpha \mathbf S)_{\mu\nu}(\mathbf P^\alpha \mathbf S)_{\nu\mu}
++
+(\mathbf P^\beta \mathbf S)_{\mu\nu}(\mathbf P^\beta \mathbf S)_{\nu\mu}
+\right]
+\]
+
+The diagonal \(B_{AA}\) is left at zero in the printed matrix, and the
+off-diagonal matrix is symmetrized.
+
+**Code path**
+
+`src/scf/population.cpp` — `mayer_bond_order_analysis()`
+
+The routine first validates the density dimensions and builds the AO lists for
+each atom.  It then forms either \(\mathbf P\mathbf S\) or the spin-resolved
+\(\mathbf P^\alpha\mathbf S\) / \(\mathbf P^\beta\mathbf S\) products and loops
+over atom pairs \(A < B\).  For each AO pair \(\mu \in A\), \(\nu \in B\) it
+accumulates the appropriate product into a dense `natoms × natoms` bond-order
+matrix.  `src/driver.cpp` prints the final matrix below the Mulliken and
+Löwdin tables whenever population reporting is enabled.
 
 ### Electric Dipole Moment
 
@@ -3233,7 +3421,10 @@ driver.cpp
 | XC matrix assembly | `src/dft/ks_matrix.cpp` | `assemble_xc_matrix` |
 | KS potential matrices | `src/dft/ks_matrix.cpp` | `combine_ks_potential` |
 | KS-DFT driver | `src/dft/driver.cpp` | `DFT::Driver::run` |
+| TD-DFT / linear response (TDA) | `src/dft/driver.cpp` | `run_linear_response_tda`, `print_linear_response_report` |
 | Mulliken population analysis | `src/scf/population.cpp` | `mulliken_population_analysis`, `gross_ao_population` |
+| Löwdin population analysis | `src/scf/population.cpp` | `lowdin_population_analysis`, `symmetric_overlap_sqrt` |
+| Mayer bond orders | `src/scf/population.cpp` | `mayer_bond_order_analysis` |
 | Dipole / quadrupole AO integrals | `src/integrals/os.cpp` | `_os_1d_moments`, `_compute_multipole_matrices` |
 | Multipole moments (traceless) | `src/integrals/os.cpp` | `_compute_multipole_moments` |
 | RMP2 natural orbitals | `src/post_hf/mp2.cpp` | `compute_rmp2_natural_orbitals` |
@@ -3247,7 +3438,7 @@ driver.cpp
 | Feature | Status |
 |---|---|
 | RHF and UHF SCF | Complete |
-| ROHF SCF | Complete (Guest–Saunders effective Fock; no SAD guess; post-HF not yet supported from ROHF reference) |
+| ROHF SCF | Complete (Guest–Saunders effective Fock with SAD guess; post-HF not yet supported from ROHF reference) |
 | Obara-Saika 1e and 2e integrals | Complete |
 | Rys quadrature ERIs | Complete |
 | Conventional and direct SCF | Complete |
@@ -3276,6 +3467,7 @@ driver.cpp
 | GGA XC functionals (B88, PBE, PW91 exchange; LYP, P86, PBE, PW91 correlation) | Complete |
 | Arbitrary libxc functionals via integer ID | Complete |
 | Molecular grid (Treutler-Ahlrichs + Lebedev + Becke) | Complete |
+| Initial TD-DFT / linear response (closed-shell RKS, TDA-style singlets) | Complete |
 | DFT geometry optimization / gradients | Not implemented |
 | Global hybrid XC functionals (B3LYP, PBE0, compatible libxc IDs) | Complete |
 | Range-separated and double-hybrid XC functionals | Not supported |

--- a/docs/index.html
+++ b/docs/index.html
@@ -250,8 +250,11 @@
 <li class="toc-level-3"><a href="#xc-matrix-assembly">XC Matrix Assembly</a></li>
 <li class="toc-level-3"><a href="#ks-dft-scf-loop">KS-DFT SCF Loop</a></li>
 <li class="toc-level-3"><a href="#dft-code-map">DFT Code Map</a></li>
+<li class="toc-level-3"><a href="#initial-td-dft-linear-response">Initial TD-DFT / Linear Response</a></li>
 <li class="toc-level-2"><a href="#19-molecular-properties">19. Molecular Properties</a></li>
 <li class="toc-level-3"><a href="#mulliken-population-analysis">Mulliken Population Analysis</a></li>
+<li class="toc-level-3"><a href="#l-wdin-population-analysis">Löwdin Population Analysis</a></li>
+<li class="toc-level-3"><a href="#mayer-bond-orders">Mayer Bond Orders</a></li>
 <li class="toc-level-3"><a href="#electric-dipole-moment">Electric Dipole Moment</a></li>
 <li class="toc-level-3"><a href="#traceless-quadrupole-moment">Traceless Quadrupole Moment</a></li>
 <li class="toc-level-3"><a href="#rmp2-natural-orbitals">RMP2 Natural Orbitals</a></li>
@@ -1794,9 +1797,53 @@ V^{xc}_{\mu\nu} = \sum_g w_g\, v_{\rho,g}\, \phi_\mu(\mathbf r_g)\, \phi_\nu(\ma
 <tr><td>KS-DFT main loop</td><td><code>src/dft/driver.cpp</code></td><td><code>DFT::Driver::run</code></td></tr>
 <tr><td>DFT entry point</td><td><code>src/dft/main.cpp</code></td><td><code>main</code></td></tr>
 </tbody></table></div>
+<h3 id="initial-td-dft-linear-response">Initial TD-DFT / Linear Response</h3>
+<p><strong>What is implemented</strong></p>
+<p>Planck currently provides an initial excited-state solver for <code>planck-dft</code> via <code>calculation tddft</code> (aliases: <code>td-dft</code>, <code>linearresponse</code>, <code>lr</code>).  The present implementation is intentionally narrow and teaching-oriented:</p>
+<ul>
+<li>closed-shell <strong>RKS only</strong></li>
+<li>singlet excitations only</li>
+<li><strong>TDA-style</strong> response build (the Hermitian <span class="math-inline">\(A\)</span> matrix is diagonalized; no full Casida <span class="math-inline">\(A/B\)</span> non-Hermitian solve yet)</li>
+<li>Hartree coupling is included</li>
+<li>global-hybrid exact exchange is included through the functional&#x27;s exact exchange coefficient</li>
+<li>semilocal XC response kernels <span class="math-inline">\(f_{xc}\)</span> are <strong>not</strong> yet included</li>
+<li>UKS/open-shell response is not yet implemented</li>
+</ul>
+<p>So, despite the user-facing <code>tddft</code> keyword, the current method is best thought of as a first linear-response / TDA excited-state module layered on top of the converged Kohn-Sham orbitals.</p>
+<p><strong>Theory</strong></p>
+<p>For a closed-shell reference with occupied orbitals <span class="math-inline">\(i,j\)</span> and virtual orbitals <span class="math-inline">\(a,b\)</span>, Planck forms the orbital-rotation excitation basis <span class="math-inline">\(| i \rightarrow a \rangle\)</span> and builds the TDA matrix</p>
+<p><span class="math-display">\[
+A_{ia,jb} = \delta_{ij}\delta_{ab}(\varepsilon_a - \varepsilon_i)
+          + 2(ia|jb)
+          - c_x (ij|ab)
+\]</span></p>
+<p>where <span class="math-inline">\(c_x\)</span> is the global-hybrid exact-exchange fraction.  In this initial implementation the semilocal XC kernel contribution is omitted, so the response matrix contains only the orbital-energy gap term, the Coulomb coupling, and the hybrid exchange correction.</p>
+<p>Diagonalizing <span class="math-inline">\(A\)</span> gives the excitation energies <span class="math-inline">\(\omega_k\)</span> and the excitation amplitudes <span class="math-inline">\(X^{(k)}_{ia}\)</span>.  Transition dipoles are then evaluated from the occupied-virtual dipole blocks:</p>
+<p><span class="math-display">\[
+\boldsymbol{\mu}^{(k)}_{\mathrm{tr}}
+= \sqrt{2}\sum_{ia} X^{(k)}_{ia}\,\langle i|\hat{\mathbf r}|a\rangle
+\]</span></p>
+<p>and the oscillator strength is reported as</p>
+<p><span class="math-display">\[
+f_k = \frac{2}{3}\,\omega_k\,\left|\boldsymbol{\mu}^{(k)}_{\mathrm{tr}}\right|^2
+\]</span></p>
+<p>with <span class="math-inline">\(\omega_k\)</span> in Hartree and <span class="math-inline">\(\boldsymbol{\mu}_{\mathrm{tr}}\)</span> in atomic units.</p>
+<p><strong>Code path</strong></p>
+<p><code>src/dft/driver.cpp</code> — <code>run_linear_response_tda()</code></p>
+<p>The solver reuses the converged KS reference already built by the SCF scaffold:</p>
+<ol>
+<li>confirm the reference is converged, closed-shell, and restricted</li>
+<li>split the MO coefficient matrix into occupied and virtual blocks</li>
+<li>transform AO ERIs into the <span class="math-inline">\(ovov\)</span> and <span class="math-inline">\(oovv\)</span> blocks needed by the response kernel</li>
+<li>assemble the dense TDA matrix <span class="math-inline">\(A\)</span></li>
+<li>diagonalize <span class="math-inline">\(A\)</span> with <code>Eigen::SelfAdjointEigenSolver</code></li>
+<li>build transition dipoles from AO dipole integrals transformed to the occupied-virtual MO basis</li>
+<li>sort and print the dominant occupied <span class="math-inline">\(\rightarrow\)</span> virtual configurations for each root</li>
+</ol>
+<p>The report printed by <code>print_linear_response_report()</code> includes the root index, excitation energy in Hartree and eV, oscillator strength, Cartesian transition dipole components, the dipole norm in Debye, and the three largest configuration weights.</p>
 <hr>
 <h2 id="19-molecular-properties">19. Molecular Properties</h2>
-<p>After SCF convergence Planck computes several molecular properties from the converged density matrix.  All are printed automatically (or under <code>verbosity verbose</code>) without additional input; no extra keywords are needed.  This section covers the theory behind each property and the code path that evaluates it.</p>
+<p>After SCF convergence Planck can compute several molecular properties from the converged density matrix. Dipole and quadrupole moments are printed automatically; population and bond-order reports are printed when <code>print_populations true</code> or the output <code>verbosity</code> is <code>verbose</code> / <code>debug</code>. This section covers the theory behind each property and the code path that evaluates it.</p>
 <h3 id="mulliken-population-analysis">Mulliken Population Analysis</h3>
 <p><strong>Theory</strong></p>
 <p>The Mulliken gross population of AO <span class="math-inline">\(\mu\)</span> is</p>
@@ -1823,6 +1870,61 @@ Eigen::VectorXd gross = (density.array() * overlap.array()).rowwise().sum();
 </code></pre>
 <p>The function then iterates over <code>basis._basis_functions</code>, accumulates <code>gross[μ]</code> into the correct atom bucket via <code>cv._shell-&gt;_atom_index</code>, and fills an <code>AtomicPopulation</code> struct.  When a <code>spin_density_ptr</code> is provided the same loop runs a second time over <span class="math-inline">\(\Delta P\)</span>.</p>
 <p>Population analysis is triggered when <code>_output._print_populations</code> is set or <code>verbosity</code> is <code>verbose</code> / <code>debug</code> (see <code>log_population_report</code> in <code>src/driver.cpp:71</code>).</p>
+<h3 id="l-wdin-population-analysis">Löwdin Population Analysis</h3>
+<p><strong>Theory</strong></p>
+<p>Mulliken populations depend directly on the AO overlap partitioning.  Löwdin analysis instead first orthogonalizes the AO basis with the symmetric overlap square root:</p>
+<p><span class="math-display">\[
+\mathbf S = \mathbf U\,\mathbf s\,\mathbf U^\mathrm T,
+\qquad
+\mathbf S^{1/2} = \mathbf U\,\mathbf s^{1/2}\,\mathbf U^\mathrm T
+\]</span></p>
+<p>The density matrix is then transformed into the orthogonal Löwdin AO basis:</p>
+<p><span class="math-display">\[
+\widetilde{\mathbf P} = \mathbf S^{1/2}\mathbf P \mathbf S^{1/2}
+\]</span></p>
+<p>The AO populations are simply the diagonal elements of this orthogonalized density,</p>
+<p><span class="math-display">\[
+q_\mu^{\mathrm{L\ddot owdin}} = \widetilde P_{\mu\mu}
+\]</span></p>
+<p>and atomic populations are obtained by summing over the AOs on each atom:</p>
+<p><span class="math-display">\[
+N_A^{\mathrm{L\ddot owdin}} = \sum_{\mu \in A} \widetilde P_{\mu\mu}
+\]</span></p>
+<p>For open-shell references the same transformation is applied to the spin-density matrix <span class="math-inline">\(\Delta P = P^\alpha - P^\beta\)</span>, giving</p>
+<p><span class="math-display">\[
+\widetilde{\Delta P} = \mathbf S^{1/2}\Delta\mathbf P\,\mathbf S^{1/2}
+\]</span></p>
+<p>and the atomic spin population is the sum of the diagonal entries belonging to that atom.</p>
+<p><strong>Code path</strong></p>
+<p><code>src/scf/population.cpp</code> — <code>lowdin_population_analysis()</code></p>
+<p>The implementation diagonalizes the AO overlap with <code>Eigen::SelfAdjointEigenSolver</code>, clips tiny eigenvalues with a numerical threshold, reconstructs the symmetric square root <span class="math-inline">\(\mathbf S^{1/2}\)</span>, and forms the orthogonalized density and spin-density matrices.  The atomic accumulation step is then shared with Mulliken analysis through <code>accumulate_atomic_populations()</code>, so the printed report has the same table layout: per-atom electron population, net charge, and optional spin population.</p>
+<h3 id="mayer-bond-orders">Mayer Bond Orders</h3>
+<p><strong>Theory</strong></p>
+<p>Mayer bond orders are built from the AO population matrix</p>
+<p><span class="math-display">\[
+\mathbf{PS} = \mathbf P \mathbf S
+\]</span></p>
+<p>For atoms <span class="math-inline">\(A\)</span> and <span class="math-inline">\(B\)</span>, the closed-shell Mayer bond order is</p>
+<p><span class="math-display">\[
+B_{AB}^{\mathrm{Mayer}} =
+\sum_{\mu \in A}\sum_{\nu \in B}
+(\mathbf{PS})_{\mu\nu}(\mathbf{PS})_{\nu\mu}
+\]</span></p>
+<p>This measures how strongly the AO subspaces on atoms <span class="math-inline">\(A\)</span> and <span class="math-inline">\(B\)</span> mix through the occupied density in a non-orthogonal basis.</p>
+<p>For open-shell references Planck uses the spin-resolved form, summing separate <span class="math-inline">\(\alpha\)</span> and <span class="math-inline">\(\beta\)</span> contributions:</p>
+<p><span class="math-display">\[
+B_{AB}^{\mathrm{Mayer}} =
+\sum_{\mu \in A}\sum_{\nu \in B}
+\left[
+(\mathbf P^\alpha \mathbf S)_{\mu\nu}(\mathbf P^\alpha \mathbf S)_{\nu\mu}
++
+(\mathbf P^\beta \mathbf S)_{\mu\nu}(\mathbf P^\beta \mathbf S)_{\nu\mu}
+\right]
+\]</span></p>
+<p>The diagonal <span class="math-inline">\(B_{AA}\)</span> is left at zero in the printed matrix, and the off-diagonal matrix is symmetrized.</p>
+<p><strong>Code path</strong></p>
+<p><code>src/scf/population.cpp</code> — <code>mayer_bond_order_analysis()</code></p>
+<p>The routine first validates the density dimensions and builds the AO lists for each atom.  It then forms either <span class="math-inline">\(\mathbf P\mathbf S\)</span> or the spin-resolved <span class="math-inline">\(\mathbf P^\alpha\mathbf S\)</span> / <span class="math-inline">\(\mathbf P^\beta\mathbf S\)</span> products and loops over atom pairs <span class="math-inline">\(A < B\)</span>.  For each AO pair <span class="math-inline">\(\mu \in A\)</span>, <span class="math-inline">\(\nu \in B\)</span> it accumulates the appropriate product into a dense <code>natoms × natoms</code> bond-order matrix.  <code>src/driver.cpp</code> prints the final matrix below the Mulliken and Löwdin tables whenever population reporting is enabled.</p>
 <h3 id="electric-dipole-moment">Electric Dipole Moment</h3>
 <p><strong>Theory</strong></p>
 <p>The electronic contribution to the electric dipole moment is</p>
@@ -2129,7 +2231,10 @@ driver.cpp
 <tr><td>XC matrix assembly</td><td><code>src/dft/ks_matrix.cpp</code></td><td><code>assemble_xc_matrix</code></td></tr>
 <tr><td>KS potential matrices</td><td><code>src/dft/ks_matrix.cpp</code></td><td><code>combine_ks_potential</code></td></tr>
 <tr><td>KS-DFT driver</td><td><code>src/dft/driver.cpp</code></td><td><code>DFT::Driver::run</code></td></tr>
+<tr><td>TD-DFT / linear response (TDA)</td><td><code>src/dft/driver.cpp</code></td><td><code>run_linear_response_tda</code>, <code>print_linear_response_report</code></td></tr>
 <tr><td>Mulliken population analysis</td><td><code>src/scf/population.cpp</code></td><td><code>mulliken_population_analysis</code>, <code>gross_ao_population</code></td></tr>
+<tr><td>Löwdin population analysis</td><td><code>src/scf/population.cpp</code></td><td><code>lowdin_population_analysis</code>, <code>symmetric_overlap_sqrt</code></td></tr>
+<tr><td>Mayer bond orders</td><td><code>src/scf/population.cpp</code></td><td><code>mayer_bond_order_analysis</code></td></tr>
 <tr><td>Dipole / quadrupole AO integrals</td><td><code>src/integrals/os.cpp</code></td><td><code>_os_1d_moments</code>, <code>_compute_multipole_matrices</code></td></tr>
 <tr><td>Multipole moments (traceless)</td><td><code>src/integrals/os.cpp</code></td><td><code>_compute_multipole_moments</code></td></tr>
 <tr><td>RMP2 natural orbitals</td><td><code>src/post_hf/mp2.cpp</code></td><td><code>compute_rmp2_natural_orbitals</code></td></tr>
@@ -2145,7 +2250,7 @@ driver.cpp
 </tr></thead>
 <tbody>
 <tr><td>RHF and UHF SCF</td><td>Complete</td></tr>
-<tr><td>ROHF SCF</td><td>Complete (Guest–Saunders effective Fock; no SAD guess; post-HF not yet supported from ROHF reference)</td></tr>
+<tr><td>ROHF SCF</td><td>Complete (Guest–Saunders effective Fock with SAD guess; post-HF not yet supported from ROHF reference)</td></tr>
 <tr><td>Obara-Saika 1e and 2e integrals</td><td>Complete</td></tr>
 <tr><td>Rys quadrature ERIs</td><td>Complete</td></tr>
 <tr><td>Conventional and direct SCF</td><td>Complete</td></tr>
@@ -2174,6 +2279,7 @@ driver.cpp
 <tr><td>GGA XC functionals (B88, PBE, PW91 exchange; LYP, P86, PBE, PW91 correlation)</td><td>Complete</td></tr>
 <tr><td>Arbitrary libxc functionals via integer ID</td><td>Complete</td></tr>
 <tr><td>Molecular grid (Treutler-Ahlrichs + Lebedev + Becke)</td><td>Complete</td></tr>
+<tr><td>Initial TD-DFT / linear response (closed-shell RKS, TDA-style singlets)</td><td>Complete</td></tr>
 <tr><td>DFT geometry optimization / gradients</td><td>Not implemented</td></tr>
 <tr><td>Global hybrid XC functionals (B3LYP, PBE0, compatible libxc IDs)</td><td>Complete</td></tr>
 <tr><td>Range-separated and double-hybrid XC functionals</td><td>Not supported</td></tr>

--- a/python/ccgen/generate.py
+++ b/python/ccgen/generate.py
@@ -138,6 +138,9 @@ def _chunk_term_bucket(
     terms: tuple[object, ...],
     workers: int,
 ) -> list[tuple[object, ...]]:
+    # Tiny workloads are cheaper to run serially than to pickle, dispatch, and
+    # merge across worker processes.  Once a bucket is large enough, split it
+    # into reasonably even chunks so each worker gets a similar amount of work.
     if workers <= 1 or len(terms) < workers * _MIN_CHUNK_TERMS:
         return [terms]
 
@@ -163,6 +166,9 @@ def _process_term_chunk(
     buckets: dict[tuple[object, ...], AlgebraTerm] = {}
     order: list[tuple[object, ...]] = []
 
+    # Projection is streamed term-by-term so we never materialize the full
+    # projected list for a large BCH expansion.  This keeps memory usage closer
+    # to "current chunk" size instead of "all terms for the manifold".
     projected_terms = iter(iter_projected_terms_from_terms(terms, manifold))
 
     while True:
@@ -178,6 +184,9 @@ def _process_term_chunk(
                 continue
             filtered_count += 1
 
+        # Many projected terms can be recognized as zero before the more
+        # expensive canonicalization step.  Pruning them here keeps the later
+        # merge/canonicalize passes focused on genuinely distinct algebra.
         if term_is_zero_before_canonicalization(projected):
             continue
         merge_exact_term_into_buckets(projected, raw_buckets, raw_order)
@@ -187,6 +196,9 @@ def _process_term_chunk(
     ]
 
     for raw_term in raw_terms:
+        # Canonicalization normalizes dummy-index naming and tensor ordering so
+        # algebraically equivalent terms acquire the same signature and can be
+        # merged into a single bucket.
         t1 = time.monotonic()
         canonical = canonicalize_term(raw_term)
         canonicalization_time += time.monotonic() - t1
@@ -220,6 +232,9 @@ def _generate_manifold_equation(
     buckets: dict[tuple[object, ...], AlgebraTerm] = {}
     order: list[tuple[object, ...]] = []
 
+    # First parallelization layer: split one manifold's BCH term bucket into
+    # chunks.  This is the right level when a single target equation dominates
+    # the runtime.
     chunk_terms = _chunk_term_bucket(terms, parallel_workers)
     if len(chunk_terms) == 1:
         chunk_results = [
@@ -239,6 +254,9 @@ def _generate_manifold_equation(
                     [connected_only] * len(chunk_terms),
                 ))
         except (OSError, PermissionError):
+            # Multiprocessing is opportunistic.  If the host disallows process
+            # creation or file-descriptor passing, we transparently fall back
+            # to the serial path instead of failing the generation request.
             chunk_results = [
                 _process_term_chunk(chunk, manifold, connected_only)
                 for chunk in chunk_terms
@@ -278,6 +296,8 @@ def _generate_manifold_equation(
     ]
     mstats["after_merge"] = len(canonical)
 
+    # The remaining passes are optional algebra simplifications layered after
+    # the canonical term list has been established.
     if collect_denominators and manifold not in ("energy", "reference"):
         canonical = collect_fock_diagonals(canonical)
         mstats["after_denom_collection"] = len(canonical)
@@ -399,6 +419,9 @@ def _find_prefix_bch_cache(
             continue
         if not set(candidate_ranks).issubset(method_ranks):
             continue
+        # Reuse is only valid when the cached method is a strict prefix in the
+        # excitation hierarchy, e.g. CCSD -> CCSDT.  Among valid candidates we
+        # prefer the longest prefix to minimize the amount of new BCH work.
         levels = _load_cached_bch_levels(child)
         if levels is None:
             continue
@@ -490,6 +513,9 @@ def generate_cc_equations(
     if targets is None:
         targets = targets_for_method(method)
 
+    # Build the symbolic Hamiltonian H and cluster operator T once, then reuse
+    # them throughout the pipeline.  Everything below transforms or projects
+    # the resulting BCH-expanded similarity-transformed Hamiltonian.
     H = build_hamiltonian()
     T = build_cluster(method)
 
@@ -528,6 +554,9 @@ def generate_cc_equations(
             T_delta = build_tn(delta_ranks[0])
             for rank in delta_ranks[1:]:
                 T_delta = T_delta + build_tn(rank)
+            # Reconstruct Hbar by continuing from the cached prefix BCH levels
+            # rather than restarting from H.  For higher-rank methods this can
+            # avoid repeating the most expensive lower-order commutators.
             Hbar, levels = bch_expand_from_prefix_levels(
                 prefix_levels,
                 T_prefix,
@@ -583,6 +612,9 @@ def generate_cc_equations(
 
     if pending:
         manifold_results: list[tuple[str, dict[str, int | float], list[AlgebraTerm]]] = []
+        # Second parallelization layer: distribute different manifolds across
+        # workers.  When we take this route, each worker handles its assigned
+        # manifold serially to avoid nested process pools.
         use_manifold_parallel = resolved_workers > 1 and len(pending) > 1
         if use_manifold_parallel:
             try:
@@ -598,6 +630,8 @@ def generate_cc_equations(
                         [1] * len(pending),
                     ))
             except (OSError, PermissionError):
+                # If manifold-level fan-out is unavailable, retry locally and
+                # still allow intra-manifold chunking via resolved_workers.
                 manifold_results = [
                     _generate_manifold_equation(
                         manifold,
@@ -630,6 +664,8 @@ def generate_cc_equations(
             if cache_root_path is not None:
                 _store_cached_manifold(cache_root_path, manifold, mstats, canonical)
 
+    # Preserve the caller-requested target order even if cache hits and parallel
+    # execution completed in a different sequence.
     stats.manifolds = {
         manifold: stats.manifolds[manifold]
         for manifold in target_tuple

--- a/python/ccgen/wick.py
+++ b/python/ccgen/wick.py
@@ -29,6 +29,10 @@ _SPACE_SHIFT = 18
 _BLOCK_SHIFT = 20
 _EDGE_LOW_MASK = (1 << 20) - 1
 
+# The contraction search runs on compact integer "signatures" rather than rich
+# SQOp objects.  Each packed word stores the operator's original position, its
+# creation/annihilation kind, orbital space, and block id, which makes the hot
+# recursion/caching path cheap to hash and pass into the optional C++ helper.
 
 @dataclass(frozen=True)
 class WickResult:
@@ -156,6 +160,10 @@ def _analyze_signature_python(
     n_blocks: int,
     ignore_block: int | None,
 ) -> tuple[bool, int, tuple[int, ...]]:
+    # Cheap pruning before recursion:
+    # 1. reject signatures that can never be fully paired,
+    # 2. reject branches that can no longer become connected,
+    # 3. choose the most constrained pivot so the branching factor stays small.
     if not _can_fully_contract(signature):
         return False, -1, ()
 
@@ -291,6 +299,9 @@ def _choose_pivot_position(
         count = len(candidates)
         if count == 0:
             return -1
+        # Prefer operators with the fewest legal partners, then break ties by
+        # the nearest partner distance.  This is the same "most constrained
+        # variable" idea used in CSP search and cuts the recursive tree a lot.
         span = min(abs(partner - pos) for partner in candidates)
         if (
             best_count is None
@@ -348,6 +359,9 @@ def _iter_wick_pairings_uncached(
         partner = signature[partner_pos]
         remaining = _remove_positions(signature, pivot_pos, partner_pos)
 
+        # Crossing an odd number of fermionic operators flips the sign of the
+        # contraction.  Because `signature` preserves the current operator order,
+        # the parity is just the number of operators strictly between the pair.
         gap = abs(partner_pos - pivot_pos) - 1
         sign_factor = -1 if gap % 2 else 1
         pair = (_word_pos(pivot), _word_pos(partner))
@@ -411,6 +425,9 @@ def _component_labels(
     if not blocks:
         return ()
 
+    # Union-find over tensor/projector blocks lets us answer "which blocks are
+    # already connected by chosen contractions?" quickly during recursive
+    # pruning without materializing explicit graph objects.
     index_of = {block: pos for pos, block in enumerate(blocks)}
     parent = list(range(len(blocks)))
 
@@ -449,6 +466,9 @@ def _can_still_be_connected(
     n_blocks: int,
     ignore_block: int | None,
 ) -> bool:
+    # For connected-only projection we do not wait until the end to check graph
+    # connectivity.  Instead we ask whether the remaining operators still admit
+    # enough inter-block contractions to connect today's partial components.
     blocks = _relevant_blocks(n_blocks, ignore_block)
     component_by_pos = _component_labels(blocks, current_edges)
     n_components = len(set(component_by_pos))
@@ -526,6 +546,9 @@ def wick_contract(
     if n_blocks is None:
         n_blocks = max(block_ids, default=-1) + 1
 
+    # Build the structural signature once, recurse in the compact integer
+    # representation, then translate the winning pairings back to Index-level
+    # delta constraints for downstream algebra code.
     signature = tuple(
         _pack_signature_op(
             i,
@@ -639,6 +662,9 @@ def apply_deltas(
         space_codes, name_codes, dummy_mask = _delta_layout_metadata(
             all_indices_tuple
         )
+        # The accelerated path solves the same union/find-style index merging as
+        # the Python fallback below, but works directly on compact metadata
+        # arrays instead of Python Index objects.
         ok, roots = _wickaccel.apply_deltas_layout(
             space_codes,
             name_codes,
@@ -664,6 +690,10 @@ def apply_deltas(
             lhs_protected = lhs_pos in protected_rank
             rhs_protected = rhs_pos in protected_rank
 
+            # Representative choice is semantic, not arbitrary:
+            # protected external indices win over dummy ones, non-generic spaces
+            # win over generic placeholders, and otherwise we keep a stable
+            # lexical choice for deterministic output.
             if lhs_protected != rhs_protected:
                 return (lhs_pos, rhs_pos) if lhs_protected else (rhs_pos, lhs_pos)
 

--- a/src/base/types.h
+++ b/src/base/types.h
@@ -81,7 +81,8 @@ namespace HartreeFock
         GeomOpt,          // Geometry Optimization
         Frequency,        // Frequency Calculation
         GeomOptFrequency, // Geometry optimization followed by frequency calculation
-        ImaginaryFollow   // Freq → displace along largest imaginary mode → geomopt
+        ImaginaryFollow,  // Freq → displace along largest imaginary mode → geomopt
+        LinearResponse    // TDDFT / linear-response excited states
     };
 
     enum class SCFMode
@@ -381,6 +382,7 @@ namespace HartreeFock
         XCCorrelationFunctional _correlation = XCCorrelationFunctional::PBE;
         int _exchange_id = 0;    // 0 => resolve from _exchange through libxc
         int _correlation_id = 0; // 0 => resolve from _correlation through libxc
+        int _lr_nstates = 5;
         bool _use_sao_blocking = true;
         bool _print_grid_summary = true;
         bool _save_checkpoint = false;

--- a/src/dft/driver.cpp
+++ b/src/dft/driver.cpp
@@ -1,5 +1,7 @@
 #include "driver.h"
 
+#include <Eigen/QR>
+
 #include <algorithm>
 #include <chrono>
 #include <cmath>
@@ -11,9 +13,11 @@
 #include "basis/basis.h"
 #include "freq/hessian.h"
 #include "integrals/base.h"
+#include "integrals/os.h"
 #include "io/checkpoint.h"
 #include "io/logging.h"
 #include "opt/geomopt.h"
+#include "post_hf/integrals.h"
 #include "scf/scf.h"
 #include "symmetry/integral_symmetry.h"
 #include "symmetry/mo_symmetry.h"
@@ -44,10 +48,193 @@ namespace DFT::Driver
 
         constexpr double NUMERICAL_GRADIENT_STEP_BOHR = 1.0e-3;
 
+        struct LinearResponseContribution
+        {
+            int occupied = 0;
+            int virtual_orbital = 0;
+            double weight = 0.0;
+            std::string occupied_symmetry;
+            std::string virtual_symmetry;
+        };
+
+        struct LinearResponseRoot
+        {
+            int root = 0;
+            double excitation_energy = 0.0;
+            double excitation_energy_ev = 0.0;
+            Eigen::Vector3d transition_dipole = Eigen::Vector3d::Zero();
+            double oscillator_strength = 0.0;
+            std::vector<LinearResponseContribution> dominant_contributions;
+        };
+
+        struct DavidsonEigenpairResult
+        {
+            Eigen::VectorXd eigenvalues;
+            Eigen::MatrixXd eigenvectors;
+            Eigen::VectorXd residual_norms;
+            int iterations = 0;
+            bool converged = false;
+        };
+
+        template <typename Apply>
+        std::expected<DavidsonEigenpairResult, std::string> davidson_lowest_eigenpairs(
+            int dimension,
+            int nroots,
+            const Eigen::VectorXd &diagonal,
+            Apply &&apply,
+            double tolerance,
+            int max_iterations,
+            int max_subspace_dimension)
+        {
+            if (dimension <= 0 || nroots <= 0)
+            {
+                return DavidsonEigenpairResult{
+                    .eigenvalues = Eigen::VectorXd(),
+                    .eigenvectors = Eigen::MatrixXd(dimension, 0),
+                    .residual_norms = Eigen::VectorXd(),
+                    .iterations = 0,
+                    .converged = true};
+            }
+
+            if (diagonal.size() != dimension)
+                return std::unexpected("Davidson solver received a diagonal with inconsistent dimension");
+
+            const int nr = std::min(nroots, dimension);
+            const int initial_subspace = std::min(dimension, std::max(2 * nr, 4));
+            const int subspace_limit = std::max(initial_subspace + 1, max_subspace_dimension);
+
+            Eigen::MatrixXd basis = Eigen::MatrixXd::Zero(dimension, initial_subspace);
+            std::vector<int> order(static_cast<std::size_t>(dimension));
+            std::iota(order.begin(), order.end(), 0);
+            std::stable_sort(order.begin(), order.end(),
+                             [&](int lhs, int rhs)
+                             { return diagonal(lhs) < diagonal(rhs); });
+            for (int col = 0; col < initial_subspace; ++col)
+                basis(order[static_cast<std::size_t>(col)], col) = 1.0;
+
+            {
+                Eigen::HouseholderQR<Eigen::MatrixXd> qr(basis);
+                basis = qr.householderQ() * Eigen::MatrixXd::Identity(dimension, initial_subspace);
+            }
+
+            DavidsonEigenpairResult result{
+                .eigenvalues = Eigen::VectorXd::Zero(nr),
+                .eigenvectors = Eigen::MatrixXd::Zero(dimension, nr),
+                .residual_norms = Eigen::VectorXd::Constant(nr, std::numeric_limits<double>::infinity()),
+                .iterations = 0,
+                .converged = false};
+
+            for (int iteration = 0; iteration < max_iterations; ++iteration)
+            {
+                const int m = static_cast<int>(basis.cols());
+                Eigen::MatrixXd sigma_basis(dimension, m);
+                for (int col = 0; col < m; ++col)
+                    sigma_basis.col(col) = apply(basis.col(col));
+
+                const Eigen::MatrixXd projected = basis.transpose() * sigma_basis;
+                Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> projected_solver(projected);
+                if (projected_solver.info() != Eigen::Success)
+                    return std::unexpected("TDDFT / Davidson projected diagonalization failed");
+
+                result.iterations = iteration + 1;
+                result.eigenvalues = projected_solver.eigenvalues().head(nr);
+                const Eigen::MatrixXd projected_vectors = projected_solver.eigenvectors().leftCols(nr);
+                result.eigenvectors = basis * projected_vectors;
+
+                double max_residual = 0.0;
+                std::vector<Eigen::VectorXd> corrections;
+                corrections.reserve(static_cast<std::size_t>(nr));
+
+                for (int root = 0; root < nr; ++root)
+                {
+                    Eigen::VectorXd residual =
+                        sigma_basis * projected_vectors.col(root) -
+                        result.eigenvalues(root) * result.eigenvectors.col(root);
+                    result.residual_norms(root) = residual.norm();
+                    max_residual = std::max(max_residual, result.residual_norms(root));
+                    if (result.residual_norms(root) <= tolerance)
+                        continue;
+
+                    for (int idx = 0; idx < dimension; ++idx)
+                    {
+                        double denom = result.eigenvalues(root) - diagonal(idx);
+                        if (std::abs(denom) < 1e-10)
+                            denom = (denom >= 0.0) ? 1e-10 : -1e-10;
+                        residual(idx) /= denom;
+                    }
+
+                    for (int col = 0; col < m; ++col)
+                        residual -= basis.col(col).dot(residual) * basis.col(col);
+                    for (const Eigen::VectorXd &accepted : corrections)
+                        residual -= accepted.dot(residual) * accepted;
+
+                    const double norm = residual.norm();
+                    if (norm > 1e-12)
+                        corrections.push_back(residual / norm);
+                }
+
+                if (max_residual <= tolerance)
+                {
+                    result.converged = true;
+                    return result;
+                }
+
+                if (corrections.empty())
+                    return result;
+
+                if (m + static_cast<int>(corrections.size()) > subspace_limit)
+                {
+                    basis = result.eigenvectors.leftCols(nr);
+                    for (int col = 0; col < static_cast<int>(basis.cols()); ++col)
+                    {
+                        for (int prev = 0; prev < col; ++prev)
+                            basis.col(col) -= basis.col(prev).dot(basis.col(col)) * basis.col(prev);
+                        const double norm = basis.col(col).norm();
+                        if (norm > 1e-12)
+                            basis.col(col) /= norm;
+                    }
+                    const int restart_cols = static_cast<int>(basis.cols());
+                    basis.conservativeResize(Eigen::NoChange, restart_cols + static_cast<int>(corrections.size()));
+                    for (int idx = 0; idx < static_cast<int>(corrections.size()); ++idx)
+                        basis.col(restart_cols + idx) = corrections[static_cast<std::size_t>(idx)];
+                }
+                else
+                {
+                    const int old_cols = m;
+                    basis.conservativeResize(Eigen::NoChange, old_cols + static_cast<int>(corrections.size()));
+                    for (int idx = 0; idx < static_cast<int>(corrections.size()); ++idx)
+                        basis.col(old_cols + idx) = corrections[static_cast<std::size_t>(idx)];
+                }
+
+                for (int col = 0; col < static_cast<int>(basis.cols()); ++col)
+                {
+                    for (int prev = 0; prev < col; ++prev)
+                        basis.col(col) -= basis.col(prev).dot(basis.col(col)) * basis.col(prev);
+                    const double norm = basis.col(col).norm();
+                    if (norm < 1e-12)
+                    {
+                        if (col + 1 < static_cast<int>(basis.cols()))
+                            basis.col(col) = basis.col(basis.cols() - 1);
+                        basis.conservativeResize(Eigen::NoChange, basis.cols() - 1);
+                        --col;
+                    }
+                    else
+                    {
+                        basis.col(col) /= norm;
+                    }
+                }
+            }
+
+            return result;
+        }
+
         std::expected<int, std::string> resolve_functional_id(
             HartreeFock::XCExchangeFunctional functional,
             int explicit_id)
         {
+            // The input layer can name a functional symbolically (PBE, B3LYP,
+            // ...) or pass a raw libxc id.  Normalize both cases here so the
+            // rest of the driver only deals with resolved libxc identifiers.
             if (explicit_id > 0)
                 return explicit_id;
 
@@ -116,6 +303,10 @@ namespace DFT::Driver
             const Options &options,
             bool preserve_checkpoint_ao_frame)
         {
+            // Full restarts are special: the checkpoint density and orbitals
+            // live in the original AO frame used when they were written.  If
+            // we re-standardized the molecule before loading them, every AO-
+            // indexed quantity would silently refer to the wrong frame.
             if (preserve_checkpoint_ao_frame)
             {
                 calculator._molecule._point_group = "C1";
@@ -167,6 +358,10 @@ namespace DFT::Driver
             if (calculator._scf._guess != HartreeFock::SCFGuess::ReadFull)
                 return false;
 
+            // ReadFull tries to restore the complete SCF state, including the
+            // geometry that defined the checkpoint AO basis.  If geometry load
+            // fails we degrade gracefully to ReadDensity, which can still reuse
+            // a density matrix when the current geometry/basis are compatible.
             auto geometry = HartreeFock::Checkpoint::load_geometry(calculator._checkpoint_path);
             if (!geometry)
             {
@@ -222,6 +417,9 @@ namespace DFT::Driver
 
         void maybe_build_sao_basis(HartreeFock::Calculator &calculator, const Options &options)
         {
+            // SAO blocking only helps when symmetry is both enabled and
+            // non-trivial.  In C1 or linear infinite groups there is no useful
+            // irrep partition to exploit, so keep the ordinary AO machinery.
             if (!calculator._dft._use_sao_blocking ||
                 !options.use_sao_blocking ||
                 !calculator._molecule._symmetry ||
@@ -264,6 +462,9 @@ namespace DFT::Driver
             HartreeFock::Calculator &calculator,
             const std::vector<HartreeFock::ShellPair> &shell_pairs)
         {
+            // Integral symmetry metadata depends on the current molecular
+            // orientation and shell layout, so refresh it before every one-
+            // electron build for the current geometry.
             HartreeFock::Symmetry::update_integral_symmetry(calculator);
 
             auto [S, T] = _compute_1e(
@@ -297,6 +498,9 @@ namespace DFT::Driver
 
             const auto make_spin_density = [&calculator, &X](std::size_t n_occ, bool doubled_occupancy) -> Eigen::MatrixXd
             {
+                // The fallback KS guess is the diagonalized core Hamiltonian in
+                // the orthonormal AO basis, identical in spirit to the HCore
+                // SCF guess used on the Hartree-Fock side.
                 const Eigen::MatrixXd Hprime = X->transpose() * calculator._hcore * (*X);
                 Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> solver(Hprime);
                 const Eigen::MatrixXd C = (*X) * solver.eigenvectors();
@@ -644,12 +848,277 @@ namespace DFT::Driver
             return occupancy * occupied * occupied.transpose();
         }
 
+        void print_linear_response_report(
+            const std::vector<LinearResponseRoot> &roots,
+            double exact_exchange_coefficient)
+        {
+            HartreeFock::Logger::logging(
+                HartreeFock::LogLevel::Info,
+                "TDDFT / Linear Response :",
+                std::format(
+                    "TDA-style singlet solver with {:.6f} exact-exchange kernel coefficient",
+                    exact_exchange_coefficient));
+            HartreeFock::Logger::logging(
+                HartreeFock::LogLevel::Info,
+                "TDDFT / Linear Response :",
+                "Semilocal XC response kernels are not included in this initial implementation");
+            HartreeFock::Logger::blank();
+
+            std::cout << std::string(118, '-') << "\n"
+                      << std::setw(6) << "Root"
+                      << std::setw(16) << "Omega (Eh)"
+                      << std::setw(14) << "Omega (eV)"
+                      << std::setw(14) << "f"
+                      << std::setw(16) << "mu_x (au)"
+                      << std::setw(16) << "mu_y (au)"
+                      << std::setw(16) << "mu_z (au)"
+                      << std::setw(20) << "|mu| (Debye)"
+                      << "\n"
+                      << std::string(118, '-') << "\n";
+
+            for (const LinearResponseRoot &root : roots)
+            {
+                const double mu_norm_debye = root.transition_dipole.norm() * AU_TO_DEBYE;
+                std::cout << std::setw(6) << root.root
+                          << std::setw(16) << std::fixed << std::setprecision(8) << root.excitation_energy
+                          << std::setw(14) << std::fixed << std::setprecision(6) << root.excitation_energy_ev
+                          << std::setw(14) << std::fixed << std::setprecision(6) << root.oscillator_strength
+                          << std::setw(16) << std::fixed << std::setprecision(6) << root.transition_dipole.x()
+                          << std::setw(16) << std::fixed << std::setprecision(6) << root.transition_dipole.y()
+                          << std::setw(16) << std::fixed << std::setprecision(6) << root.transition_dipole.z()
+                          << std::setw(20) << std::fixed << std::setprecision(6) << mu_norm_debye
+                          << "\n";
+            }
+
+            std::cout << std::string(118, '-') << "\n";
+
+            for (const LinearResponseRoot &root : roots)
+            {
+                HartreeFock::Logger::logging(
+                    HartreeFock::LogLevel::Info,
+                    "",
+                    std::format("  Root {:2d} dominant configurations:", root.root));
+
+                for (const LinearResponseContribution &contribution : root.dominant_contributions)
+                {
+                    const std::string occupied_label =
+                        contribution.occupied_symmetry.empty()
+                            ? std::format("MO{}", contribution.occupied)
+                            : std::format("MO{} ({})", contribution.occupied, contribution.occupied_symmetry);
+                    const std::string virtual_label =
+                        contribution.virtual_symmetry.empty()
+                            ? std::format("MO{}", contribution.virtual_orbital)
+                            : std::format("MO{} ({})", contribution.virtual_orbital, contribution.virtual_symmetry);
+
+                    HartreeFock::Logger::logging(
+                        HartreeFock::LogLevel::Info,
+                        "",
+                        std::format("    {:<18} -> {:<18} weight = {:.6f}",
+                                    occupied_label,
+                                    virtual_label,
+                                    contribution.weight));
+                }
+            }
+            HartreeFock::Logger::blank();
+        }
+
+        std::expected<std::vector<LinearResponseRoot>, std::string> run_linear_response_tda(
+            HartreeFock::Calculator &calculator,
+            const DFT::XC::Functional &exchange_functional)
+        {
+            if (!calculator._info._is_converged)
+                return std::unexpected("TDDFT / linear response requires a converged RKS reference");
+            if (calculator._scf._scf != HartreeFock::SCFType::RHF || calculator._info._scf.is_uhf)
+                return std::unexpected("Initial TDDFT / linear response support currently requires a closed-shell RKS reference");
+
+            const int n_electrons = static_cast<int>(
+                calculator._molecule.atomic_numbers.cast<int>().sum() - calculator._molecule.charge);
+            if (n_electrons % 2 != 0)
+                return std::unexpected("Closed-shell RKS TDDFT / linear response requires an even number of electrons");
+
+            const Eigen::Index nbasis = static_cast<Eigen::Index>(calculator._shells.nbasis());
+            const int n_occ = n_electrons / 2;
+            const int n_virt = static_cast<int>(nbasis) - n_occ;
+            if (n_occ <= 0 || n_virt <= 0)
+                return std::unexpected("TDDFT / linear response requires at least one occupied and one virtual orbital");
+
+            const int nov = n_occ * n_virt;
+            const int nroots = std::min(std::max(calculator._dft._lr_nstates, 1), nov);
+
+            const Eigen::MatrixXd &coefficients = calculator._info._scf.alpha.mo_coefficients;
+            const Eigen::VectorXd &energies = calculator._info._scf.alpha.mo_energies;
+            const std::vector<std::string> &mo_symmetry = calculator._info._scf.alpha.mo_symmetry;
+
+            const Eigen::MatrixXd C_occ = coefficients.leftCols(n_occ);
+            const Eigen::MatrixXd C_virt = coefficients.middleCols(n_occ, n_virt);
+
+            std::vector<double> eri_local;
+            const auto shell_pairs = build_shellpairs(calculator._shells);
+            const std::vector<double> &eri = HartreeFock::Correlation::ensure_eri(
+                calculator,
+                shell_pairs,
+                eri_local,
+                "TDDFT / Linear Response :");
+
+            const std::vector<double> mo_ia_jb =
+                HartreeFock::Correlation::transform_eri(eri, static_cast<std::size_t>(nbasis), C_occ, C_virt, C_occ, C_virt);
+            const std::vector<double> mo_ij_ab =
+                HartreeFock::Correlation::transform_eri(eri, static_cast<std::size_t>(nbasis), C_occ, C_occ, C_virt, C_virt);
+
+            auto idx_ia = [n_virt](int i, int a) -> int
+            {
+                return i * n_virt + a;
+            };
+            auto idx_ia_jb = [n_occ, n_virt](int i, int a, int j, int b) -> std::size_t
+            {
+                return ((static_cast<std::size_t>(i) * n_virt + a) * n_occ + j) * n_virt + b;
+            };
+            auto idx_ij_ab = [n_occ, n_virt](int i, int j, int a, int b) -> std::size_t
+            {
+                return ((static_cast<std::size_t>(i) * n_occ + j) * n_virt + a) * n_virt + b;
+            };
+
+            const double exact_exchange_coefficient =
+                exchange_functional.is_hybrid() ? exchange_functional.exact_exchange_coefficient() : 0.0;
+
+            Eigen::VectorXd diagonal = Eigen::VectorXd::Zero(nov);
+            for (int i = 0; i < n_occ; ++i)
+                for (int a = 0; a < n_virt; ++a)
+                {
+                    const int ia = idx_ia(i, a);
+                    diagonal(ia) =
+                        energies(n_occ + a) - energies(i) +
+                        2.0 * mo_ia_jb[idx_ia_jb(i, a, i, a)] -
+                        exact_exchange_coefficient * mo_ij_ab[idx_ij_ab(i, i, a, a)];
+                }
+
+            const auto apply_tda_matrix = [&](const Eigen::Ref<const Eigen::VectorXd> &trial) -> Eigen::VectorXd
+            {
+                Eigen::VectorXd sigma = Eigen::VectorXd::Zero(nov);
+                for (int i = 0; i < n_occ; ++i)
+                    for (int a = 0; a < n_virt; ++a)
+                    {
+                        const int ia = idx_ia(i, a);
+                        double value = (energies(n_occ + a) - energies(i)) * trial(ia);
+                        for (int j = 0; j < n_occ; ++j)
+                            for (int b = 0; b < n_virt; ++b)
+                            {
+                                const int jb = idx_ia(j, b);
+                                value += 2.0 * mo_ia_jb[idx_ia_jb(i, a, j, b)] * trial(jb);
+                                value -= exact_exchange_coefficient * mo_ij_ab[idx_ij_ab(i, j, a, b)] * trial(jb);
+                            }
+                        sigma(ia) = value;
+                    }
+                return sigma;
+            };
+
+            HartreeFock::Logger::logging(
+                HartreeFock::LogLevel::Info,
+                "TDDFT / Davidson :",
+                std::format("Solving {} lowest roots in a {}-dimensional excitation space", nroots, nov));
+
+            auto davidson = davidson_lowest_eigenpairs(
+                nov,
+                nroots,
+                diagonal,
+                apply_tda_matrix,
+                1.0e-8,
+                100,
+                std::max(6 * nroots, 24));
+            if (!davidson)
+                return std::unexpected(davidson.error());
+
+            HartreeFock::Logger::logging(
+                HartreeFock::LogLevel::Info,
+                "TDDFT / Davidson :",
+                std::format(
+                    "{} after {} iterations (max residual {:.3e})",
+                    davidson->converged ? "Converged" : "Stopped",
+                    davidson->iterations,
+                    davidson->residual_norms.size() > 0 ? davidson->residual_norms.maxCoeff() : 0.0));
+            HartreeFock::Logger::blank();
+
+            const HartreeFock::MultipoleMatrices multipoles =
+                HartreeFock::ObaraSaika::_compute_multipole_matrices(
+                    shell_pairs,
+                    static_cast<std::size_t>(nbasis),
+                    Eigen::Vector3d::Zero());
+
+            std::array<Eigen::MatrixXd, 3> mo_dipole_ov = {
+                C_occ.transpose() * multipoles.dipole[0] * C_virt,
+                C_occ.transpose() * multipoles.dipole[1] * C_virt,
+                C_occ.transpose() * multipoles.dipole[2] * C_virt};
+
+            std::vector<LinearResponseRoot> roots;
+            roots.reserve(static_cast<std::size_t>(nroots));
+
+            for (int root = 0; root < nroots; ++root)
+            {
+                const Eigen::VectorXd amplitudes = davidson->eigenvectors.col(root);
+                Eigen::Vector3d transition_dipole = Eigen::Vector3d::Zero();
+
+                for (int i = 0; i < n_occ; ++i)
+                    for (int a = 0; a < n_virt; ++a)
+                    {
+                        const double amplitude = amplitudes(idx_ia(i, a));
+                        transition_dipole.x() += std::sqrt(2.0) * amplitude * mo_dipole_ov[0](i, a);
+                        transition_dipole.y() += std::sqrt(2.0) * amplitude * mo_dipole_ov[1](i, a);
+                        transition_dipole.z() += std::sqrt(2.0) * amplitude * mo_dipole_ov[2](i, a);
+                    }
+
+                std::vector<LinearResponseContribution> contributions;
+                contributions.reserve(static_cast<std::size_t>(nov));
+                for (int i = 0; i < n_occ; ++i)
+                    for (int a = 0; a < n_virt; ++a)
+                    {
+                        const double amplitude = amplitudes(idx_ia(i, a));
+                        contributions.push_back(
+                            LinearResponseContribution{
+                                .occupied = i + 1,
+                                .virtual_orbital = n_occ + a + 1,
+                                .weight = amplitude * amplitude,
+                                .occupied_symmetry =
+                                    (static_cast<std::size_t>(i) < mo_symmetry.size()) ? mo_symmetry[static_cast<std::size_t>(i)] : "",
+                                .virtual_symmetry =
+                                    (static_cast<std::size_t>(n_occ + a) < mo_symmetry.size()) ? mo_symmetry[static_cast<std::size_t>(n_occ + a)] : ""});
+                    }
+
+                std::ranges::sort(
+                    contributions,
+                    [](const LinearResponseContribution &lhs, const LinearResponseContribution &rhs)
+                    {
+                        return lhs.weight > rhs.weight;
+                    });
+                if (contributions.size() > 3)
+                    contributions.resize(3);
+
+                const double excitation_energy = davidson->eigenvalues(root);
+                const double oscillator_strength =
+                    std::max(0.0, (2.0 / 3.0) * excitation_energy * transition_dipole.squaredNorm());
+
+                roots.push_back(
+                    LinearResponseRoot{
+                        .root = root + 1,
+                        .excitation_energy = excitation_energy,
+                        .excitation_energy_ev = excitation_energy * HARTREE_TO_EV,
+                        .transition_dipole = transition_dipole,
+                        .oscillator_strength = oscillator_strength,
+                        .dominant_contributions = std::move(contributions)});
+            }
+
+            print_linear_response_report(roots, exact_exchange_coefficient);
+            return roots;
+        }
+
         std::expected<Result, std::string> run_ks_scf_scaffold(
             HartreeFock::Calculator &calculator,
             const PreparedSystem &prepared,
             const DFT::XC::Functional &x_functional,
             const DFT::XC::Functional &c_functional)
         {
+            // This routine is the shared KS-SCF engine used for the initial
+            // single-point, displaced geometries in numerical derivatives, and
+            // repeated geometry-optimization/frequency evaluations.
             if (prepared.ao_grid.npoints() != prepared.molecular_grid.points.rows())
                 return std::unexpected("DFT KS-SCF scaffold reached with inconsistent AO/grid dimensions");
 
@@ -694,6 +1163,10 @@ namespace DFT::Driver
                     const auto iter_start = std::chrono::steady_clock::now();
                     calculator._info._scf.alpha.density = density;
 
+                    // DFT replaces the HF Coulomb/exchange build with a grid
+                    // loop that evaluates the current density, queries libxc
+                    // for the semilocal derivatives, and assembles the AO-space
+                    // KS potential for the present density matrix.
                     auto xc_grid = evaluate_current_density_and_xc(
                         calculator,
                         prepared,
@@ -717,6 +1190,9 @@ namespace DFT::Driver
                     double diis_error = 0.0;
                     if (use_diis)
                     {
+                        // Reuse the standard commutator error in the orthogonal
+                        // AO basis so KS and HF share the same convergence
+                        // acceleration machinery.
                         const Eigen::MatrixXd error =
                             X.transpose() *
                             (fock * density * calculator._overlap - calculator._overlap * density * fock) *
@@ -1113,6 +1589,10 @@ namespace DFT::Driver
             const InitializedFunctionals &functionals,
             bool preserve_previous_density)
         {
+            // Geometry-derivative code paths call back into the driver many
+            // times.  This helper rebuilds only geometry-dependent objects and
+            // optionally seeds the next SCF with the density from the previous
+            // nearby geometry for faster convergence.
             auto prepared = prepare_current_geometry(calculator, preserve_previous_density);
             if (!prepared)
                 return std::unexpected(prepared.error());
@@ -1185,6 +1665,9 @@ namespace DFT::Driver
 
             auto energy_at = [&](const Eigen::MatrixXd &geometry) -> std::expected<double, std::string>
             {
+                // Each displaced-point energy is a full DFT single-point at a
+                // new geometry.  Silence the nested SCF logging so the user sees
+                // the final derivative report rather than dozens of inner traces.
                 calculator._molecule.set_standard_from_bohr(geometry);
                 HartreeFock::Logger::ScopedSilence silence;
                 auto result = run_single_point_current_geometry(
@@ -1728,10 +2211,27 @@ namespace DFT::Driver
                 functionals->exchange.name(),
                 functionals->correlation.name()));
 
+        // All higher-level DFT workflows start from the same converged KS
+        // reference.  Gradient, optimization, and frequency branches then build
+        // their derivative-specific machinery on top of that shared entry step.
         switch (calculator._calculation)
         {
         case HartreeFock::CalculationType::SinglePoint:
             return run_initial_single_point(calculator, options, *functionals);
+
+        case HartreeFock::CalculationType::LinearResponse:
+        {
+            auto result = run_initial_single_point(calculator, options, *functionals);
+            if (!result)
+                return std::unexpected(result.error());
+            if (!result->converged)
+                return *result;
+
+            auto response = run_linear_response_tda(calculator, functionals->exchange);
+            if (!response)
+                return std::unexpected(response.error());
+            return *result;
+        }
 
         case HartreeFock::CalculationType::Gradient:
         {

--- a/src/dft/xc_grid.cpp
+++ b/src/dft/xc_grid.cpp
@@ -44,6 +44,10 @@ namespace DFT
             const AOGridEvaluation &ao_grid,
             const Eigen::Ref<const Eigen::MatrixXd> &density)
         {
+            // The density matrix is symmetrized defensively before grid
+            // contraction so tiny SCF asymmetries do not leak into rho or its
+            // gradient.  `density_times_values` is reused across rho and all
+            // gradient components to keep the AO-grid contractions compact.
             const Eigen::MatrixXd symmetric_density = 0.5 * (density + density.transpose());
             const Eigen::MatrixXd density_times_values = ao_grid.values * symmetric_density;
 
@@ -60,6 +64,9 @@ namespace DFT
             const Eigen::Index npoints = density.npoints();
             std::vector<double> rho(static_cast<std::size_t>(npoints * (density.polarized ? 2 : 1)));
 
+            // libxc expects point-major arrays:
+            //   unpolarized: [rho(point0), rho(point1), ...]
+            //   polarized:   [rho_a(point0), rho_b(point0), rho_a(point1), ...]
             if (!density.polarized)
             {
                 for (Eigen::Index point = 0; point < npoints; ++point)
@@ -92,6 +99,9 @@ namespace DFT
 
             const Eigen::VectorXd sigma_aa = density.alpha.gradient_squared();
             const Eigen::VectorXd sigma_bb = density.beta.gradient_squared();
+            // libxc's polarized GGA interface uses the conventional ordering
+            // (sigma_aa, sigma_ab, sigma_bb) at each grid point rather than a
+            // full 2x2 spin-gradient matrix.
             const Eigen::VectorXd sigma_ab =
                 (density.alpha.grad_x.array() * density.beta.grad_x.array() + density.alpha.grad_y.array() * density.beta.grad_y.array() + density.alpha.grad_z.array() * density.beta.grad_z.array()).matrix();
 
@@ -111,6 +121,9 @@ namespace DFT
             Eigen::Index npoints,
             Eigen::Index ncols)
         {
+            // libxc returns derivatives in the same point-major layout that its
+            // evaluation routines consume.  Convert back to an Eigen matrix with
+            // one row per grid point so later AO assembly code can stay vectorized.
             Eigen::MatrixXd matrix(npoints, ncols);
             for (Eigen::Index point = 0; point < npoints; ++point)
             {
@@ -179,6 +192,9 @@ namespace DFT
             std::vector<double> vrho;
             std::vector<double> vsigma;
 
+            // The grid layer currently supports semilocal functionals only.
+            // LDA depends on rho alone, while GGA additionally consumes sigma =
+            // grad(rho)·grad(rho) spin invariants.
             if (functional.is_lda_like())
             {
                 if (auto eval = functional.evaluate_lda_exc_vxc(rho, static_cast<int>(npoints), exc, vrho); !eval)
@@ -211,6 +227,9 @@ namespace DFT
             else
                 result.vsigma = unpack_point_major(vsigma, npoints, functional.sigma_components());
 
+            // The XC energy density stored here is the quadrature-ready
+            // integrand rho(r) * eps_xc(r).  The actual scalar XC contribution
+            // is obtained only after multiplying by the molecular grid weights.
             result.energy_density =
                 (density.total.rho.array() * result.exc.array()).matrix();
             result.energy = molecular_grid.points.col(3).dot(result.energy_density);

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -77,69 +77,159 @@ static void log_population_report(const HartreeFock::Calculator &calculator)
     if (!wants_population)
         return;
 
-    Eigen::MatrixXd total_density = calculator._info._scf.alpha.density;
-    Eigen::MatrixXd spin_density;
-    const Eigen::MatrixXd *spin_density_ptr = nullptr;
-    if (calculator._info._scf.is_uhf)
+    auto print_population_table = [](const std::string &title,
+                                     const HartreeFock::SCF::PopulationAnalysis &analysis)
     {
-        total_density += calculator._info._scf.beta.density;
-        spin_density = calculator._info._scf.alpha.density - calculator._info._scf.beta.density;
-        spin_density_ptr = &spin_density;
-    }
-
-    auto analysis = HartreeFock::SCF::mulliken_population_analysis(
-        calculator._molecule,
-        calculator._shells,
-        calculator._overlap,
-        total_density,
-        spin_density_ptr);
-
-    if (!analysis)
-    {
-        HartreeFock::Logger::logging(
-            HartreeFock::LogLevel::Warning,
-            "Population Analysis :",
-            "Unavailable: " + analysis.error());
-        HartreeFock::Logger::blank();
-        return;
-    }
-
-    HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "Mulliken Population Analysis :", "");
-    const int line_width = analysis->has_spin_population ? 94 : 78;
-    std::cout << std::string(line_width, '-') << "\n"
+        HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, title + " :", "");
+        const int line_width = analysis.has_spin_population ? 94 : 78;
+        std::cout << std::string(line_width, '-') << "\n"
               << std::setw(6) << std::right << "Atom"
               << std::setw(8) << std::right << "Elem"
               << std::setw(8) << std::right << "Z"
               << std::setw(20) << std::right << "Population"
               << std::setw(20) << std::right << "Charge";
-    if (analysis->has_spin_population)
-        std::cout << std::setw(16) << std::right << "Spin";
-    std::cout << "\n"
+        if (analysis.has_spin_population)
+            std::cout << std::setw(16) << std::right << "Spin";
+        std::cout << "\n"
               << std::string(line_width, '-') << "\n";
 
-    for (const auto &atom : analysis->atoms)
+        for (const auto &atom : analysis.atoms)
+        {
+            const auto element = element_from_z(static_cast<std::uint64_t>(atom.atomic_number));
+            const std::string symbol = element ? std::string(element->symbol) : "?";
+            std::cout << std::setw(6) << std::right << (atom.atom_index + 1)
+                      << std::setw(8) << std::right << symbol
+                      << std::setw(8) << std::right << atom.atomic_number
+                      << std::setw(20) << std::right << std::fixed << std::setprecision(8) << atom.electron_population
+                      << std::setw(20) << std::right << std::fixed << std::setprecision(8) << atom.net_charge;
+            if (analysis.has_spin_population)
+                std::cout << std::setw(16) << std::right << std::fixed << std::setprecision(8) << atom.spin_population;
+            std::cout << "\n";
+        }
+
+        std::cout << std::string(line_width, '-') << "\n"
+                  << std::setw(22) << std::left << "  Total"
+                  << std::setw(20) << std::right << std::fixed << std::setprecision(8) << analysis.total_electrons
+                  << std::setw(20) << std::right << std::fixed << std::setprecision(8) << analysis.total_charge;
+        if (analysis.has_spin_population)
+            std::cout << std::setw(16) << std::right << std::fixed << std::setprecision(8) << analysis.total_spin_population;
+        std::cout << "\n"
+                  << std::string(line_width, '-') << "\n";
+        HartreeFock::Logger::blank();
+    };
+
+    auto print_mayer_bond_orders = [](const HartreeFock::Calculator &calculator,
+                                      const HartreeFock::SCF::MayerBondOrderAnalysis &analysis)
     {
-        const auto element = element_from_z(static_cast<std::uint64_t>(atom.atomic_number));
-        const std::string symbol = element ? std::string(element->symbol) : "?";
-        std::cout << std::setw(6) << std::right << (atom.atom_index + 1)
-                  << std::setw(8) << std::right << symbol
-                  << std::setw(8) << std::right << atom.atomic_number
-                  << std::setw(20) << std::right << std::fixed << std::setprecision(8) << atom.electron_population
-                  << std::setw(20) << std::right << std::fixed << std::setprecision(8) << atom.net_charge;
-        if (analysis->has_spin_population)
-            std::cout << std::setw(16) << std::right << std::fixed << std::setprecision(8) << atom.spin_population;
-        std::cout << "\n";
+        HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "Mayer Bond Orders :", "");
+        constexpr int line_width = 54;
+        std::cout << std::string(line_width, '-') << "\n"
+                  << std::setw(8) << std::right << "Atom A"
+                  << std::setw(8) << std::right << "Atom B"
+                  << std::setw(10) << std::right << "Elem A"
+                  << std::setw(10) << std::right << "Elem B"
+                  << std::setw(18) << std::right << "Bond Order"
+                  << "\n"
+                  << std::string(line_width, '-') << "\n";
+
+        for (std::size_t a = 0; a < calculator._molecule.natoms; ++a)
+        {
+            for (std::size_t b = a + 1; b < calculator._molecule.natoms; ++b)
+            {
+                const auto elem_a = element_from_z(static_cast<std::uint64_t>(
+                    calculator._molecule.atomic_numbers(static_cast<Eigen::Index>(a))));
+                const auto elem_b = element_from_z(static_cast<std::uint64_t>(
+                    calculator._molecule.atomic_numbers(static_cast<Eigen::Index>(b))));
+                const std::string sym_a = elem_a ? std::string(elem_a->symbol) : "?";
+                const std::string sym_b = elem_b ? std::string(elem_b->symbol) : "?";
+
+                std::cout << std::setw(8) << std::right << (a + 1)
+                          << std::setw(8) << std::right << (b + 1)
+                          << std::setw(10) << std::right << sym_a
+                          << std::setw(10) << std::right << sym_b
+                          << std::setw(18) << std::right << std::fixed << std::setprecision(8)
+                          << analysis.bond_orders(static_cast<Eigen::Index>(a), static_cast<Eigen::Index>(b))
+                          << "\n";
+            }
+        }
+
+        std::cout << std::string(line_width, '-') << "\n";
+        HartreeFock::Logger::blank();
+    };
+
+    const bool has_spin_channels =
+        calculator._scf._scf != HartreeFock::SCFType::RHF &&
+        calculator._info._scf.beta.density.rows() == calculator._info._scf.alpha.density.rows();
+
+    Eigen::MatrixXd total_density = calculator._info._scf.alpha.density;
+    Eigen::MatrixXd spin_density;
+    const Eigen::MatrixXd *spin_density_ptr = nullptr;
+    const Eigen::MatrixXd *alpha_density_ptr = nullptr;
+    const Eigen::MatrixXd *beta_density_ptr = nullptr;
+    if (has_spin_channels)
+    {
+        total_density += calculator._info._scf.beta.density;
+        spin_density = calculator._info._scf.alpha.density - calculator._info._scf.beta.density;
+        spin_density_ptr = &spin_density;
+        alpha_density_ptr = &calculator._info._scf.alpha.density;
+        beta_density_ptr = &calculator._info._scf.beta.density;
     }
 
-    std::cout << std::string(line_width, '-') << "\n"
-              << std::setw(22) << std::left << "  Total"
-              << std::setw(20) << std::right << std::fixed << std::setprecision(8) << analysis->total_electrons
-              << std::setw(20) << std::right << std::fixed << std::setprecision(8) << analysis->total_charge;
-    if (analysis->has_spin_population)
-        std::cout << std::setw(16) << std::right << std::fixed << std::setprecision(8) << analysis->total_spin_population;
-    std::cout << "\n"
-              << std::string(line_width, '-') << "\n";
-    HartreeFock::Logger::blank();
+    auto mulliken = HartreeFock::SCF::mulliken_population_analysis(
+        calculator._molecule,
+        calculator._shells,
+        calculator._overlap,
+        total_density,
+        spin_density_ptr);
+    if (!mulliken)
+    {
+        HartreeFock::Logger::logging(
+            HartreeFock::LogLevel::Warning,
+            "Population Analysis :",
+            "Unavailable: " + mulliken.error());
+        HartreeFock::Logger::blank();
+        return;
+    }
+    print_population_table("Mulliken Population Analysis", *mulliken);
+
+    auto lowdin = HartreeFock::SCF::lowdin_population_analysis(
+        calculator._molecule,
+        calculator._shells,
+        calculator._overlap,
+        total_density,
+        spin_density_ptr);
+    if (!lowdin)
+    {
+        HartreeFock::Logger::logging(
+            HartreeFock::LogLevel::Warning,
+            "Löwdin Population Analysis :",
+            "Unavailable: " + lowdin.error());
+        HartreeFock::Logger::blank();
+    }
+    else
+    {
+        print_population_table("Löwdin Population Analysis", *lowdin);
+    }
+
+    auto mayer = HartreeFock::SCF::mayer_bond_order_analysis(
+        calculator._molecule,
+        calculator._shells,
+        calculator._overlap,
+        total_density,
+        alpha_density_ptr,
+        beta_density_ptr);
+    if (!mayer)
+    {
+        HartreeFock::Logger::logging(
+            HartreeFock::LogLevel::Warning,
+            "Mayer Bond Orders :",
+            "Unavailable: " + mayer.error());
+        HartreeFock::Logger::blank();
+    }
+    else
+    {
+        print_mayer_bond_orders(calculator, *mayer);
+    }
 }
 
 int main(int argc, const char *argv[])

--- a/src/io/io.cpp
+++ b/src/io/io.cpp
@@ -259,7 +259,15 @@ namespace HartreeFock::IO
 
                 {"imagfollow", HartreeFock::CalculationType::ImaginaryFollow},
                 {"imag_follow", HartreeFock::CalculationType::ImaginaryFollow},
-                {"irc_follow", HartreeFock::CalculationType::ImaginaryFollow}};
+                {"irc_follow", HartreeFock::CalculationType::ImaginaryFollow},
+
+                {"tddft", HartreeFock::CalculationType::LinearResponse},
+                {"td-dft", HartreeFock::CalculationType::LinearResponse},
+                {"td_dft", HartreeFock::CalculationType::LinearResponse},
+                {"linearresponse", HartreeFock::CalculationType::LinearResponse},
+                {"linear_response", HartreeFock::CalculationType::LinearResponse},
+                {"linear-response", HartreeFock::CalculationType::LinearResponse},
+                {"lr", HartreeFock::CalculationType::LinearResponse}};
 
         return lookup_enum(_table, value, "Invalid Calculation Type : ");
     }
@@ -867,6 +875,27 @@ namespace HartreeFock::IO
                  {
                      dft._correlation = HartreeFock::XCCorrelationFunctional::Custom;
                      dft._correlation_id = std::stoi(value);
+                     return std::expected<void, std::string>{};
+                 }},
+                {"lr_nstates", [&dft](const std::string &value) -> std::expected<void, std::string>
+                 {
+                     dft._lr_nstates = std::stoi(value);
+                     if (dft._lr_nstates < 1)
+                         return std::unexpected("lr_nstates must be >= 1");
+                     return std::expected<void, std::string>{};
+                 }},
+                {"tddft_nstates", [&dft](const std::string &value) -> std::expected<void, std::string>
+                 {
+                     dft._lr_nstates = std::stoi(value);
+                     if (dft._lr_nstates < 1)
+                         return std::unexpected("tddft_nstates must be >= 1");
+                     return std::expected<void, std::string>{};
+                 }},
+                {"nstates", [&dft](const std::string &value) -> std::expected<void, std::string>
+                 {
+                     dft._lr_nstates = std::stoi(value);
+                     if (dft._lr_nstates < 1)
+                         return std::unexpected("nstates must be >= 1");
                      return std::expected<void, std::string>{};
                  }}};
 

--- a/src/io/logging.h
+++ b/src/io/logging.h
@@ -2,6 +2,7 @@
 #define HF_LOGGING_H
 
 #include <iomanip>
+#include <format>
 #include <iostream>
 #include <mutex>
 #include <string>
@@ -559,6 +560,8 @@ const inline std::string map_enum<HartreeFock::CalculationType>(HartreeFock::Cal
         return "Geometry Optimization + Frequency";
     case HartreeFock::CalculationType::ImaginaryFollow:
         return "Imaginary Mode Follow";
+    case HartreeFock::CalculationType::LinearResponse:
+        return "TDDFT / Linear Response";
     }
     return "Unknown";
 }

--- a/src/post_hf/casscf/casscf.cpp
+++ b/src/post_hf/casscf/casscf.cpp
@@ -82,6 +82,12 @@ namespace
         constexpr double merit_weight = 0.10;
         selection.merit = selection.energy + merit_weight * selection.sa_gnorm * selection.sa_gnorm;
 
+        // Candidate generation produces a menu of orbital directions from
+        // different heuristics (AH, Newton-like, fallback probes, root-first
+        // variants, ...).  This selector actually tests them by rotating the
+        // orbitals, re-evaluating the MCSCF state, and accepting only moves
+        // that improve energy/merit without clearly destabilizing the SA
+        // gradient.
         for (const auto &candidate : candidates)
         {
             for (double scale : CASSCF_MACRO_STEP_SCALES)
@@ -240,6 +246,10 @@ namespace HartreeFock::Correlation::CASSCF
         std::vector<int> all_mo_irr;
         if (have_sym && point_group_is_abelian_for_labels && !calc._info._scf.alpha.mo_symmetry.empty())
         {
+            // Only Abelian point groups are used for CI screening here because
+            // the current machinery assumes one-dimensional irrep products.
+            // Non-Abelian labels remain useful for reporting, but not for the
+            // determinant-space selection logic below.
             sym_ctx = build_symmetry_context(calc);
             if (!sym_ctx)
                 return std::unexpected(tag + ": failed to build an Abelian irrep product table for CI screening.");

--- a/src/post_hf/casscf/casscf_driver_internal.cpp
+++ b/src/post_hf/casscf/casscf_driver_internal.cpp
@@ -35,6 +35,10 @@ namespace HartreeFock::Correlation::CASSCF
         if (overlaps.size() == 0)
             return;
 
+        // State-averaged and excited-state optimizations care about "which
+        // root is which" from one macroiteration to the next.  Reorder the new
+        // CI eigenpairs so they follow the previous root identities by maximum
+        // overlap instead of raw eigenvalue order.
         const std::vector<int> assignment = match_roots_by_max_overlap(overlaps);
         Eigen::VectorXd E_reordered = E;
         Eigen::MatrixXd V_reordered = V;
@@ -110,6 +114,9 @@ namespace HartreeFock::Correlation::CASSCF
         const std::vector<double> &source,
         double weight)
     {
+        // Several SA-CASSCF intermediates are accumulated as weighted sums over
+        // roots.  Lazily size the destination from the first contributor so
+        // callers can start from an empty buffer.
         if (destination.empty())
             destination.assign(source.size(), 0.0);
         for (std::size_t i = 0; i < source.size(); ++i)
@@ -153,6 +160,8 @@ namespace HartreeFock::Correlation::CASSCF
         const std::vector<StateSpecificData> &roots,
         int nbasis)
     {
+        // The state-averaged orbital step is driven by the weighted sum of the
+        // root-specific orbital gradients, not by any single state alone.
         Eigen::MatrixXd gradient = Eigen::MatrixXd::Zero(nbasis, nbasis);
         for (const auto &root : roots)
             gradient.noalias() += root.weight * root.g_orb;
@@ -218,6 +227,11 @@ namespace HartreeFock::Correlation::CASSCF
                 continue;
             }
 
+            // Score the proposed orbital step against each root's local
+            // quadratic model, then aggregate with SA weights.  The spread
+            // around the weighted prediction is used later as a "fairness"
+            // diagnostic: a step that helps the average but badly hurts one
+            // root is less trustworthy.
             const Eigen::MatrixXd F_sum = F_I_mo + root.F_A_mo;
             Eigen::VectorXd g_flat(static_cast<int>(pairs.size()));
             Eigen::VectorXd h_flat(static_cast<int>(pairs.size()));

--- a/src/post_hf/casscf/response.cpp
+++ b/src/post_hf/casscf/response.cpp
@@ -148,6 +148,10 @@ namespace
         if (!have_full_cache)
             return dga_active_only;
 
+        // The active-only derivative above captures rotations entirely within
+        // the active block.  When the cache is available, extend it with the
+        // core/virtual -> active couplings by differentiating the mixed-basis
+        // (p,u,v,w) integral cache against the full orbital rotation.
         std::vector<double> dga = dga_active_only;
         for (int t = 0; t < n_act; ++t)
             for (int u = 0; u < n_act; ++u)
@@ -277,6 +281,10 @@ namespace
         op.pairs = symmetry_allowed_pairs(n_core, n_act, n_virt, mo_irreps, use_sym);
         op.nbasis = nbasis;
 
+        // For modest pair counts we explicitly build the orbital-response
+        // matrix and solve in that reduced pair basis.  Larger problems fall
+        // back to matrix-free actions elsewhere to avoid dense O(n_pair^2)
+        // storage and setup costs.
         if (orbital_hessian_ctx == nullptr || op.pairs.empty() || static_cast<int>(op.pairs.size()) > max_dense_pairs)
             return op;
 

--- a/src/post_hf/cc/ccsdt.cpp
+++ b/src/post_hf/cc/ccsdt.cpp
@@ -16,6 +16,9 @@ namespace
 
     [[nodiscard]] std::optional<RCCSDTBackend> parse_rccsdt_backend_override() noexcept
     {
+        // A simple environment-variable override is enough for development and
+        // regression testing: it lets us force a backend without threading a
+        // debugging option through the public input language.
         const char *value = std::getenv("PLANCK_RCCSDT_BACKEND");
         if (value == nullptr)
             return std::nullopt;
@@ -91,6 +94,10 @@ namespace HartreeFock::Correlation::CC
         const std::optional<RCCSDTBackend> override = parse_rccsdt_backend_override();
         const RCCSDTBackend backend = override.value_or(choose_rccsdt_backend(*selector_ref));
 
+        // Backend choice is centralized here so all RCCSDT entry points share
+        // the same policy: small systems can use the determinant-space teaching
+        // backend, larger ones move to tensor implementations, and developers
+        // can still pin a backend explicitly for debugging.
         if (override.has_value())
         {
             HartreeFock::Logger::logging(
@@ -136,6 +143,8 @@ namespace HartreeFock::Correlation::CC
             calculator, *system_res, 2, "RCCSDT[CCSD-REF] :");
         if (!ccsd_res)
             return std::unexpected("run_rccsdt: failed to build CCSD reference energy: " + ccsd_res.error());
+        // Record a same-backend CCSD reference so later reporting can separate
+        // the triples correction from the underlying doubles contribution.
         calculator._ccsd_reference_correlation_energy = *ccsd_res;
         calculator._have_ccsd_reference_energy = true;
 

--- a/src/post_hf/cc/solver_arbitrary.cpp
+++ b/src/post_hf/cc/solver_arbitrary.cpp
@@ -10,6 +10,11 @@ namespace HartreeFock::Correlation::CC
             const RHFReference &reference,
             int excitation_rank)
         {
+            // Rank-r amplitudes/residuals are stored as dense tensors with
+            // occupied indices first and virtual indices second:
+            //   t_r(i1, ..., ir, a1, ..., ar)
+            // This helper produces the shape expected by every rank-specific
+            // buffer so allocation and validation stay consistent.
             std::vector<int> dims;
             dims.reserve(static_cast<std::size_t>(2 * excitation_rank));
             for (int i = 0; i < excitation_rank; ++i)
@@ -86,6 +91,8 @@ namespace HartreeFock::Correlation::CC
 
         ArbitraryOrderResiduals residuals;
         residuals.by_rank.reserve(static_cast<std::size_t>(max_excitation_rank));
+        // Allocate one zero-filled tensor per excitation manifold so the
+        // solver can treat CCSD, CCSDT, ... with the same update code.
         for (int rank = 1; rank <= max_excitation_rank; ++rank)
             residuals.by_rank.emplace_back(rank_dims(reference, rank), 0.0);
         return residuals;
@@ -97,6 +104,9 @@ namespace HartreeFock::Correlation::CC
         for (const auto &tensor : amps.by_rank)
             total_size += tensor.size();
 
+        // DIIS operates on flat vectors rather than ragged tensor collections.
+        // We therefore serialize the rank-1, rank-2, ... amplitude blocks into
+        // one contiguous vector while preserving their existing in-memory order.
         Eigen::VectorXd packed(static_cast<Eigen::Index>(total_size));
         Eigen::Index offset = 0;
         for (const auto &tensor : amps.by_rank)
@@ -115,6 +125,8 @@ namespace HartreeFock::Correlation::CC
         }
 
         Eigen::Index offset = 0;
+        // The inverse of pack_amplitudes(): restore the solver state back into
+        // the per-rank tensors after Jacobi updates and optional DIIS mixing.
         for (auto &tensor : amps.by_rank)
             for (double &value : tensor.data)
                 value = packed(offset++);
@@ -179,6 +191,10 @@ namespace HartreeFock::Correlation::CC
         Eigen::Index offset = 0;
         for (int rank = 1; rank <= amps.max_rank(); ++rank)
         {
+            // Pull rank-matched tensor views so each excitation manifold is
+            // updated against its own residual and denominator tensor.  Layout
+            // checks make the flattening logic below safe even if a caller
+            // constructed one of the storage objects incorrectly.
             auto amp = static_cast<const ArbitraryOrderRCCAmplitudes &>(amps).tensor(rank);
             if (!amp)
                 return std::unexpected("update_amplitudes_with_jacobi_diis: " + amp.error());
@@ -203,6 +219,10 @@ namespace HartreeFock::Correlation::CC
             double step_sum_sq = 0.0;
             for (std::size_t idx = 0; idx < amp->size(); ++idx)
             {
+                // Plain Jacobi step:
+                //   t <- t + damping * R / D
+                // Small denominators are skipped instead of amplified to avoid
+                // exploding updates from nearly singular orbital gaps.
                 double delta = 0.0;
                 if (std::abs(denom->data[idx]) >= 1e-12)
                     delta = damping * residual->data[idx] / denom->data[idx];
@@ -216,6 +236,9 @@ namespace HartreeFock::Correlation::CC
             offset += static_cast<Eigen::Index>(amp->size());
         }
 
+        // DIIS sees the fully packed amplitude/residual vectors so it can mix
+        // information across all excitation ranks at once instead of solving
+        // separate extrapolation problems for T1, T2, T3, ...
         diis.push(updated, residual_vec);
         if (use_diis && diis.ready())
         {
@@ -234,6 +257,10 @@ namespace HartreeFock::Correlation::CC
 
         if (use_diis && diis.size() >= 2)
         {
+            // Once DIIS changes the step, the per-rank RMS values computed from
+            // the raw Jacobi updates are no longer accurate.  Recompute them
+            // from the final extrapolated vector so diagnostics reflect the
+            // actual move accepted by the solver.
             metrics.step_rms_by_rank.clear();
             Eigen::Index rank_offset = 0;
             for (int rank = 1; rank <= amps.max_rank(); ++rank)

--- a/src/post_hf/cc/tensor_backend.cpp
+++ b/src/post_hf/cc/tensor_backend.cpp
@@ -355,6 +355,10 @@ namespace
         so.eps_occ = Eigen::VectorXd(so.n_occ);
         so.eps_virt = Eigen::VectorXd(so.n_virt);
 
+        // Start from the spatial-orbital RHF partition and duplicate each
+        // orbital energy into alpha/beta spin-orbital slots.  The tensor CC
+        // backend then works entirely in spin-orbital indexing even though the
+        // source SCF reference is restricted.
         for (int i = 0; i < so.n_occ; ++i)
             so.eps_occ(i) = base.eps_occ(spatial_index(i));
         for (int a = 0; a < so.n_virt; ++a)
@@ -388,6 +392,10 @@ namespace
             .vvvv = Tensor4D(so.n_virt, so.n_virt, so.n_virt, so.n_virt, 0.0),
         };
 
+        // Expand each spatial block into antisymmetrized spin-orbital blocks.
+        // The `same_spin` gates encode the RHF selection rule that a spatial
+        // integral contributes only when the corresponding spin labels match,
+        // and the second term in each assignment inserts the exchange piece.
         for (int i = 0; i < so.n_occ; ++i)
             for (int j = 0; j < so.n_occ; ++j)
                 for (int k = 0; k < so.n_occ; ++k)
@@ -500,6 +508,10 @@ namespace
             .vvvv = Tensor4D(so.n_virt, so.n_virt, so.n_virt, so.n_virt, 0.0),
         };
 
+        // This variant keeps plain chemists-notation Coulomb blocks without the
+        // antisymmetrization step above.  The generated RCCSDT path and the
+        // PySCF-aligned "dressed intermediate" experiments consume these raw
+        // blocks directly and apply their own permutation algebra later.
         for (int i = 0; i < so.n_occ; ++i)
             for (int j = 0; j < so.n_occ; ++j)
                 for (int k = 0; k < so.n_occ; ++k)

--- a/src/post_hf/cc/tensor_backend_state.cpp
+++ b/src/post_hf/cc/tensor_backend_state.cpp
@@ -93,6 +93,9 @@ namespace HartreeFock::Correlation::CC
         const Eigen::MatrixXd fock_mo =
             C_full.transpose() * calculator._info._scf.alpha.fock * C_full;
 
+        // Keep both views of the RHF reference: the original occupied/virtual
+        // partition plus explicit oo/ov/vv Fock blocks that the tensor CC
+        // kernels consume directly without repeated MO slicing.
         CanonicalRHFCCReference reference{
             .orbital_partition = std::move(*ref_res),
             .f_oo = Tensor2D(base.n_occ, base.n_occ, 0.0),
@@ -131,6 +134,9 @@ namespace HartreeFock::Correlation::CC
         TensorCCBlockCache blocks;
         try
         {
+            // Materialize the standard RHF MO-ERI blocks once up front.  The
+            // tensor RCCSD(T) paths pay this memory cost in exchange for much
+            // simpler and faster residual kernels later on.
             blocks.oooo = Tensor4D(
                 partition.n_occ, partition.n_occ, partition.n_occ, partition.n_occ,
                 HartreeFock::Correlation::transform_eri(
@@ -254,6 +260,9 @@ namespace HartreeFock::Correlation::CC
     std::string format_tensor_memory_summary(
         const TensorRCCSDTState &state)
     {
+        // Report per-block sizes instead of only a grand total so users can see
+        // which ERI block dominates memory when a tensor calculation becomes
+        // impractical for a given basis.
         std::ostringstream out;
         out << "Tensor RCCSDT memory estimate:";
         for (const TensorMemoryBlock &block : state.mo_blocks.memory_report)

--- a/src/post_hf/mp2.cpp
+++ b/src/post_hf/mp2.cpp
@@ -98,6 +98,9 @@ HartreeFock::Correlation::run_ump2(
             for (std::size_t a = 0; a < nva; ++a)
                 for (std::size_t b = 0; b < nva; ++b)
                 {
+                    // Same-spin MP2 must use antisymmetrized integrals because
+                    // exchanging the two alpha electrons changes the sign of
+                    // the spin-adapted two-electron state.
                     const double iajb = mo_aa[i * nva * n_alpha * nva + a * n_alpha * nva + j * nva + b];
                     const double ibja = mo_aa[i * nva * n_alpha * nva + b * n_alpha * nva + j * nva + a];
                     const double anti = iajb - ibja;
@@ -113,6 +116,8 @@ HartreeFock::Correlation::run_ump2(
             for (std::size_t a = 0; a < nvb; ++a)
                 for (std::size_t b = 0; b < nvb; ++b)
                 {
+                    // The beta-beta contribution is algebraically identical to
+                    // alpha-alpha, just evaluated in the beta orbital space.
                     const double iajb = mo_bb[i * nvb * n_beta * nvb + a * n_beta * nvb + j * nvb + b];
                     const double ibja = mo_bb[i * nvb * n_beta * nvb + b * n_beta * nvb + j * nvb + a];
                     const double anti = iajb - ibja;
@@ -158,6 +163,9 @@ HartreeFock::Correlation::compute_rmp2_natural_orbitals(
     const int nmo = n_occ + n_virt;
 
     Eigen::MatrixXd dm1_mo = Eigen::MatrixXd::Zero(nmo, nmo);
+    // Natural orbitals come from the spin-summed 1PDM.  The RHF reference
+    // contributes the closed-shell occupation of 2.0 in the occupied block,
+    // while the MP2 density correction contributes the oo and vv blocks.
     dm1_mo.topLeftCorner(n_occ, n_occ) =
         2.0 * Eigen::MatrixXd::Identity(n_occ, n_occ) + dens.P_occ + dens.P_occ.transpose();
     dm1_mo.bottomRightCorner(n_virt, n_virt) =
@@ -176,6 +184,8 @@ HartreeFock::Correlation::compute_rmp2_natural_orbitals(
 
     for (int i = 0; i < nmo; ++i)
     {
+        // Eigen returns eigenpairs in ascending order, but natural orbitals are
+        // conventionally reported from highest to lowest occupation.
         const int src = nmo - 1 - i;
         result.occupations(i) = occ_asc(src);
         result.coefficients_mo.col(i) = coeff_asc.col(src);

--- a/src/post_hf/mp2_gradient.cpp
+++ b/src/post_hf/mp2_gradient.cpp
@@ -12,6 +12,9 @@ namespace
 {
     inline std::size_t idx_iajb(int i, int a, int j, int b, int n_occ, int n_virt)
     {
+        // Shared flattening convention for ovov tensors used throughout the
+        // MP2 codepath.  Keeping this centralized avoids subtle mismatches
+        // between energy, density, and gradient intermediates.
         return ((static_cast<std::size_t>(i) * n_virt + a) * n_occ + j) * n_virt + b;
     }
 
@@ -53,6 +56,9 @@ namespace
         const std::vector<double> &pair_dm2,
         int nb)
     {
+        // Forms the AO-space Imat contraction that appears in the Lagrangian
+        // treatment of orbital-response terms:
+        //   I_pq = sum_{i,r,s} (ip|rs) * Gamma_{iqrs}
         Eigen::MatrixXd imat = Eigen::MatrixXd::Zero(nb, nb);
         for (int p = 0; p < nb; ++p)
             for (int q = 0; q < nb; ++q)
@@ -97,6 +103,9 @@ namespace
         const HartreeFock::Calculator &calculator,
         int nb)
     {
+        // Reconstruct the spin occupations from total charge and multiplicity
+        // instead of trusting cached counts.  That keeps the gradient path
+        // aligned with the same electron bookkeeping used in the UHF driver.
         int n_electrons = 0;
         for (auto Z : calculator._molecule.atomic_numbers)
             n_electrons += static_cast<int>(Z);
@@ -132,6 +141,10 @@ namespace
         if (std::abs(coeff) < 1e-14)
             return;
 
+        // Generic 4-index back-transformation for one rank-1 separable MO 2PDM
+        // contribution.  The UMP2 implementation builds the explicit pair
+        // density term-by-term and accumulates each contribution directly in AO
+        // space to avoid storing large spin-resolved 2PDM tensors in MO space.
         for (int mu = 0; mu < nao; ++mu)
         {
             const double c1 = C1(mu, p);
@@ -309,6 +322,10 @@ namespace HartreeFock::Correlation
                     {
                         const double t_ijab = amp.t2[idx_iajb(i, a, j, b, amp.n_occ, amp.n_virt)];
                         const double t_ijba = amp.t2[idx_iajb(i, b, j, a, amp.n_occ, amp.n_virt)];
+                        // Explicit connected MP2 pair-density contribution in
+                        // spin-summed spatial-orbital form.  The disconnected
+                        // reference/HF pieces are added elsewhere in the full
+                        // Lagrangian-based gradient assembly.
                         const double dovov = 4.0 * t_ijab - 2.0 * t_ijba;
 
                         dm2[idx_dm2(i, o + a, j, o + b, nmo)] += dovov;
@@ -476,6 +493,9 @@ namespace HartreeFock::Correlation
         Eigen::MatrixXd imat_ao = contract_imat_from_pair_density(eri, pair_dm2_ao, nb);
         Eigen::MatrixXd imat_mo = -C.transpose() * imat_ao * calculator._overlap * C;
 
+        // Xvo is the occupied-virtual orbital-gradient block of the MP2
+        // Lagrangian.  Solving the RHF CPHF system with -Xvo gives the Z-vector
+        // that restores the missing first-order orbital relaxation.
         Eigen::MatrixXd Xvo =
             amp.C_virt.transpose() * veff_corr_ao * amp.C_occ + imat_mo.topRightCorner(amp.n_occ, amp.n_virt).transpose() - imat_mo.bottomLeftCorner(amp.n_virt, amp.n_occ);
 
@@ -488,6 +508,8 @@ namespace HartreeFock::Correlation
         corr_relaxed_mo.bottomLeftCorner(amp.n_virt, amp.n_occ) = z;
         corr_relaxed_mo.topRightCorner(amp.n_occ, amp.n_virt) = z.transpose();
 
+        // Final first-order density = RHF reference occupancy + MP2 oo/vv
+        // correction + ov response block from the Z-vector.
         Eigen::MatrixXd P_mo = build_rhf_reference_density_mo(amp.n_occ, nb) + corr_relaxed_mo;
         Eigen::MatrixXd P_ao = C * P_mo * C.transpose();
 
@@ -502,6 +524,9 @@ namespace HartreeFock::Correlation
         for (int a = 0; a < amp.n_virt; ++a)
             for (int i = 0; i < amp.n_occ; ++i)
             {
+                // Mixed occupied-virtual blocks use occupied energies so the
+                // AO-space weighted density matches the conventional RHF/MP2
+                // Pulay-form expression.
                 zeta_weights(amp.n_occ + a, i) = amp.eps_occ(i);
                 zeta_weights(i, amp.n_occ + a) = amp.eps_occ(i);
             }
@@ -585,6 +610,10 @@ namespace HartreeFock::Correlation
             return ((static_cast<std::size_t>(i) * nva + a) * nbeta + j) * nvb + b;
         };
 
+        // Same-spin alpha and beta blocks use antisymmetrized amplitudes,
+        // exactly mirroring the energy expression.  The diagonal oo/vv updates
+        // here are the simplest unrelaxed density pieces needed by the current
+        // UMP2 gradient implementation.
         for (int i = 0; i < counts.n_alpha; ++i)
             for (int j = 0; j < counts.n_alpha; ++j)
                 for (int a = 0; a < counts.nva; ++a)
@@ -623,6 +652,10 @@ namespace HartreeFock::Correlation
                         add_rank4_mo_to_ao(pair_dm2_ao, nb, Cb_virt, a, Cb_occ, i, Cb_virt, b, Cb_occ, j, t);
                     }
 
+        // Opposite-spin alpha-beta pairs do not antisymmetrize; instead they
+        // contribute directly through the Coulomb-like amplitude.  The factor
+        // of 2.0 in the AO pair-density accumulation restores the spin-summed
+        // convention expected by the derivative contractions.
         for (int i = 0; i < counts.n_alpha; ++i)
             for (int j = 0; j < counts.n_beta; ++j)
                 for (int a = 0; a < counts.nva; ++a)
@@ -648,6 +681,8 @@ namespace HartreeFock::Correlation
             Cb_occ * Db_occ * Cb_occ.transpose() +
             Cb_virt * Db_virt * Cb_virt.transpose();
 
+        // Build spin-resolved energy-weighted densities in AO space.  These are
+        // the UHF analog of the RHF `W` matrix used in overlap/Pulay terms.
         Eigen::MatrixXd Wa_corr = Eigen::MatrixXd::Zero(nb, nb);
         for (int i = 0; i < counts.n_alpha; ++i)
             for (int j = 0; j < counts.n_alpha; ++j)

--- a/src/post_hf/mp2_gradient.h
+++ b/src/post_hf/mp2_gradient.h
@@ -21,7 +21,11 @@ namespace HartreeFock::Correlation
         Eigen::VectorXd eps_occ;
         Eigen::VectorXd eps_virt;
 
-        // Stored in row-major [i,a,j,b] order.
+        // Stored in row-major [i,a,j,b] order so all downstream MP2 routines
+        // can share the same flat indexing helper.  `iajb` is the direct MO
+        // integral, `ibja` is the exchanged view, `t2` is the plain MP2
+        // amplitude, and `tau` is the spin-adapted combination used in RMP2
+        // energies and densities.
         std::vector<double> iajb;
         std::vector<double> ibja;
         std::vector<double> t2;
@@ -56,13 +60,16 @@ namespace HartreeFock::Correlation
 
     struct UMP2GradientIntermediates
     {
+        // Spin-resolved relaxed-density-like objects used by the analytic UMP2
+        // gradient driver.  The current implementation keeps the correction in
+        // AO form because the final derivative contraction is also AO-based.
         Eigen::MatrixXd P_alpha_ao;        // alpha HF + correlated first-order density
         Eigen::MatrixXd P_beta_ao;         // beta HF + correlated first-order density
-        Eigen::MatrixXd P_alpha_corr_ao;   // alpha correlated density correction
-        Eigen::MatrixXd P_beta_corr_ao;    // beta correlated density correction
+        Eigen::MatrixXd P_alpha_corr_ao;   // alpha correlated density correction only
+        Eigen::MatrixXd P_beta_corr_ao;    // beta correlated density correction only
         Eigen::MatrixXd P_total_ao;        // spin-summed HF + correlated first-order density
         Eigen::MatrixXd W_ao;              // spin-summed energy-weighted density
-        std::vector<double> Gamma_pair_ao; // explicit UMP2 pair-density correction
+        std::vector<double> Gamma_pair_ao; // explicit AO-space UMP2 pair-density term
     };
 
     std::expected<RMP2AmplitudeData, std::string> build_rmp2_amplitudes(

--- a/src/scf/population.cpp
+++ b/src/scf/population.cpp
@@ -1,5 +1,7 @@
 #include "scf/population.h"
 
+#include <Eigen/Eigenvalues>
+
 #include <format>
 
 namespace HartreeFock::SCF
@@ -11,12 +13,119 @@ namespace HartreeFock::SCF
             return matrix.rows() == rows && matrix.cols() == cols;
         }
 
+        std::expected<void, std::string> validate_population_inputs(
+            const Molecule &molecule,
+            const Basis &basis,
+            const Eigen::MatrixXd &overlap,
+            const Eigen::MatrixXd &total_density,
+            const Eigen::MatrixXd *spin_density)
+        {
+            const Eigen::Index nbasis = static_cast<Eigen::Index>(basis.nbasis());
+            if (nbasis == 0)
+                return std::unexpected("population analysis requires a non-empty AO basis");
+            if (molecule.atomic_numbers.size() != static_cast<Eigen::Index>(molecule.natoms))
+                return std::unexpected("population analysis requires initialized molecular atom data");
+            if (!matrix_has_shape(overlap, nbasis, nbasis))
+                return std::unexpected(std::format(
+                    "overlap matrix has shape {}x{} but expected {}x{}",
+                    overlap.rows(), overlap.cols(), nbasis, nbasis));
+            if (!matrix_has_shape(total_density, nbasis, nbasis))
+                return std::unexpected(std::format(
+                    "density matrix has shape {}x{} but expected {}x{}",
+                    total_density.rows(), total_density.cols(), nbasis, nbasis));
+            if (spin_density != nullptr && !matrix_has_shape(*spin_density, nbasis, nbasis))
+                return std::unexpected(std::format(
+                    "spin-density matrix has shape {}x{} but expected {}x{}",
+                    spin_density->rows(), spin_density->cols(), nbasis, nbasis));
+            return {};
+        }
+
+        std::expected<std::vector<std::vector<int>>, std::string> build_atom_ao_indices(
+            const Molecule &molecule,
+            const Basis &basis)
+        {
+            std::vector<std::vector<int>> atom_to_aos(molecule.natoms);
+            for (std::size_t mu = 0; mu < basis._basis_functions.size(); ++mu)
+            {
+                const ContractedView &bf = basis._basis_functions[mu];
+                if (bf._shell == nullptr)
+                    return std::unexpected(std::format("basis function {} has no parent shell", mu));
+                const std::size_t atom = static_cast<std::size_t>(bf._shell->_atom_index);
+                if (atom >= molecule.natoms)
+                    return std::unexpected(std::format(
+                        "basis function {} belongs to atom {} but molecule has only {} atom(s)",
+                        mu + 1, atom + 1, molecule.natoms));
+                atom_to_aos[atom].push_back(static_cast<int>(mu));
+            }
+            return atom_to_aos;
+        }
+
         Eigen::VectorXd gross_ao_population(
             const Eigen::MatrixXd &density,
             const Eigen::MatrixXd &overlap)
         {
             // Mulliken AO gross population: q_mu = sum_nu P_mu,nu S_mu,nu.
             return (density.array() * overlap.array()).rowwise().sum();
+        }
+
+        std::expected<Eigen::MatrixXd, std::string> symmetric_overlap_sqrt(
+            const Eigen::MatrixXd &overlap,
+            double threshold = 1e-10)
+        {
+            Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> solver(overlap);
+            if (solver.info() != Eigen::Success)
+                return std::unexpected("failed to diagonalize overlap matrix");
+
+            const Eigen::VectorXd &evals = solver.eigenvalues();
+            if (evals.minCoeff() < -threshold)
+                return std::unexpected(std::format(
+                    "overlap matrix is not positive semidefinite (min eigenvalue = {:.3e})",
+                    evals.minCoeff()));
+
+            Eigen::VectorXd sqrt_evals(evals.size());
+            for (Eigen::Index i = 0; i < evals.size(); ++i)
+                sqrt_evals(i) = (evals(i) > threshold) ? std::sqrt(evals(i)) : 0.0;
+
+            return solver.eigenvectors() * sqrt_evals.asDiagonal() * solver.eigenvectors().transpose();
+        }
+
+        PopulationAnalysis accumulate_atomic_populations(
+            const Molecule &molecule,
+            const std::vector<std::vector<int>> &atom_to_aos,
+            const Eigen::VectorXd &ao_population,
+            const Eigen::VectorXd *ao_spin_population)
+        {
+            PopulationAnalysis analysis;
+            analysis.atoms.resize(molecule.natoms);
+            analysis.ao_population = ao_population;
+            analysis.has_spin_population = (ao_spin_population != nullptr);
+
+            for (std::size_t atom = 0; atom < molecule.natoms; ++atom)
+            {
+                analysis.atoms[atom].atom_index = atom;
+                analysis.atoms[atom].atomic_number = molecule.atomic_numbers(static_cast<Eigen::Index>(atom));
+                analysis.atoms[atom].net_charge = static_cast<double>(analysis.atoms[atom].atomic_number);
+
+                for (const int mu : atom_to_aos[atom])
+                {
+                    analysis.atoms[atom].electron_population += ao_population(mu);
+                    if (ao_spin_population != nullptr)
+                        analysis.atoms[atom].spin_population += (*ao_spin_population)(mu);
+                }
+            }
+
+            analysis.total_electrons = ao_population.sum();
+            analysis.total_charge = 0.0;
+            analysis.total_spin_population =
+                (ao_spin_population != nullptr) ? ao_spin_population->sum() : 0.0;
+
+            for (auto &atom : analysis.atoms)
+            {
+                atom.net_charge -= atom.electron_population;
+                analysis.total_charge += atom.net_charge;
+            }
+
+            return analysis;
         }
     } // namespace
 
@@ -27,64 +136,136 @@ namespace HartreeFock::SCF
         const Eigen::MatrixXd &total_density,
         const Eigen::MatrixXd *spin_density)
     {
-        const Eigen::Index nbasis = static_cast<Eigen::Index>(basis.nbasis());
-        if (nbasis == 0)
-            return std::unexpected("Mulliken population analysis requires a non-empty AO basis");
-        if (molecule.atomic_numbers.size() != static_cast<Eigen::Index>(molecule.natoms))
-            return std::unexpected("Mulliken population analysis requires initialized molecular atom data");
-        if (!matrix_has_shape(overlap, nbasis, nbasis))
-            return std::unexpected(std::format(
-                "overlap matrix has shape {}x{} but expected {}x{}",
-                overlap.rows(), overlap.cols(), nbasis, nbasis));
-        if (!matrix_has_shape(total_density, nbasis, nbasis))
-            return std::unexpected(std::format(
-                "density matrix has shape {}x{} but expected {}x{}",
-                total_density.rows(), total_density.cols(), nbasis, nbasis));
-        if (spin_density != nullptr && !matrix_has_shape(*spin_density, nbasis, nbasis))
-            return std::unexpected(std::format(
-                "spin-density matrix has shape {}x{} but expected {}x{}",
-                spin_density->rows(), spin_density->cols(), nbasis, nbasis));
+        if (auto valid = validate_population_inputs(
+                molecule, basis, overlap, total_density, spin_density);
+            !valid)
+        {
+            return std::unexpected("Mulliken population analysis " + valid.error());
+        }
 
-        PopulationAnalysis analysis;
-        analysis.atoms.resize(molecule.natoms);
-        analysis.ao_population = gross_ao_population(total_density, overlap);
-        analysis.has_spin_population = (spin_density != nullptr);
+        auto atom_to_aos = build_atom_ao_indices(molecule, basis);
+        if (!atom_to_aos)
+            return std::unexpected("Mulliken population analysis " + atom_to_aos.error());
 
+        const Eigen::VectorXd ao_population = gross_ao_population(total_density, overlap);
         Eigen::VectorXd ao_spin_population;
-        if (analysis.has_spin_population)
+        if (spin_density != nullptr)
             ao_spin_population = gross_ao_population(*spin_density, overlap);
 
-        for (std::size_t atom = 0; atom < molecule.natoms; ++atom)
+        return accumulate_atomic_populations(
+            molecule,
+            *atom_to_aos,
+            ao_population,
+            (spin_density != nullptr) ? &ao_spin_population : nullptr);
+    }
+
+    std::expected<PopulationAnalysis, std::string> lowdin_population_analysis(
+        const Molecule &molecule,
+        const Basis &basis,
+        const Eigen::MatrixXd &overlap,
+        const Eigen::MatrixXd &total_density,
+        const Eigen::MatrixXd *spin_density)
+    {
+        if (auto valid = validate_population_inputs(
+                molecule, basis, overlap, total_density, spin_density);
+            !valid)
         {
-            analysis.atoms[atom].atom_index = atom;
-            analysis.atoms[atom].atomic_number = molecule.atomic_numbers(static_cast<Eigen::Index>(atom));
-            analysis.atoms[atom].net_charge = static_cast<double>(analysis.atoms[atom].atomic_number);
+            return std::unexpected("Löwdin population analysis " + valid.error());
         }
 
-        for (std::size_t mu = 0; mu < basis._basis_functions.size(); ++mu)
-        {
-            const ContractedView &bf = basis._basis_functions[mu];
-            if (bf._shell == nullptr)
-                return std::unexpected(std::format("basis function {} has no parent shell", mu));
-            const std::size_t atom = static_cast<std::size_t>(bf._shell->_atom_index);
-            if (atom >= analysis.atoms.size())
-                return std::unexpected(std::format(
-                    "basis function {} belongs to atom {} but molecule has only {} atom(s)",
-                    mu + 1, atom + 1, analysis.atoms.size()));
+        auto atom_to_aos = build_atom_ao_indices(molecule, basis);
+        if (!atom_to_aos)
+            return std::unexpected("Löwdin population analysis " + atom_to_aos.error());
 
-            analysis.atoms[atom].electron_population += analysis.ao_population(static_cast<Eigen::Index>(mu));
-            if (analysis.has_spin_population)
-                analysis.atoms[atom].spin_population += ao_spin_population(static_cast<Eigen::Index>(mu));
+        auto S_half = symmetric_overlap_sqrt(overlap);
+        if (!S_half)
+            return std::unexpected("Löwdin population analysis " + S_half.error());
+
+        const Eigen::MatrixXd lowdin_density =
+            (*S_half) * total_density * (*S_half);
+        const Eigen::VectorXd ao_population = lowdin_density.diagonal();
+
+        Eigen::VectorXd ao_spin_population;
+        if (spin_density != nullptr)
+        {
+            const Eigen::MatrixXd lowdin_spin_density =
+                (*S_half) * (*spin_density) * (*S_half);
+            ao_spin_population = lowdin_spin_density.diagonal();
         }
 
-        analysis.total_electrons = analysis.ao_population.sum();
-        analysis.total_charge = 0.0;
-        analysis.total_spin_population = analysis.has_spin_population ? ao_spin_population.sum() : 0.0;
+        return accumulate_atomic_populations(
+            molecule,
+            *atom_to_aos,
+            ao_population,
+            (spin_density != nullptr) ? &ao_spin_population : nullptr);
+    }
 
-        for (auto &atom : analysis.atoms)
+    std::expected<MayerBondOrderAnalysis, std::string> mayer_bond_order_analysis(
+        const Molecule &molecule,
+        const Basis &basis,
+        const Eigen::MatrixXd &overlap,
+        const Eigen::MatrixXd &total_density,
+        const Eigen::MatrixXd *alpha_density,
+        const Eigen::MatrixXd *beta_density)
+    {
+        if (auto valid = validate_population_inputs(
+                molecule, basis, overlap, total_density, nullptr);
+            !valid)
         {
-            atom.net_charge -= atom.electron_population;
-            analysis.total_charge += atom.net_charge;
+            return std::unexpected("Mayer bond-order analysis " + valid.error());
+        }
+
+        const Eigen::Index nbasis = static_cast<Eigen::Index>(basis.nbasis());
+        if (alpha_density != nullptr && !matrix_has_shape(*alpha_density, nbasis, nbasis))
+            return std::unexpected(std::format(
+                "Mayer bond-order analysis alpha-density matrix has shape {}x{} but expected {}x{}",
+                alpha_density->rows(), alpha_density->cols(), nbasis, nbasis));
+        if (beta_density != nullptr && !matrix_has_shape(*beta_density, nbasis, nbasis))
+            return std::unexpected(std::format(
+                "Mayer bond-order analysis beta-density matrix has shape {}x{} but expected {}x{}",
+                beta_density->rows(), beta_density->cols(), nbasis, nbasis));
+
+        auto atom_to_aos = build_atom_ao_indices(molecule, basis);
+        if (!atom_to_aos)
+            return std::unexpected("Mayer bond-order analysis " + atom_to_aos.error());
+
+        MayerBondOrderAnalysis analysis;
+        analysis.bond_orders = Eigen::MatrixXd::Zero(
+            static_cast<Eigen::Index>(molecule.natoms),
+            static_cast<Eigen::Index>(molecule.natoms));
+
+        const Eigen::MatrixXd PS_total = total_density * overlap;
+        const Eigen::MatrixXd PS_alpha =
+            (alpha_density != nullptr) ? (*alpha_density) * overlap : Eigen::MatrixXd();
+        const Eigen::MatrixXd PS_beta =
+            (beta_density != nullptr) ? (*beta_density) * overlap : Eigen::MatrixXd();
+
+        for (std::size_t atom_a = 0; atom_a < molecule.natoms; ++atom_a)
+        {
+            for (std::size_t atom_b = atom_a + 1; atom_b < molecule.natoms; ++atom_b)
+            {
+                double bond_order = 0.0;
+                for (const int mu : (*atom_to_aos)[atom_a])
+                    for (const int nu : (*atom_to_aos)[atom_b])
+                    {
+                        if (alpha_density != nullptr && beta_density != nullptr)
+                        {
+                            bond_order += PS_alpha(mu, nu) * PS_alpha(nu, mu);
+                            bond_order += PS_beta(mu, nu) * PS_beta(nu, mu);
+                        }
+                        else
+                        {
+                            bond_order += PS_total(mu, nu) * PS_total(nu, mu);
+                        }
+                    }
+
+                analysis.bond_orders(
+                    static_cast<Eigen::Index>(atom_a),
+                    static_cast<Eigen::Index>(atom_b)) = bond_order;
+                analysis.bond_orders(
+                    static_cast<Eigen::Index>(atom_b),
+                    static_cast<Eigen::Index>(atom_a)) = bond_order;
+            }
         }
 
         return analysis;

--- a/src/scf/population.h
+++ b/src/scf/population.h
@@ -30,12 +30,32 @@ namespace HartreeFock::SCF
         bool has_spin_population = false;
     };
 
+    struct MayerBondOrderAnalysis
+    {
+        Eigen::MatrixXd bond_orders;
+    };
+
     std::expected<PopulationAnalysis, std::string> mulliken_population_analysis(
         const Molecule &molecule,
         const Basis &basis,
         const Eigen::MatrixXd &overlap,
         const Eigen::MatrixXd &total_density,
         const Eigen::MatrixXd *spin_density = nullptr);
+
+    std::expected<PopulationAnalysis, std::string> lowdin_population_analysis(
+        const Molecule &molecule,
+        const Basis &basis,
+        const Eigen::MatrixXd &overlap,
+        const Eigen::MatrixXd &total_density,
+        const Eigen::MatrixXd *spin_density = nullptr);
+
+    std::expected<MayerBondOrderAnalysis, std::string> mayer_bond_order_analysis(
+        const Molecule &molecule,
+        const Basis &basis,
+        const Eigen::MatrixXd &overlap,
+        const Eigen::MatrixXd &total_density,
+        const Eigen::MatrixXd *alpha_density = nullptr,
+        const Eigen::MatrixXd *beta_density = nullptr);
 } // namespace HartreeFock::SCF
 
 #endif // HF_SCF_POPULATION_H

--- a/src/scf/sad.cpp
+++ b/src/scf/sad.cpp
@@ -5,6 +5,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -269,11 +270,18 @@ namespace
     // ── Atomic UHF ───────────────────────────────────────────────────────────
 
     // Runs atomic UHF for element Z in the given atomic basis (single atom at
-    // the origin).  Returns (P_alpha + P_beta, S_atom) — both in the atomic AO
+    // the origin).  Returns (P_alpha, P_beta, S_atom) — all in the atomic AO
     // basis ordering (size n_at × n_at).
     // Inherits integral engine and ERI tolerance from the molecular calculator.
     // All Logger output is suppressed via ScopedSilence.
-    static std::expected<std::pair<Eigen::MatrixXd, Eigen::MatrixXd>, std::string>
+    struct AtomicSadSpinDensities
+    {
+        Eigen::MatrixXd alpha;
+        Eigen::MatrixXd beta;
+        Eigen::MatrixXd overlap;
+    };
+
+    static std::expected<AtomicSadSpinDensities, std::string>
     run_atomic_uhf(int Z,
                    const HartreeFock::Basis &atomic_basis,
                    const HartreeFock::Calculator &mol_calc)
@@ -339,10 +347,10 @@ namespace
                     "SAD: atomic UHF failed for Z = " + std::to_string(Z) + ": " + result.error());
         }
 
-        Eigen::MatrixXd P_atom =
-            atom._info._scf.alpha.density + atom._info._scf.beta.density;
-
-        return std::pair{std::move(P_atom), std::move(S_at)};
+        return AtomicSadSpinDensities{
+            .alpha = atom._info._scf.alpha.density,
+            .beta = atom._info._scf.beta.density,
+            .overlap = std::move(S_at)};
     }
 
     // ── Spherical averaging ───────────────────────────────────────────────────
@@ -493,6 +501,35 @@ namespace
         return 0.5 * (P + P.transpose());
     }
 
+    // Projects one raw spin channel onto the nearest proper idempotent
+    // spin-density with trace n_occ in the molecular AO metric.
+    static std::expected<Eigen::MatrixXd, std::string> project_raw_sad_to_spin_density(
+        const Eigen::MatrixXd &P_raw,
+        const Eigen::MatrixXd &S_mol,
+        int n_occ,
+        double thresh)
+    {
+        if (n_occ < 0)
+            return std::unexpected("SAD: spin occupation cannot be negative");
+        if (n_occ > P_raw.rows())
+            return std::unexpected("SAD: spin occupation exceeds AO dimension");
+
+        const Eigen::MatrixXd X = make_thresholded_inverse_sqrt(S_mol, thresh);
+
+        Eigen::MatrixXd P_bar = X.transpose() * P_raw * X;
+        P_bar = 0.5 * (P_bar + P_bar.transpose());
+
+        Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> es(P_bar);
+        if (es.info() != Eigen::Success)
+            return std::unexpected("SAD: failed to diagonalize orthogonalized spin density");
+
+        const Eigen::MatrixXd U_occ = es.eigenvectors().rightCols(n_occ);
+        const Eigen::MatrixXd C_occ = X * U_occ;
+
+        Eigen::MatrixXd P = C_occ * C_occ.transpose();
+        return 0.5 * (P + P.transpose());
+    }
+
 } // anonymous namespace
 
 // ---------------------------------------------------------------------------
@@ -582,7 +619,9 @@ namespace HartreeFock
                 auto atomic_res = run_atomic_uhf(Z, atomic_basis, calc);
                 if (!atomic_res)
                     return std::unexpected(atomic_res.error());
-                auto [P_atom, S_atom] = std::move(*atomic_res);
+                Eigen::MatrixXd P_atom =
+                    std::move(atomic_res->alpha) + std::move(atomic_res->beta);
+                const Eigen::MatrixXd &S_atom = atomic_res->overlap;
 
                 spherical_average_atomic_density(atomic_basis, S_atom, P_atom, 1e-10);
                 P_atom = 0.5 * (P_atom + P_atom.transpose());
@@ -600,6 +639,76 @@ namespace HartreeFock
             // ── Step 4: reconstruct proper RHF density ────────────────────────
             return project_raw_sad_to_rhf_density(
                 P_raw, calc._overlap, n_electrons, 1e-8);
+        }
+
+        std::expected<std::pair<Eigen::MatrixXd, Eigen::MatrixXd>, std::string>
+        compute_sad_guess_open_shell(
+            const HartreeFock::Calculator &calc,
+            int n_alpha,
+            int n_beta)
+        {
+            if (n_alpha < 0 || n_beta < 0)
+                return std::unexpected("SAD: alpha and beta occupations must be non-negative");
+            if (n_alpha < n_beta)
+                return std::unexpected("SAD: expected n_alpha >= n_beta for open-shell SAD");
+
+            const std::string gbs_file =
+                calc._basis._basis_path + "/" + calc._basis._basis_name;
+            auto atomic_bases_res = read_gbs_basis_atomic(
+                gbs_file,
+                calc._molecule,
+                calc._basis._basis);
+            if (!atomic_bases_res)
+                return std::unexpected(atomic_bases_res.error());
+            auto atomic_bases = std::move(*atomic_bases_res);
+
+            std::unordered_map<std::string, Eigen::MatrixXd> atomic_Pa_cache;
+            std::unordered_map<std::string, Eigen::MatrixXd> atomic_Pb_cache;
+
+            for (auto &[sym, atomic_basis] : atomic_bases)
+            {
+                auto element = element_from_symbol(sym);
+                if (!element)
+                    return std::unexpected(element.error());
+                const int Z = static_cast<int>(element->Z);
+
+                auto atomic_res = run_atomic_uhf(Z, atomic_basis, calc);
+                if (!atomic_res)
+                    return std::unexpected(atomic_res.error());
+
+                Eigen::MatrixXd P_alpha = std::move(atomic_res->alpha);
+                Eigen::MatrixXd P_beta = std::move(atomic_res->beta);
+                const Eigen::MatrixXd &S_atom = atomic_res->overlap;
+
+                spherical_average_atomic_density(atomic_basis, S_atom, P_alpha, 1e-10);
+                spherical_average_atomic_density(atomic_basis, S_atom, P_beta, 1e-10);
+                P_alpha = 0.5 * (P_alpha + P_alpha.transpose());
+                P_beta = 0.5 * (P_beta + P_beta.transpose());
+
+                atomic_Pa_cache[sym] = std::move(P_alpha);
+                atomic_Pb_cache[sym] = std::move(P_beta);
+            }
+
+            auto raw_alpha = assemble_raw_sad_density(calc, atomic_Pa_cache);
+            if (!raw_alpha)
+                return std::unexpected(raw_alpha.error());
+            auto raw_beta = assemble_raw_sad_density(calc, atomic_Pb_cache);
+            if (!raw_beta)
+                return std::unexpected(raw_beta.error());
+
+            Eigen::MatrixXd Pa_raw = 0.5 * ((*raw_alpha) + raw_alpha->transpose());
+            Eigen::MatrixXd Pb_raw = 0.5 * ((*raw_beta) + raw_beta->transpose());
+
+            auto Pa = project_raw_sad_to_spin_density(Pa_raw, calc._overlap, n_alpha, 1e-8);
+            if (!Pa)
+                return std::unexpected(Pa.error());
+            auto Pb = project_raw_sad_to_spin_density(Pb_raw, calc._overlap, n_beta, 1e-8);
+            if (!Pb)
+                return std::unexpected(Pb.error());
+
+            return std::pair<Eigen::MatrixXd, Eigen::MatrixXd>{
+                std::move(*Pa),
+                std::move(*Pb)};
         }
 
     } // namespace SCF

--- a/src/scf/sad.h
+++ b/src/scf/sad.h
@@ -4,6 +4,7 @@
 #include <Eigen/Core>
 #include <expected>
 #include <string>
+#include <utility>
 #include <unordered_map>
 
 #include "base/types.h"
@@ -40,6 +41,23 @@ namespace HartreeFock
         //   - n_electrons = sum(Z) - charge must be even
         std::expected<Eigen::MatrixXd, std::string> compute_sad_guess_rhf(
             const HartreeFock::Calculator &calc);
+
+        // Compute spin-resolved SAD initial densities for open-shell SCF.
+        //
+        // The atomic step is the same as in RHF SAD (atomic UHF + shell-wise
+        // spherical averaging), but the molecular projection is performed
+        // separately for alpha and beta occupations:
+        //   X = S^{-1/2}  →  diagonalize X^T P_alpha X and X^T P_beta X
+        //   → occupy the top n_alpha / n_beta natural orbitals with unit
+        //      occupancy in each spin channel.
+        //
+        // The result can be used directly as the initial {P_alpha, P_beta}
+        // guess for both UHF and ROHF.
+        std::expected<std::pair<Eigen::MatrixXd, Eigen::MatrixXd>, std::string>
+        compute_sad_guess_open_shell(
+            const HartreeFock::Calculator &calc,
+            int n_alpha,
+            int n_beta);
 
     } // namespace SCF
 } // namespace HartreeFock

--- a/src/scf/scf.cpp
+++ b/src/scf/scf.cpp
@@ -499,15 +499,26 @@ std::expected<void, std::string> HartreeFock::SCF::run_uhf(
         (calculator._scf._guess == HartreeFock::SCFGuess::ReadDensity ||
          calculator._scf._guess == HartreeFock::SCFGuess::ReadFull);
 
-    if (calculator._scf._guess == HartreeFock::SCFGuess::SAD)
-        return std::unexpected("SAD guess is currently implemented only for RHF");
-
-    Eigen::MatrixXd Pa = use_chk_uhf
-                             ? calculator._info._scf.alpha.density
-                             : make_density_spin(n_alpha);
-    Eigen::MatrixXd Pb = use_chk_uhf
-                             ? calculator._info._scf.beta.density
-                             : make_density_spin(n_beta);
+    Eigen::MatrixXd Pa, Pb;
+    if (use_chk_uhf)
+    {
+        Pa = calculator._info._scf.alpha.density;
+        Pb = calculator._info._scf.beta.density;
+    }
+    else if (calculator._scf._guess == HartreeFock::SCFGuess::SAD)
+    {
+        auto sad_res = HartreeFock::SCF::compute_sad_guess_open_shell(
+            calculator, n_alpha, n_beta);
+        if (!sad_res)
+            return std::unexpected("UHF SAD guess failed: " + sad_res.error());
+        Pa = std::move(sad_res->first);
+        Pb = std::move(sad_res->second);
+    }
+    else
+    {
+        Pa = make_density_spin(n_alpha);
+        Pb = make_density_spin(n_beta);
+    }
 
     const unsigned int max_iter = calculator._scf.get_max_cycles(nbasis);
     const double level_shift = calculator._scf._level_shift;
@@ -910,8 +921,6 @@ std::expected<void, std::string> HartreeFock::SCF::run_rohf(
 
     if (n_open < 0)
         return std::unexpected("ROHF requires n_alpha >= n_beta");
-    if (calculator._scf._guess == HartreeFock::SCFGuess::SAD)
-        return std::unexpected("SAD guess is currently implemented only for RHF");
 
     auto X_result = build_orthogonalizer(S);
     if (!X_result)
@@ -992,6 +1001,15 @@ std::expected<void, std::string> HartreeFock::SCF::run_rohf(
         if (Pa.rows() != static_cast<Eigen::Index>(nbasis) ||
             Pb.rows() != static_cast<Eigen::Index>(nbasis))
             return std::unexpected("ROHF checkpoint density is missing alpha/beta spin channels");
+    }
+    else if (calculator._scf._guess == HartreeFock::SCFGuess::SAD)
+    {
+        auto sad_res = HartreeFock::SCF::compute_sad_guess_open_shell(
+            calculator, n_alpha, n_beta);
+        if (!sad_res)
+            return std::unexpected("ROHF SAD guess failed: " + sad_res.error());
+        Pa = std::move(sad_res->first);
+        Pb = std::move(sad_res->second);
     }
     else
     {

--- a/tests/inputs/regression/dft/h2_dft_tddft_pbe.hfinp
+++ b/tests/inputs/regression/dft/h2_dft_tddft_pbe.hfinp
@@ -1,0 +1,38 @@
+%begin_control
+    basis       sto-3g
+    calculation tddft
+    verbosity   normal
+    basis_type  cartesian
+%end_control
+
+%begin_scf
+    scf_type    rhf
+    use_diis    .true.
+    diis_dim    6
+    engine      os
+    guess       hcore
+    max_cycles  50
+    tol_energy  1.0e-8
+    tol_density 1.0e-8
+%end_scf
+
+%begin_dft
+    grid                coarse
+    exchange            pbe
+    correlation         pbe
+    lr_nstates          1
+    print_grid_summary  .true.
+%end_dft
+
+%begin_geom
+    coord_type  cartesian
+    coord_units angstrom
+    use_symm    .true.
+%end_geom
+
+%begin_coords
+2
+0   1
+H     0.000000     0.000000    -0.370000
+H     0.000000     0.000000     0.370000
+%end_coords

--- a/tests/population_analysis.cpp
+++ b/tests/population_analysis.cpp
@@ -93,6 +93,49 @@ int main()
                      "total spin population should equal Tr((P_alpha-P_beta) S)");
     }
 
+    const auto lowdin =
+        HartreeFock::SCF::lowdin_population_analysis(molecule, basis, S, P, &spin);
+
+    ok &= expect(static_cast<bool>(lowdin),
+                 "Löwdin analysis should accept compatible molecule, basis, overlap, and density data");
+    if (lowdin)
+    {
+        ok &= expect(near(lowdin->atoms[0].electron_population, 1.1),
+                     "atom 1 Löwdin population should equal the diagonal of S^(1/2) P S^(1/2) for this symmetric toy case");
+        ok &= expect(near(lowdin->atoms[1].electron_population, 1.1),
+                     "atom 2 Löwdin population should equal the diagonal of S^(1/2) P S^(1/2) for this symmetric toy case");
+        ok &= expect(near(lowdin->atoms[0].spin_population, 0.5959591794226539, 1e-10),
+                     "atom 1 Löwdin spin population should come from the diagonal of S^(1/2) (P_alpha-P_beta) S^(1/2)");
+        ok &= expect(near(lowdin->atoms[1].spin_population, 0.2040408205773456, 1e-10),
+                     "atom 2 Löwdin spin population should come from the diagonal of S^(1/2) (P_alpha-P_beta) S^(1/2)");
+        ok &= expect(near(lowdin->total_electrons, 2.2),
+                     "total Löwdin population should equal Tr(P S)");
+        ok &= expect(near(lowdin->total_spin_population, 0.8),
+                     "total Löwdin spin population should equal Tr((P_alpha-P_beta) S)");
+    }
+
+    Eigen::MatrixXd alpha(2, 2);
+    alpha << 0.8, 0.25,
+        0.25, 0.6;
+    Eigen::MatrixXd beta(2, 2);
+    beta << 0.2, 0.25,
+        0.25, 0.4;
+
+    const auto mayer =
+        HartreeFock::SCF::mayer_bond_order_analysis(molecule, basis, S, P, &alpha, &beta);
+
+    ok &= expect(static_cast<bool>(mayer),
+                 "Mayer bond-order analysis should accept compatible molecule, basis, overlap, and spin densities");
+    if (mayer)
+    {
+        ok &= expect(near(mayer->bond_orders(0, 1), 0.2474, 1e-12),
+                     "Mayer bond order should be the sum of alpha and beta (P S) cross products for the atom pair");
+        ok &= expect(near(mayer->bond_orders(1, 0), 0.2474, 1e-12),
+                     "Mayer bond-order matrix should be symmetric");
+        ok &= expect(near(mayer->bond_orders(0, 0), 0.0),
+                     "Mayer bond-order diagonal should remain zero");
+    }
+
     const Eigen::MatrixXd bad_density = Eigen::MatrixXd::Identity(3, 3);
     const auto bad =
         HartreeFock::SCF::mulliken_population_analysis(molecule, basis, S, bad_density);

--- a/tests/pyscf/README.md
+++ b/tests/pyscf/README.md
@@ -1,6 +1,7 @@
 # PySCF Reference Calculations
 
-External reference suite for validating Planck CASSCF/SA-CASSCF energies against PySCF.
+External reference suite for validating Planck CASSCF, SA-CASSCF, CCSD, and
+CCSDT energies against PySCF.
 
 ## Requirements
 
@@ -12,28 +13,36 @@ PySCF 2.x is required. These scripts have no other dependencies beyond PySCF and
 
 ## Running
 
-Run all cases and print a comparison table:
+Run all equivalence cases and print a comparison table:
 
 ```bash
-python3 tests/pyscf/run_all.py
+tests/pyscf/.venv/bin/python tests/pyscf/run_all.py
+```
+
+When configuring with CMake, the `planck-pyscf-equivalence` test will
+automatically use `tests/pyscf/.venv/bin/python` when that repo-local virtualenv
+exists. On other machines you can point CMake at any Python with PySCF installed:
+
+```bash
+cmake -S . -B build -DPLANCK_PYSCF_PYTHON=/path/to/python
 ```
 
 Run specific cases:
 
 ```bash
-python3 tests/pyscf/run_all.py --case h2_cas22_sto3g water_cas44_sto3g
+tests/pyscf/.venv/bin/python tests/pyscf/run_all.py --case h2_cas22_sto3g --case water_cas44_sto3g
 ```
 
 Run a single script directly:
 
 ```bash
-python3 tests/pyscf/h2_cas22_sto3g.py
+tests/pyscf/.venv/bin/python tests/pyscf/h2_cas22_sto3g.py
 ```
 
-Adjust tolerance (default 1e-5 Eh):
+List available cases:
 
 ```bash
-python3 tests/pyscf/run_all.py --tolerance 1e-4
+tests/pyscf/.venv/bin/python tests/pyscf/run_all.py --list
 ```
 
 ## Cases
@@ -49,31 +58,21 @@ python3 tests/pyscf/run_all.py --tolerance 1e-4
 | `ethylene_casscf_ccpvdz.py` | C₂H₄ (planar) | cc-pVDZ | CAS(2e,2o) | SS-CASSCF |
 | `water_cas44_sto3g_sa2.py` | H₂O | STO-3G | CAS(4e,4o) | SA-CASSCF (2 roots) |
 | `ethylene_cas44_sto3g_sa2.py` | C₂H₄ (90° twisted) | STO-3G | CAS(4e,4o) | SA-CASSCF (2 roots) |
+| `h2_rccsd_sto3g.py` | H₂ | STO-3G | n/a | RCCSD |
+| `lih_rccsdt_sto3g.py` | LiH | STO-3G | n/a | RCCSDT |
+| `b_uccsdt_sto3g.py` | B | STO-3G | n/a | UCCSD/UCCSDT |
+| `bh3_rccsdt_sto3g.py` | BH₃ | STO-3G | n/a | RCCSDT diagnostic |
 
-All geometries match the Planck `.hfinp` inputs in `tests/benchmarks/casscf/pyscf_reference/`.
-
-## Planck reference energies
-
-| Case | Planck / Eh |
-|---|---|
-| h2_cas22_sto3g | −1.1372838351 |
-| lih_cas22_sto3g | −7.8811184797 |
-| water_cas44_sto3g | −74.4700757755 |
-| water_cas44_631g | −75.5497490402 |
-| water_cas44_ccpvdz | −75.6045806122 |
-| ethylene_casscf_321g | −77.5145223872 |
-| ethylene_casscf_ccpvdz | −77.9524855976 |
-| water_cas44_sto3g_sa2 (SA-weighted) | −74.7751279351 |
-| ethylene_cas44_sto3g_sa2 (SA-weighted) | −77.0034974301 |
+The case manifest lives in `tests/pyscf/cases.json`. All geometries match the
+Planck `.hfinp` inputs in `tests/benchmarks/casscf/pyscf_reference/` or
+`tests/inputs/regression/post_hf/`.
 
 ## Tolerance
 
-- SS-CASSCF: energies should agree within 1e-5 Eh
-- SA-CASSCF: SA-weighted energies should agree within 1e-5 Eh
-
-The tolerance covers differences in convergence thresholds, orbital reordering, and
-minor numerical path differences. Larger disagreements indicate a genuine algorithmic
-discrepancy.
+- Most CASSCF and CC cross-checks use `1e-7` to `1e-8` Eh tolerances inside the
+  individual scripts.
+- The BH₃ tensor RCCSDT case is intentionally diagnostic: it is accepted either
+  as a full match or as the current known no-fallback non-convergence status.
 
 ## Notes on orbital selection
 

--- a/tests/pyscf/b_uccsdt_sto3g.py
+++ b/tests/pyscf/b_uccsdt_sto3g.py
@@ -27,9 +27,18 @@ PLANCK_EXE = REPO_ROOT / "build/hartree-fock"
 UCCSD_INPUT = REPO_ROOT / "tests/inputs/regression/post_hf/b_uccsd_sto3g.hfinp"
 UCCSDT_INPUT = REPO_ROOT / "tests/inputs/regression/post_hf/b_uccsdt_sto3g.hfinp"
 
-CORR_PATTERN = re.compile(r"^\s*Correlation Energy\s+([-+0-9Ee\.]+)", re.MULTILINE)
-UCCSD_TOTAL_PATTERN = re.compile(r"^\s*Total UCCSD Energy\s+([-+0-9Ee\.]+)", re.MULTILINE)
-UCCSDT_TOTAL_PATTERN = re.compile(r"^\s*Total UCCSDT Energy\s+([-+0-9Ee\.]+)", re.MULTILINE)
+CORR_PATTERN = re.compile(
+    r"^\s*(?:Correlation Energy|\[INF\]\s+UCCSDT? Correlation)\s+([-+0-9Ee\.]+)",
+    re.MULTILINE,
+)
+UCCSD_TOTAL_PATTERN = re.compile(
+    r"^\s*(?:Total UCCSD Energy|\[INF\]\s+UCCSD Energy)\s+([-+0-9Ee\.]+)",
+    re.MULTILINE,
+)
+UCCSDT_TOTAL_PATTERN = re.compile(
+    r"^\s*(?:Total UCCSDT Energy|\[INF\]\s+UCCSDT Energy)\s+([-+0-9Ee\.]+)",
+    re.MULTILINE,
+)
 
 
 def parse_last_float(pattern: re.Pattern[str], text: str, label: str) -> float:

--- a/tests/pyscf/cases.json
+++ b/tests/pyscf/cases.json
@@ -1,0 +1,94 @@
+{
+  "cases": [
+    {
+      "id": "b_uccsdt_sto3g",
+      "script": "tests/pyscf/b_uccsdt_sto3g.py",
+      "kind": "cc",
+      "allowed_statuses": ["PASS"]
+    },
+    {
+      "id": "bh3_rccsdt_sto3g",
+      "script": "tests/pyscf/bh3_rccsdt_sto3g.py",
+      "kind": "cc",
+      "allowed_statuses": ["PASS", "PLANCK_NO_FALLBACK_DID_NOT_CONVERGE"]
+    },
+    {
+      "id": "ethylene_cas44_sto3g_sa2",
+      "script": "tests/pyscf/ethylene_cas44_sto3g_sa2.py",
+      "kind": "casscf",
+      "allowed_statuses": ["PASS"]
+    },
+    {
+      "id": "ethylene_casscf_321g",
+      "script": "tests/pyscf/ethylene_casscf_321g.py",
+      "kind": "casscf",
+      "allowed_statuses": ["PASS"]
+    },
+    {
+      "id": "ethylene_casscf_321g_nroot2",
+      "script": "tests/pyscf/ethylene_casscf_321g_nroot2.py",
+      "kind": "casscf",
+      "allowed_statuses": ["PASS"]
+    },
+    {
+      "id": "ethylene_casscf_ccpvdz",
+      "script": "tests/pyscf/ethylene_casscf_ccpvdz.py",
+      "kind": "casscf",
+      "allowed_statuses": ["PASS"]
+    },
+    {
+      "id": "h2_cas22_sto3g",
+      "script": "tests/pyscf/h2_cas22_sto3g.py",
+      "kind": "casscf",
+      "allowed_statuses": ["PASS"]
+    },
+    {
+      "id": "h2_rccsd_sto3g",
+      "script": "tests/pyscf/h2_rccsd_sto3g.py",
+      "kind": "cc",
+      "allowed_statuses": ["PASS"]
+    },
+    {
+      "id": "lih_cas22_sto3g",
+      "script": "tests/pyscf/lih_cas22_sto3g.py",
+      "kind": "casscf",
+      "allowed_statuses": ["PASS"]
+    },
+    {
+      "id": "lih_rccsdt_sto3g",
+      "script": "tests/pyscf/lih_rccsdt_sto3g.py",
+      "kind": "cc",
+      "allowed_statuses": ["PASS"]
+    },
+    {
+      "id": "water_cas44_631g",
+      "script": "tests/pyscf/water_cas44_631g.py",
+      "kind": "casscf",
+      "allowed_statuses": ["PASS"]
+    },
+    {
+      "id": "water_cas44_b1",
+      "script": "tests/pyscf/water_cas44_b1.py",
+      "kind": "casscf",
+      "allowed_statuses": ["PASS"]
+    },
+    {
+      "id": "water_cas44_ccpvdz",
+      "script": "tests/pyscf/water_cas44_ccpvdz.py",
+      "kind": "casscf",
+      "allowed_statuses": ["PASS"]
+    },
+    {
+      "id": "water_cas44_sto3g",
+      "script": "tests/pyscf/water_cas44_sto3g.py",
+      "kind": "casscf",
+      "allowed_statuses": ["PASS"]
+    },
+    {
+      "id": "water_cas44_sto3g_sa2",
+      "script": "tests/pyscf/water_cas44_sto3g_sa2.py",
+      "kind": "casscf",
+      "allowed_statuses": ["PASS"]
+    }
+  ]
+}

--- a/tests/pyscf/generate_regression_references.py
+++ b/tests/pyscf/generate_regression_references.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from pyscf import cc, dft, gto, mp, scf
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MANIFEST = REPO_ROOT / "tests" / "pyscf" / "regression_reference_cases.json"
+DEFAULT_OUTPUT = REPO_ROOT / "tests" / "pyscf" / "regression_references.json"
+
+LABEL_PATTERNS = {
+    "CASSCF_ENERGY": re.compile(r"^CASSCF_ENERGY:\s*([-+0-9Ee.]+)", re.MULTILINE),
+}
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def parse_bool(value: str) -> bool:
+    return value.strip().lower() in {".true.", "true", "yes", "1"}
+
+
+def parse_input_file(path: Path) -> dict[str, Any]:
+    sections: dict[str, list[str]] = {}
+    current: str | None = None
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.split("#", 1)[0].rstrip()
+        stripped = line.strip()
+        if not stripped:
+            continue
+        lower = stripped.lower()
+        if lower.startswith("%begin_"):
+            current = lower[len("%begin_"):]
+            sections[current] = []
+            continue
+        if lower.startswith("%end_"):
+            current = None
+            continue
+        if current is not None:
+            sections[current].append(stripped)
+
+    parsed: dict[str, Any] = {}
+    for name in ("control", "scf", "geom", "dft"):
+        values: dict[str, str] = {}
+        for entry in sections.get(name, []):
+            parts = entry.split()
+            if parts:
+                values[parts[0].lower()] = " ".join(parts[1:])
+        parsed[name] = values
+
+    coords_lines = sections.get("coords", [])
+    if len(coords_lines) < 2:
+        raise ValueError(f"{path} is missing a valid coords section")
+    natoms = int(coords_lines[0].split()[0])
+    charge, multiplicity = (int(x) for x in coords_lines[1].split()[:2])
+    atoms: list[tuple[str, tuple[float, float, float]]] = []
+    for entry in coords_lines[2 : 2 + natoms]:
+        symbol, x, y, z = entry.split()[:4]
+        atoms.append((symbol, (float(x), float(y), float(z))))
+    parsed["coords"] = {
+        "natoms": natoms,
+        "charge": charge,
+        "multiplicity": multiplicity,
+        "atoms": atoms,
+    }
+    return parsed
+
+
+def build_molecule(spec: dict[str, Any]) -> gto.Mole:
+    control = spec["control"]
+    geom = spec["geom"]
+    coords = spec["coords"]
+    basis_name = control["basis"].lower()
+    basis_aliases = {
+        "cc-pvdz-unc": "cc-pvdz",
+    }
+
+    mol = gto.Mole()
+    mol.atom = "\n".join(
+        f"{symbol} {xyz[0]:.10f} {xyz[1]:.10f} {xyz[2]:.10f}"
+        for symbol, xyz in coords["atoms"]
+    )
+    mol.basis = basis_aliases.get(basis_name, control["basis"])
+    mol.charge = coords["charge"]
+    mol.spin = coords["multiplicity"] - 1
+    mol.cart = control.get("basis_type", "cartesian").lower() == "cartesian"
+    mol.symmetry = parse_bool(geom.get("use_symm", ".false."))
+    mol.unit = "Bohr" if geom.get("coord_units", "angstrom").lower() == "bohr" else "Angstrom"
+    mol.verbose = 0
+    mol.build()
+    return mol
+
+
+def functional_string(dft_section: dict[str, str]) -> str:
+    exchange = dft_section.get("exchange", "").strip().lower()
+    correlation = dft_section.get("correlation", "").strip().lower()
+    if exchange in {"b3lyp", "pbe0", "pbeh"}:
+        return {"b3lyp": "b3lyp", "pbe0": "pbe0", "pbeh": "pbe0"}[exchange]
+    if exchange == "lda":
+        exchange = "slater"
+    if correlation == "vwn":
+        correlation = "vwn5"
+    return f"{exchange},{correlation}"
+
+
+def grid_level(name: str) -> int:
+    return {
+        "coarse": 0,
+        "normal": 1,
+        "fine": 3,
+        "ultrafine": 5,
+    }.get(name.lower(), 1)
+
+
+def run_input_case(case: dict[str, Any]) -> dict[str, float]:
+    spec = parse_input_file(REPO_ROOT / case["input"])
+    mol = build_molecule(spec)
+    scf_section = spec["scf"]
+    dft_section = spec["dft"]
+    scf_type = scf_section.get("scf_type", "rhf").lower()
+    correlation = scf_section.get("correlation", "").lower()
+    tol_energy = float(scf_section.get("tol_energy", "1e-10"))
+
+    uses_dft = bool(dft_section)
+    if uses_dft:
+        if scf_type in {"rhf", "rks"}:
+            mf: Any = dft.RKS(mol)
+        elif scf_type in {"uhf", "uks"}:
+            mf = dft.UKS(mol)
+        else:
+            raise ValueError(f"Unsupported DFT scf_type {scf_type!r} for {case['id']}")
+        mf.xc = functional_string(dft_section)
+        mf.grids.level = grid_level(dft_section.get("grid", dft_section.get("grid_level", "normal")))
+    else:
+        if scf_type == "rhf":
+            mf = scf.RHF(mol)
+        elif scf_type == "uhf":
+            mf = scf.UHF(mol)
+        else:
+            raise ValueError(f"Unsupported SCF type {scf_type!r} for {case['id']}")
+
+    mf.conv_tol = tol_energy
+    mf.kernel()
+
+    metrics: dict[str, float] = {}
+    if uses_dft:
+        metrics["dft_total_energy"] = float(mf.e_tot)
+        return metrics
+
+    metrics["rhf_total_energy"] = float(mf.e_tot)
+    if not correlation:
+        return metrics
+
+    if correlation == "rmp2":
+        corr, *_ = mp.MP2(mf).kernel()
+        metrics["mp2_total_energy"] = float(mf.e_tot + corr)
+    elif correlation == "ump2":
+        corr, *_ = mp.UMP2(mf).kernel()
+        metrics["mp2_total_energy"] = float(mf.e_tot + corr)
+    elif correlation == "ccsdt":
+        corr, *_ = cc.RCCSDT(mf).kernel()
+        metrics["rccsdt_total_energy"] = float(mf.e_tot + corr)
+    elif correlation == "uccsd":
+        corr, *_ = cc.UCCSD(mf).kernel()
+        metrics["uccsd_total_energy"] = float(mf.e_tot + corr)
+    elif correlation == "uccsdt":
+        corr, *_ = cc.UCCSDT(mf).kernel()
+        metrics["uccsdt_total_energy"] = float(mf.e_tot + corr)
+    else:
+        raise ValueError(f"Unsupported correlation method {correlation!r} for {case['id']}")
+    return metrics
+
+
+def run_script_case(case: dict[str, Any], python_executable: Path) -> dict[str, float]:
+    proc = subprocess.run(
+        [str(python_executable), str(REPO_ROOT / case["script"])],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    output = proc.stdout + proc.stderr
+    if proc.returncode != 0:
+        raise RuntimeError(f"PySCF script failed for {case['id']}:\n{output}")
+
+    metrics: dict[str, float] = {}
+    for metric_name, label in case["parse_labels"].items():
+        pattern = LABEL_PATTERNS[label]
+        match = pattern.search(output)
+        if match is None:
+            raise RuntimeError(f"Could not parse {label} from {case['script']}")
+        metrics[metric_name] = float(match.group(1))
+    return metrics
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate PySCF references for Planck regressions")
+    parser.add_argument("--manifest", default=str(DEFAULT_MANIFEST))
+    parser.add_argument("--output", default=str(DEFAULT_OUTPUT))
+    parser.add_argument("--python", default=sys.executable)
+    parser.add_argument("--case", action="append", default=[])
+    args = parser.parse_args()
+
+    manifest = load_manifest(Path(args.manifest))
+    selected = set(args.case)
+    python_executable = Path(args.python).expanduser()
+
+    references: dict[str, dict[str, dict[str, float]]] = {}
+    for case in manifest["cases"]:
+        if selected and case["id"] not in selected:
+            continue
+        print(f"[PySCF] {case['id']}", file=sys.stderr)
+        if case["mode"] == "input":
+            metrics = run_input_case(case)
+        elif case["mode"] == "script":
+            metrics = run_script_case(case, python_executable)
+        else:
+            raise ValueError(f"Unknown mode {case['mode']!r}")
+
+        payload: dict[str, dict[str, float]] = {}
+        for metric_name, expected in metrics.items():
+            entry = {"expected": float(expected)}
+            if metric_name in case.get("tolerances", {}):
+                entry["atol"] = float(case["tolerances"][metric_name])
+            payload[metric_name] = entry
+        references[case["id"]] = payload
+
+    output_path = Path(args.output)
+    output_path.write_text(json.dumps({"cases": references}, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"Wrote {output_path}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/pyscf/regression_reference_cases.json
+++ b/tests/pyscf/regression_reference_cases.json
@@ -1,0 +1,134 @@
+{
+  "cases": [
+    {
+      "id": "h2_rmp2_sto3g",
+      "mode": "input",
+      "input": "inputs/examples/hf/mp2_validation/val_h2.hfinp",
+      "tolerances": {
+        "rhf_total_energy": 1e-7,
+        "mp2_total_energy": 1e-7
+      }
+    },
+    {
+      "id": "lih_rmp2_sto3g",
+      "mode": "input",
+      "input": "inputs/examples/hf/mp2_validation/val_lih.hfinp",
+      "tolerances": {
+        "rhf_total_energy": 1e-7,
+        "mp2_total_energy": 1e-7
+      }
+    },
+    {
+      "id": "hf_rmp2_sto3g",
+      "mode": "input",
+      "input": "inputs/examples/hf/mp2_validation/val_hf.hfinp",
+      "tolerances": {
+        "rhf_total_energy": 1e-7,
+        "mp2_total_energy": 1e-7
+      }
+    },
+    {
+      "id": "water_rmp2_sto3g",
+      "mode": "input",
+      "input": "inputs/examples/hf/mp2_validation/val_water.hfinp",
+      "tolerances": {
+        "rhf_total_energy": 1e-7,
+        "mp2_total_energy": 1e-7
+      }
+    },
+    {
+      "id": "nh3_rmp2_sto3g",
+      "mode": "input",
+      "input": "inputs/examples/hf/mp2_validation/val_nh3.hfinp",
+      "tolerances": {
+        "rhf_total_energy": 1e-7,
+        "mp2_total_energy": 1e-7
+      }
+    },
+    {
+      "id": "ch4_rmp2_sto3g",
+      "mode": "input",
+      "input": "inputs/examples/hf/mp2_validation/val_ch4.hfinp",
+      "tolerances": {
+        "rhf_total_energy": 1e-7,
+        "mp2_total_energy": 1e-7
+      }
+    },
+    {
+      "id": "water_radical_cation_uhf_ump2_sto3g",
+      "mode": "input",
+      "input": "tests/inputs/regression/open_shell/water_radical_cation_uhf_ump2_sto3g.hfinp",
+      "tolerances": {
+        "rhf_total_energy": 1e-7,
+        "mp2_total_energy": 1e-6
+      }
+    },
+    {
+      "id": "h2_rccsdt_sto3g",
+      "mode": "input",
+      "input": "tests/inputs/regression/post_hf/h2_rccsdt_sto3g.hfinp",
+      "tolerances": {
+        "rhf_total_energy": 5e-8,
+        "rccsdt_total_energy": 3e-7
+      }
+    },
+    {
+      "id": "lih_rccsdt_sto3g",
+      "mode": "input",
+      "input": "tests/inputs/regression/post_hf/lih_rccsdt_sto3g.hfinp",
+      "tolerances": {
+        "rhf_total_energy": 5e-8,
+        "rccsdt_total_energy": 1e-7
+      }
+    },
+    {
+      "id": "water_rccsdt_sto3g",
+      "mode": "input",
+      "input": "tests/inputs/regression/post_hf/water_rccsdt_sto3g.hfinp",
+      "tolerances": {
+        "rhf_total_energy": 5e-8,
+        "rccsdt_total_energy": 1e-6
+      }
+    },
+    {
+      "id": "b_uccsd_sto3g",
+      "mode": "input",
+      "input": "tests/inputs/regression/post_hf/b_uccsd_sto3g.hfinp",
+      "tolerances": {
+        "rhf_total_energy": 1e-7,
+        "uccsd_total_energy": 1e-6
+      }
+    },
+    {
+      "id": "b_uccsdt_sto3g",
+      "mode": "input",
+      "input": "tests/inputs/regression/post_hf/b_uccsdt_sto3g.hfinp",
+      "tolerances": {
+        "rhf_total_energy": 1e-7,
+        "uccsdt_total_energy": 1e-6
+      }
+    },
+    {
+      "id": "water_casscf_c2v_b1",
+      "mode": "script",
+      "script": "tests/pyscf/water_cas44_b1.py",
+      "parse_labels": {
+        "casscf_total_energy": "CASSCF_ENERGY"
+      },
+      "tolerances": {
+        "casscf_total_energy": 1e-5
+      }
+    },
+    {
+      "id": "water_casscf_ccpvdz_a1",
+      "mode": "script",
+      "script": "tests/pyscf/water_cas44_ccpvdz.py",
+      "parse_labels": {
+        "casscf_total_energy": "CASSCF_ENERGY"
+      },
+      "tolerances": {
+        "casscf_total_energy": 1e-5
+      }
+    }
+  ]
+}

--- a/tests/pyscf/regression_references.json
+++ b/tests/pyscf/regression_references.json
@@ -1,0 +1,136 @@
+{
+  "cases": {
+    "b_uccsd_sto3g": {
+      "rhf_total_energy": {
+        "atol": 1e-07,
+        "expected": -24.148988598853652
+      },
+      "uccsd_total_energy": {
+        "atol": 1e-06,
+        "expected": -24.18925808470455
+      }
+    },
+    "b_uccsdt_sto3g": {
+      "rhf_total_energy": {
+        "atol": 1e-07,
+        "expected": -24.148988598853652
+      },
+      "uccsdt_total_energy": {
+        "atol": 1e-06,
+        "expected": -24.189263556910305
+      }
+    },
+    "ch4_rmp2_sto3g": {
+      "mp2_total_energy": {
+        "atol": 1e-07,
+        "expected": -39.78320307368553
+      },
+      "rhf_total_energy": {
+        "atol": 1e-07,
+        "expected": -39.72674332479202
+      }
+    },
+    "h2_rccsdt_sto3g": {
+      "rccsdt_total_energy": {
+        "atol": 3e-07,
+        "expected": -1.137274570976646
+      },
+      "rhf_total_energy": {
+        "atol": 5e-08,
+        "expected": -1.1167061372361056
+      }
+    },
+    "h2_rmp2_sto3g": {
+      "mp2_total_energy": {
+        "atol": 1e-07,
+        "expected": -1.1298973809859585
+      },
+      "rhf_total_energy": {
+        "atol": 1e-07,
+        "expected": -1.1167593073964255
+      }
+    },
+    "hf_rmp2_sto3g": {
+      "mp2_total_energy": {
+        "atol": 1e-07,
+        "expected": -98.58812430415765
+      },
+      "rhf_total_energy": {
+        "atol": 1e-07,
+        "expected": -98.5707799860142
+      }
+    },
+    "lih_rccsdt_sto3g": {
+      "rccsdt_total_energy": {
+        "atol": 1e-07,
+        "expected": -7.882401799102108
+      },
+      "rhf_total_energy": {
+        "atol": 5e-08,
+        "expected": -7.862023860127114
+      }
+    },
+    "lih_rmp2_sto3g": {
+      "mp2_total_energy": {
+        "atol": 1e-07,
+        "expected": -7.874888499239941
+      },
+      "rhf_total_energy": {
+        "atol": 1e-07,
+        "expected": -7.862023860127114
+      }
+    },
+    "nh3_rmp2_sto3g": {
+      "mp2_total_energy": {
+        "atol": 1e-07,
+        "expected": -55.499667030106394
+      },
+      "rhf_total_energy": {
+        "atol": 1e-07,
+        "expected": -55.436386833801876
+      }
+    },
+    "water_casscf_c2v_b1": {
+      "casscf_total_energy": {
+        "atol": 1e-05,
+        "expected": -74.5856164513
+      }
+    },
+    "water_casscf_ccpvdz_a1": {
+      "casscf_total_energy": {
+        "atol": 1e-05,
+        "expected": -76.0440109036
+      }
+    },
+    "water_radical_cation_uhf_ump2_sto3g": {
+      "mp2_total_energy": {
+        "atol": 1e-06,
+        "expected": -74.68333544047587
+      },
+      "rhf_total_energy": {
+        "atol": 1e-07,
+        "expected": -74.65570586363151
+      }
+    },
+    "water_rccsdt_sto3g": {
+      "rccsdt_total_energy": {
+        "atol": 1e-06,
+        "expected": -75.01249757526931
+      },
+      "rhf_total_energy": {
+        "atol": 5e-08,
+        "expected": -74.9629916147492
+      }
+    },
+    "water_rmp2_sto3g": {
+      "mp2_total_energy": {
+        "atol": 1e-07,
+        "expected": -74.97677732883211
+      },
+      "rhf_total_energy": {
+        "atol": 1e-07,
+        "expected": -74.94588076098961
+      }
+    }
+  }
+}

--- a/tests/pyscf/run_all.py
+++ b/tests/pyscf/run_all.py
@@ -1,167 +1,202 @@
 #!/usr/bin/env python3
 """
-Run all PySCF reference calculations and print a comparison table.
+Run the full PySCF equivalence corpus against the local Planck build.
 
-Usage:
-    python3 tests/pyscf/run_all.py
-    python3 tests/pyscf/run_all.py --case h2_cas22_sto3g water_cas44_sto3g
-    python3 tests/pyscf/run_all.py --tolerance 1e-4
-
-Each case is run as a subprocess so a failure in one does not abort the rest.
-Output is collected and parsed for CASSCF_ENERGY / SA_ENERGY / STATUS lines.
+Each PySCF case script performs its own PySCF vs Planck comparison and emits a
+machine-readable STATUS line. This runner centralizes discovery, uses the
+checked-in PySCF virtualenv by default, and makes the suite easy to run from
+CTest.
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import re
 import subprocess
 import sys
 import time
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
-HERE = Path(__file__).parent
+HERE = Path(__file__).resolve().parent
+DEFAULT_PYTHON = HERE / ".venv" / "bin" / "python"
+DEFAULT_MANIFEST = HERE / "cases.json"
 
-ALL_CASES = [
-    "h2_cas22_sto3g",
-    "lih_cas22_sto3g",
-    "water_cas44_sto3g",
-    "water_cas44_631g",
-    "water_cas44_ccpvdz",
-    "water_cas44_b1",
-    "ethylene_casscf_321g",
-    "ethylene_casscf_321g_nroot2",
-    "ethylene_casscf_ccpvdz",
-    "water_cas44_sto3g_sa2",
-    "ethylene_cas44_sto3g_sa2",
-]
-
-PLANCK_ENERGIES: dict[str, float] = {
-    "h2_cas22_sto3g": -1.1372838351,
-    "lih_cas22_sto3g": -7.8811184797,
-    "water_cas44_sto3g": -74.9760171760,
-    "water_cas44_631g": -75.9998609785,
-    "water_cas44_ccpvdz": -76.0440109052,
-    "water_cas44_b1": -74.5856163677,
-    "ethylene_casscf_321g": -77.5145223872,
-    "ethylene_casscf_321g_nroot2": -77.5145223872,
-    "ethylene_casscf_ccpvdz": -77.9524855977,
-    "water_cas44_sto3g_sa2": -74.7751377977,
-    "ethylene_cas44_sto3g_sa2": -77.0034974301,
-}
-
-SA_CASES = {"water_cas44_sto3g_sa2", "ethylene_cas44_sto3g_sa2"}
-
-ENERGY_PATTERN = re.compile(
-    r"^(?:CASSCF_ENERGY|SA_ENERGY)\s*:\s*([-+0-9Ee.]+)", re.MULTILINE
-)
-STATUS_PATTERN = re.compile(r"^STATUS\s*:\s*(\w+)", re.MULTILINE)
+STATUS_PATTERN = re.compile(r"^STATUS\s*:\s*([A-Z0-9_]+)", re.MULTILINE)
+DELTA_PATTERN = re.compile(r"^(DELTA_[A-Z0-9_]+)\s*:\s*([-+0-9Ee.]+)\s+Eh", re.MULTILINE)
 
 
-def run_case(script: Path, timeout: int = 300) -> tuple[str | None, str]:
-    """Run one script, return (pyscf_energy_str_or_None, status_str)."""
+@dataclass
+class CaseSpec:
+    case_id: str
+    script: Path
+    kind: str
+    allowed_statuses: tuple[str, ...]
+
+
+@dataclass
+class CaseResult:
+    case_id: str
+    kind: str
+    outcome: str
+    raw_status: str
+    max_delta: float | None
+    elapsed_s: float
+    detail: str | None
+
+
+def load_cases(manifest_path: Path) -> list[CaseSpec]:
+    payload: dict[str, Any] = json.loads(manifest_path.read_text(encoding="utf-8"))
+    cases: list[CaseSpec] = []
+    for case in payload["cases"]:
+        cases.append(
+            CaseSpec(
+                case_id=case["id"],
+                script=(HERE.parent.parent / case["script"]).resolve(),
+                kind=case["kind"],
+                allowed_statuses=tuple(case.get("allowed_statuses", ["PASS"])),
+            )
+        )
+    return cases
+
+
+def select_cases(
+    cases: list[CaseSpec],
+    requested_ids: set[str],
+    requested_kind: str,
+) -> list[CaseSpec]:
+    selected = cases
+    if requested_ids:
+        selected = [case for case in selected if case.case_id in requested_ids]
+    if requested_kind != "all":
+        selected = [case for case in selected if case.kind == requested_kind]
+    return selected
+
+
+def parse_status(output: str) -> str:
+    match = STATUS_PATTERN.search(output)
+    return match.group(1) if match else "MISSING_STATUS"
+
+
+def parse_max_delta(output: str) -> float | None:
+    values = [abs(float(value)) for _label, value in DELTA_PATTERN.findall(output)]
+    return max(values) if values else None
+
+
+def run_case(case: CaseSpec, python_executable: Path, timeout_s: int) -> CaseResult:
+    start = time.monotonic()
     try:
-        result = subprocess.run(
-            [sys.executable, str(script)],
+        proc = subprocess.run(
+            [str(python_executable), str(case.script)],
+            cwd=HERE.parent.parent,
             capture_output=True,
             text=True,
-            timeout=timeout,
+            timeout=timeout_s,
+            check=False,
         )
-        output = result.stdout + result.stderr
+        output = proc.stdout + proc.stderr
+        raw_status = parse_status(output)
+        max_delta = parse_max_delta(output)
+        if proc.returncode == 0 and raw_status in case.allowed_statuses:
+            outcome = "PASS"
+            detail = None
+        elif proc.returncode == 0:
+            outcome = "FAIL"
+            detail = f"unexpected STATUS {raw_status!r}; expected one of {case.allowed_statuses}"
+        else:
+            outcome = "ERROR"
+            detail = f"exit code {proc.returncode}"
+        if outcome != "PASS":
+            trailer = "\n".join(output.strip().splitlines()[-20:])
+            detail = f"{detail}\n{trailer}".strip()
     except subprocess.TimeoutExpired:
-        return None, "TIMEOUT"
-    except Exception as exc:
-        return None, f"ERROR({exc})"
+        raw_status = "TIMEOUT"
+        max_delta = None
+        outcome = "ERROR"
+        detail = f"timed out after {timeout_s}s"
 
-    energy_match = ENERGY_PATTERN.search(output)
-    status_match = STATUS_PATTERN.search(output)
-    energy = energy_match.group(1) if energy_match else None
-    status = status_match.group(1) if status_match else "ERROR"
-    return energy, status
+    elapsed_s = time.monotonic() - start
+    return CaseResult(
+        case_id=case.case_id,
+        kind=case.kind,
+        outcome=outcome,
+        raw_status=raw_status,
+        max_delta=max_delta,
+        elapsed_s=elapsed_s,
+        detail=detail,
+    )
+
+
+def format_delta(value: float | None) -> str:
+    return f"{value:.2e}" if value is not None else "-"
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Run PySCF reference calculations")
-    parser.add_argument(
-        "--case", nargs="*", default=None,
-        help="Specific case(s) to run (default: all)",
-    )
-    parser.add_argument(
-        "--tolerance", type=float, default=1e-5,
-        help="Energy match tolerance in Eh (default: 1e-5)",
-    )
-    parser.add_argument(
-        "--timeout", type=int, default=300,
-        help="Per-case timeout in seconds (default: 300)",
-    )
+    parser = argparse.ArgumentParser(description="Run PySCF equivalence cases")
+    parser.add_argument("--manifest", default=str(DEFAULT_MANIFEST))
+    parser.add_argument("--python", default=str(DEFAULT_PYTHON))
+    parser.add_argument("--case", action="append", default=[])
+    parser.add_argument("--kind", choices=["all", "casscf", "cc"], default="all")
+    parser.add_argument("--timeout", type=int, default=600)
+    parser.add_argument("--list", action="store_true")
     args = parser.parse_args()
 
-    cases = args.case if args.case else ALL_CASES
-    unknown = [c for c in cases if c not in PLANCK_ENERGIES]
-    if unknown:
-        print(f"Unknown case(s): {', '.join(unknown)}", file=sys.stderr)
-        print(f"Available: {', '.join(ALL_CASES)}", file=sys.stderr)
+    manifest_path = Path(args.manifest).resolve()
+    python_executable = Path(args.python).expanduser()
+    if not manifest_path.exists():
+        print(f"Manifest not found: {manifest_path}", file=sys.stderr)
+        return 1
+    if not python_executable.exists():
+        print(f"PySCF virtualenv Python not found: {python_executable}", file=sys.stderr)
         return 1
 
+    cases = load_cases(manifest_path)
+    known_case_ids = {case.case_id for case in cases}
+    requested_ids = set(args.case)
+    unknown = sorted(requested_ids - known_case_ids)
+    if unknown:
+        print(f"Unknown case(s): {', '.join(unknown)}", file=sys.stderr)
+        return 1
+    selected = select_cases(cases, requested_ids, args.kind)
+    if args.list:
+        for case in selected:
+            print(f"{case.case_id}\t{case.kind}\t{case.script.relative_to(HERE.parent.parent)}")
+        return 0
+
     header = (
-        f"{'Case':<35} {'PySCF / Eh':>14} {'Planck / Eh':>14} "
-        f"{'Delta / Eh':>12} {'Status':<8} {'Time(s)':>7}"
+        f"{'Case':<35} {'Kind':<8} {'Outcome':<8} {'Status':<34} "
+        f"{'Max Delta / Eh':>14} {'Time(s)':>7}"
     )
     sep = "-" * len(header)
     print(sep)
     print(header)
     print(sep)
 
-    passed = failed = errors = 0
+    passed = 0
+    failed = 0
 
-    for case in cases:
-        script = HERE / f"{case}.py"
-        if not script.exists():
-            print(f"  {case:<33} {'<script missing>':<14}")
-            errors += 1
-            continue
-
-        t0 = time.monotonic()
-        energy_str, status = run_case(script, timeout=args.timeout)
-        elapsed = time.monotonic() - t0
-
-        planck = PLANCK_ENERGIES[case]
-
-        if energy_str is not None:
-            try:
-                pyscf_e = float(energy_str)
-                delta = abs(pyscf_e - planck)
-                # Re-evaluate status against caller's tolerance
-                if status not in ("TIMEOUT", "ERROR") and not status.startswith("ERROR"):
-                    status = "PASS" if delta < args.tolerance else "FAIL"
-                row = (
-                    f"  {case:<33} {pyscf_e:>14.10f} {planck:>14.10f} "
-                    f"{delta:>12.2e} {status:<8} {elapsed:>7.1f}"
-                )
-            except ValueError:
-                row = f"  {case:<33} {'<parse error>':<14}"
-                status = "ERROR"
-        else:
-            row = (
-                f"  {case:<33} {'<no energy>':<14} {planck:>14.10f} "
-                f"{'':>12} {status:<8} {elapsed:>7.1f}"
-            )
-
-        print(row)
-
-        if status == "PASS":
+    for case in selected:
+        result = run_case(case, python_executable, args.timeout)
+        print(
+            f"{result.case_id:<35} {result.kind:<8} {result.outcome:<8} "
+            f"{result.raw_status:<34} {format_delta(result.max_delta):>14} {result.elapsed_s:>7.1f}"
+        )
+        if result.outcome == "PASS":
             passed += 1
-        elif status == "FAIL":
-            failed += 1
-        else:
-            errors += 1
+            continue
+        failed += 1
+        if result.detail:
+            print("---- detail ----")
+            print(result.detail)
+            print(sep)
 
-    total = passed + failed + errors
+    total = passed + failed
     print(sep)
-    print(f"  {passed}/{total} passed, {failed} failed, {errors} errors")
+    print(f"{passed}/{total} passed, {failed} failed")
     print(sep)
-
-    return 0 if failed == 0 and errors == 0 else 1
+    return 0 if failed == 0 else 1
 
 
 if __name__ == "__main__":

--- a/tests/regression_cases.json
+++ b/tests/regression_cases.json
@@ -467,6 +467,24 @@
       ]
     },
     {
+      "id": "h2_dft_tddft_pbe_sto3g",
+      "input": "tests/inputs/regression/dft/h2_dft_tddft_pbe.hfinp",
+      "executable": "planck-dft",
+      "tags": ["smoke", "extended"],
+      "expected_exit_code": 0,
+      "contains": [
+        "Reference :                   RKS",
+        "TDDFT / Linear Response :     TDA-style singlet solver",
+        "Root  1 dominant configurations:",
+        "DFT Energy :"
+      ],
+      "checks": [
+        {"type": "metric_eq", "metric": "point_group", "expected": "Dinfh"},
+        {"type": "metric_close", "metric": "dft_total_energy", "expected": -1.1497054828, "atol": 1e-9},
+        {"type": "metric_close", "metric": "lr_root1_energy_ev", "expected": 29.991901, "atol": 1e-6}
+      ]
+    },
+    {
       "id": "h_dft_uks_b3lyp_sto3g",
       "input": "tests/inputs/regression/dft/h_dft_uks_b3lyp.hfinp",
       "executable": "planck-dft",
@@ -519,6 +537,7 @@
       "id": "water_casscf_ccpvdz_a1",
       "input": "tests/benchmarks/casscf/pyscf_reference/water_cas44_ccpvdz.hfinp",
       "tags": ["extended"],
+      "timeout_s": 300,
       "expected_exit_code": 0,
       "contains": [
         "Point Group :                 C2v",

--- a/tests/run_regressions.py
+++ b/tests/run_regressions.py
@@ -31,6 +31,7 @@ METRIC_PATTERNS: dict[str, re.Pattern[str]] = {
     "casscf_corr_energy": re.compile(r"^\s*CASSCF Correlation Energy\s+([-+0-9Ee\.]+)", re.MULTILINE),
     "casscf_total_energy": re.compile(r"^\s*CASSCF Total Energy\s+([-+0-9Ee\.]+)", re.MULTILINE),
     "dft_total_energy": re.compile(r"^\s*(?:\[INF\]\s+)?DFT Energy\s*:\s*([-+0-9Ee\.]+)\s+Eh", re.MULTILINE),
+    "lr_root1_energy_ev": re.compile(r"^\s*1\s+[-+0-9Ee\.]+\s+([-+0-9Ee\.]+)\s+[-+0-9Ee\.]+\s+[-+0-9Ee\.]+\s+[-+0-9Ee\.]+\s+[-+0-9Ee\.]+\s+[-+0-9Ee\.]+", re.MULTILINE),
     "casscf_sa_gnorm": re.compile(r"sa_g=([-+0-9Ee\.]+)"),
     "casscf_root_screen_gnorm": re.compile(r"root_screen_g=([-+0-9Ee\.]+)"),
     "casscf_max_root_gnorm": re.compile(r"max_root_g=([-+0-9Ee\.]+)"),
@@ -69,6 +70,14 @@ class CaseResult:
 def load_manifest(path: Path) -> dict[str, Any]:
     with path.open("r", encoding="utf-8") as handle:
         return json.load(handle)
+
+
+def load_pyscf_references(path: Path | None) -> dict[str, Any]:
+    if path is None or not path.exists():
+        return {}
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    return payload.get("cases", {})
 
 
 def extract_metrics(output: str) -> dict[str, Any]:
@@ -122,20 +131,52 @@ def resolve_executable(case: dict[str, Any], repo_root: Path, build_dir: str, de
     return repo_root / executable_path
 
 
-def run_case(case: dict[str, Any], repo_root: Path, build_dir: str, default_executable: Path) -> CaseResult:
+def resolve_metric_expectation(
+    case_id: str,
+    metric: str,
+    check: dict[str, Any],
+    pyscf_references: dict[str, Any],
+) -> tuple[float, float]:
+    override = pyscf_references.get(case_id, {}).get(metric)
+    if override is None:
+        return float(check["expected"]), float(check.get("atol", 1e-9))
+    return float(override["expected"]), float(override.get("atol", check.get("atol", 1e-9)))
+
+
+def run_case(
+    case: dict[str, Any],
+    repo_root: Path,
+    build_dir: str,
+    default_executable: Path,
+    pyscf_references: dict[str, Any],
+) -> CaseResult:
     case_id = case["id"]
     input_path = repo_root / case["input"]
     timeout_s = int(case.get("timeout_s", 120))
     executable = resolve_executable(case, repo_root, build_dir, default_executable)
 
     start = time.perf_counter()
-    proc = subprocess.run(
-        [str(executable), str(input_path)],
-        cwd=repo_root,
-        text=True,
-        capture_output=True,
-        timeout=timeout_s,
-    )
+    try:
+        proc = subprocess.run(
+            [str(executable), str(input_path)],
+            cwd=repo_root,
+            text=True,
+            capture_output=True,
+            timeout=timeout_s,
+        )
+    except subprocess.TimeoutExpired as exc:
+        duration_s = time.perf_counter() - start
+        detail_lines = [f"timed out after {timeout_s}s"]
+        partial_output = ((exc.stdout or "") + (exc.stderr or "")).strip()
+        if partial_output:
+            detail_lines.append("---- captured output ----")
+            detail_lines.extend(partial_output.splitlines()[-40:])
+        return CaseResult(
+            case_id=case_id,
+            passed=False,
+            duration_s=duration_s,
+            details=detail_lines,
+        )
     duration_s = time.perf_counter() - start
 
     output = proc.stdout + proc.stderr
@@ -171,8 +212,7 @@ def run_case(case: dict[str, Any], repo_root: Path, build_dir: str, default_exec
 
         elif ctype == "metric_close":
             metric = check["metric"]
-            expected = float(check["expected"])
-            atol = float(check.get("atol", 1e-9))
+            expected, atol = resolve_metric_expectation(case_id, metric, check, pyscf_references)
             actual = metrics.get(metric)
             if actual is None or not approx_equal(float(actual), expected, atol):
                 passed = False
@@ -244,6 +284,7 @@ def should_run(case: dict[str, Any], suite: str, selected_cases: set[str]) -> bo
 def main() -> int:
     parser = argparse.ArgumentParser(description="Run Planck regression tests")
     parser.add_argument("--manifest", default="tests/regression_cases.json")
+    parser.add_argument("--pyscf-refs", default="tests/pyscf/regression_references.json")
     parser.add_argument("--build-dir", default="build")
     parser.add_argument("--executable", default=None)
     parser.add_argument("--suite", default="core", choices=["smoke", "core", "extended", "all"])
@@ -254,6 +295,7 @@ def main() -> int:
     repo_root = Path(__file__).resolve().parents[1]
     manifest_path = repo_root / args.manifest
     manifest = load_manifest(manifest_path)
+    pyscf_references = load_pyscf_references(repo_root / args.pyscf_refs if args.pyscf_refs else None)
     cases = manifest["cases"]
 
     if args.list:
@@ -278,7 +320,7 @@ def main() -> int:
     total_start = time.perf_counter()
 
     for case in chosen:
-        result = run_case(case, repo_root, args.build_dir, executable)
+        result = run_case(case, repo_root, args.build_dir, executable, pyscf_references)
         status = "PASS" if result.passed else "FAIL"
         print(f"[{status}] {result.case_id} ({result.duration_s:.2f}s)")
         for line in result.details:


### PR DESCRIPTION
Implement an initial closed-shell TDDFT / linear-response solver for planck-dft. The new path is selected via calculation tddft (aliases td-dft, linearresponse, lr) and is layered on top of a converged RKS reference. The TDA-style singlet response matrix combines orbital-energy gaps, Hartree coupling, and the global-hybrid exact-exchange contribution through the functional's exact-exchange coefficient; semilocal XC kernels and UKS response are not yet included. Excited-state roots are extracted with a Davidson lowest-eigenpair solver so the response cost no longer scales with the dense (occupied x virtual)^2 matrix.

Report excitation energies in Hartree and eV, occupied-virtual transition dipoles, oscillator strengths, and the dominant orbital configuration weights for each root through a dedicated linear-response printout. Add CalculationType::LinearResponse, the new lr_nstates / tddft_nstates / nstates DFT keywords, log-level mapping, and the corresponding entries in the input parser, README, and teaching guide. Cover the new path with the h2_dft_tddft_pbe_sto3g regression case (energy and root-1 excitation energy in eV).

Add Löwdin population analysis and Mayer bond orders alongside the existing Mulliken implementation. Both reuse the shared atomic-AO index helper, follow the same std::expected<...> contract, and are printed together with Mulliken whenever population reporting is enabled in src/driver.cpp. Document the new APIs in the teaching guide and exercise them in tests/population_analysis.cpp.

Extend the SAD initial guess to UHF and ROHF. The new compute_sad_guess_open_shell builds spherically averaged spin-resolved atomic densities, projects each spin channel onto the molecular AO metric with trace n_alpha / n_beta, and is wired into both UHF and ROHF SCF paths in src/scf/scf.cpp; the previous "SAD only for RHF" rejection is removed.

Refactor the PySCF equivalence harness around tests/pyscf/cases.json so each case declares its script, kind, and the set of allowed STATUS strings emitted by the case script. tests/pyscf/run_all.py now discovers cases from the manifest, dispatches each script as a subprocess, and prints a structured table; tests/pyscf/b_uccsdt_sto3g.py is updated to also recognize the newer [INF] UCCSD(T) log lines. Add generate_regression_references.py and the
regression_reference_cases.json / regression_references.json pair so PySCF reference energies and tolerances can be regenerated and consumed by tests/run_regressions.py through the new --pyscf-refs override mechanism. CMakeLists.txt grows a PLANCK_PYSCF_PYTHON cache variable, an import probe for pyscf, and the planck-pyscf-equivalence CTest target / custom target when the chosen interpreter has PySCF available.

Improve the regression runner's robustness: subprocess timeouts now produce a structured failure with the last 40 lines of captured output instead of raising, the lr_root1_energy_ev metric is parsed for the new TDDFT case, and water_casscf_ccpvdz_a1 gets a 300 s timeout that matches its actual wall time.

Add explanatory "why" comments across the rest of the codebase to keep the teaching narrative current with the implementation: DFT KS-SCF scaffold and geometry-derivative driver, libxc point-major layout in xc_grid.cpp, CASSCF candidate-step selector and root-tracking helpers, SA orbital response setup in response.cpp, RCCSDT backend dispatch and arbitrary-order RCC tensor packing/Jacobi+DIIS update, ccgen BCH chunking and prefix-cache reuse, MP2/UMP2 tensor layout descriptions, and the open-shell SAD projection helper.

Update the teaching guide and regenerated docs/index.html to cover TDDFT-TDA (with the A_{ia,jb} matrix and oscillator-strength formula), Löwdin populations, and Mayer bond orders, mark ROHF as having SAD support, and add the new entries to the implementation status tables.

Verified with: cmake --build build -j; python3 tests/run_regressions.py --build-dir build --case h2_dft_tddft_pbe_sto3g; ctest --test-dir build -R planck-population-analysis.