### PR TITLE
Extend TDDFT to full Casida with triplet and UKS spin-conserving response

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,6 +1,6 @@
 ### Quickstart
 
-This guide gets you from zero to a converged Hartree-Fock calculation in five minutes.
+This guide gets you from zero to a converged Hartree-Fock calculation in five minutes, then shows the shortest path into DFT and TDDFT.
 
 ### 1. Build
 
@@ -91,6 +91,26 @@ ZZ                     ...
 
 The total energy is printed in Hartree, eV, and kcal/mol. After convergence, Planck also prints dipole and quadrupole components automatically from the final AO density matrix. Dipoles are reported in atomic units and Debye; quadrupoles are reported as a traceless Cartesian tensor in atomic units.
 
+### 2b. First DFT calculation
+
+Use `planck-dft` to run Kohn-Sham DFT with libxc functionals:
+
+```bash
+./build/planck-dft water.hfinp
+```
+
+Add a `%begin_dft` block to switch on DFT. For example, PBE/STO-3G:
+
+```text
+%begin_dft
+    grid        coarse
+    exchange    pbe
+    correlation pbe
+%end_dft
+```
+
+`scf_type rhf` gives an RKS reference and `scf_type uhf` gives a UKS reference.
+
 ### 3. Open-shell calculation (UHF)
 
 For open-shell systems set `scf_type uhf` and the correct multiplicity. Triplet water (M=3):
@@ -115,6 +135,52 @@ UHF output includes spin contamination diagnostics:
 <S^2> :   2.004321  (exact: 2.000000)
 <S>   :   1.415390
 ```
+
+The same `scf_type uhf` setting also selects UKS when you run `planck-dft`.
+
+### 3b. TDDFT / linear response
+
+Planck’s TDDFT driver lives in `planck-dft` and is requested with `calculation tddft` (aliases: `linearresponse`, `lr`, `td-dft`).
+
+Minimal closed-shell singlet example:
+
+```text
+%begin_control
+    basis       sto-3g
+    calculation tddft
+    verbosity   normal
+    basis_type  cartesian
+%end_control
+
+%begin_scf
+    scf_type    rhf
+    engine      os
+%end_scf
+
+%begin_dft
+    grid        coarse
+    exchange    pbe
+    correlation pbe
+    lr_nstates  3
+%end_dft
+```
+
+Useful TDDFT controls:
+
+```text
+lr_nstates   5                # number of roots
+lr_method    casida           # default; use tda for A-only response
+lr_spin      singlet          # RKS: singlet or triplet
+lr_spin      spin_conserving  # UKS/open-shell response
+```
+
+Current behavior:
+
+- `lr_method casida` is the default and solves the full \(A/B\) problem.
+- `lr_method tda` keeps the older Hermitian \(A\)-only approximation.
+- RKS supports `singlet` and `triplet` response.
+- UKS supports spin-conserving response blocks.
+- Semilocal XC kernels are included for the supported LDA and GGA functionals.
 
 
 ### 4. Checkpoint and restart

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A quantum chemistry program implementing restricted, unrestricted, and restricte
 
 - **RHF / ROHF / UHF** — closed-shell, restricted open-shell, and unrestricted Hartree-Fock; ROHF uses a Roothaan-type effective Fock construction with aufbau orbital reordering and DIIS convergence
 - **RKS / UKS (Kohn-Sham DFT)** — closed-shell and open-shell Kohn-Sham SCF via the `planck-dft` executable; LDA, GGA, and global hybrid exchange-correlation functionals through libxc; four grid quality presets (Coarse/Normal/Fine/UltraFine); arbitrary libxc functionals via integer ID
-- **Initial TDDFT / linear response** — closed-shell RKS excited-state roots via a TDA-style singlet response build on top of converged KS orbitals, with transition dipoles and oscillator strengths. The current implementation includes Hartree and global-hybrid exact-exchange coupling, but does not yet include semilocal XC kernels or UKS response.
+- **TDDFT / linear response** — full Casida and optional TDA excited-state roots on top of converged KS orbitals, with RKS singlet/triplet support, UKS spin-conserving response, semilocal XC kernels, transition dipoles, and oscillator strengths
 - **Two integral engines** — Obara-Saika for low angular momentum; Rys quadrature for high angular momentum; automatic engine selection per shell quartet (`engine auto`)
 - **Electric multipole moments** — dipole and quadrupole moment analysis after SCF convergence for both `hartree-fock` and `planck-dft`
 - **Mulliken population analysis** — atomic gross populations, net charges, and (for UHF/ROHF) spin populations; printed when `print_populations true` or verbosity is `verbose`/`debug`
@@ -217,7 +217,9 @@ Kohn-Sham DFT settings. Only read by `planck-dft`; ignored by `hartree-fock`. Th
 | `correlation` | enum | `vwn`/`vwn5`, `lyp`, `p86`, `pw91`, `pbe` | `pbe` | Correlation functional |
 | `exchange_id` | int | any libxc integer ID | — | Use an arbitrary libxc exchange functional by its integer identifier. Overrides `exchange`. |
 | `correlation_id` | int | any libxc integer ID | — | Use an arbitrary libxc correlation functional by its integer identifier. Overrides `correlation`. |
-| `lr_nstates` / `tddft_nstates` / `nstates` | int | ≥ 1 | `5` | Number of singlet excited states to report for `calculation tddft` / `linearresponse`. |
+| `lr_nstates` / `tddft_nstates` / `nstates` | int | ≥ 1 | `5` | Number of excited states to report for `calculation tddft` / `linearresponse`. |
+| `lr_method` / `tddft_method` | enum | `casida`, `full`, `tda` | `casida` | Linear-response solver form. `casida`/`full` solves the full \(A/B\) problem; `tda` diagonalizes the Hermitian \(A\) block only. |
+| `lr_spin` / `tddft_spin` | enum | `auto`, `singlet`, `triplet`, `spin_conserving` | `auto` | Spin channel for TDDFT response. `auto` resolves to `singlet` for RKS and `spin_conserving` for UKS. `triplet` is currently available for closed-shell RKS only. |
 | `use_sao_blocking` | bool | `.true.`, `.false.` | `.true.` | Enable symmetry-adapted AO blocking for the Coulomb matrix assembly. |
 | `print_grid_summary` | bool | `.true.`, `.false.` | `.true.` | Print a per-atom grid point count summary before the KS iterations. |
 | `save_checkpoint` | bool | `.true.`, `.false.` | `.false.` | Write a `.dftchk` checkpoint file after successful convergence. |

--- a/docs/PLANCK_TEACHING_GUIDE.md
+++ b/docs/PLANCK_TEACHING_GUIDE.md
@@ -2805,55 +2805,196 @@ The `KSPotentialMatrices` struct holds the Coulomb, XC-alpha, and XC-beta matric
 | KS-DFT main loop | `src/dft/driver.cpp` | `DFT::Driver::run` |
 | DFT entry point | `src/dft/main.cpp` | `main` |
 
-### Initial TD-DFT / Linear Response
+### TD-DFT / Linear Response
 
 **What is implemented**
 
-Planck currently provides an initial excited-state solver for `planck-dft` via
-`calculation tddft` (aliases: `td-dft`, `linearresponse`, `lr`).  The present
-implementation is intentionally narrow and teaching-oriented:
+Planck provides a TDDFT excited-state solver for `planck-dft` via
+`calculation tddft` (aliases: `td-dft`, `linearresponse`, `lr`) on top of the
+converged Kohn-Sham reference. The current implementation supports:
 
-- closed-shell **RKS only**
-- singlet excitations only
-- **TDA-style** response build (the Hermitian \(A\) matrix is diagonalized; no
-  full Casida \(A/B\) non-Hermitian solve yet)
-- Hartree coupling is included
-- global-hybrid exact exchange is included through the functional's exact
-  exchange coefficient
-- semilocal XC response kernels \(f_{xc}\) are **not** yet included
-- UKS/open-shell response is not yet implemented
+- closed-shell **RKS** singlet and triplet response
+- open-shell **UKS** spin-conserving response
+- **full Casida** response as the default solver
+- optional **TDA** response via `lr_method tda`
+- Hartree coupling
+- global-hybrid exact exchange through the functional exact-exchange fraction
+- semilocal XC response kernels \(f_{xc}\) for the supported LDA and GGA libxc
+  functionals
 
-So, despite the user-facing `tddft` keyword, the current method is best thought
-of as a first linear-response / TDA excited-state module layered on top of the
-converged Kohn-Sham orbitals.
+The implementation is still intentionally compact and dense-matrix based, but
+it is no longer limited to the original RKS singlet TDA scaffold.
 
 **Theory**
 
-For a closed-shell reference with occupied orbitals \(i,j\) and virtual
-orbitals \(a,b\), Planck forms the orbital-rotation excitation basis
-\(| i \rightarrow a \rangle\) and builds the TDA matrix
+TD-DFT in Planck is formulated in the usual Kohn-Sham orbital-rotation basis.
+Starting from a converged KS determinant, we consider first-order amplitudes
+that mix occupied orbitals \(i,j,\dots\) with virtual orbitals
+\(a,b,\dots\).  In that basis, the linear-response problem is written in terms
+of forward and backward amplitudes \(X\) and \(Y\):
 
 \[
-A_{ia,jb} = \delta_{ij}\delta_{ab}(\varepsilon_a - \varepsilon_i)
-          + 2(ia|jb)
-          - c_x (ij|ab)
+\begin{pmatrix}
+A & B \\
+B & A
+\end{pmatrix}
+\begin{pmatrix}
+X \\
+Y
+\end{pmatrix}
+=
+\omega
+\begin{pmatrix}
+1 & 0 \\
+0 & -1
+\end{pmatrix}
+\begin{pmatrix}
+X \\
+Y
+\end{pmatrix}
 \]
 
-where \(c_x\) is the global-hybrid exact-exchange fraction.  In this initial
-implementation the semilocal XC kernel contribution is omitted, so the response
-matrix contains only the orbital-energy gap term, the Coulomb coupling, and the
-hybrid exchange correction.
+The diagonal orbital-energy-gap part is simple:
 
-Diagonalizing \(A\) gives the excitation energies \(\omega_k\) and the
-excitation amplitudes \(X^{(k)}_{ia}\).  Transition dipoles are then evaluated
-from the occupied-virtual dipole blocks:
+\[
+A_{ia,jb}^{(0)} = \delta_{ij}\delta_{ab}(\varepsilon_a - \varepsilon_i),
+\qquad
+B_{ia,jb}^{(0)} = 0
+\]
+
+Everything interesting is in the interaction kernel.  In Planck, each matrix
+element is built from three physical pieces:
+
+1. Coulomb (Hartree) response
+2. exact-exchange response for global hybrids
+3. semilocal XC-kernel response \(f_{xc}\)
+
+So the working matrices are
+
+\[
+A = A^{(0)} + K^{J} + K^{x,\mathrm{hyb}} + K^{xc},
+\qquad
+B = B^{J} + B^{x,\mathrm{hyb}} + B^{xc}
+\]
+
+For a closed-shell RKS reference, Planck then spin-adapts these spatial-orbital
+blocks into singlet and triplet channels.
+
+For **singlets**, the Coulomb term survives and carries the familiar factor of
+two:
+
+\[
+A^{S}_{ia,jb}
+= \delta_{ij}\delta_{ab}(\varepsilon_a - \varepsilon_i)
++ 2(ia|jb)
+- c_x(ij|ab)
++ K^{S,xc}_{ia,jb}
+\]
+
+\[
+B^{S}_{ia,jb}
+= 2(ia|bj)
+- c_x(ib|aj)
++ L^{S,xc}_{ia,jb}
+\]
+
+where \(c_x\) is the global-hybrid exact-exchange fraction.  Here
+\(K^{S,xc}\) and \(L^{S,xc}\) are the singlet-projected semilocal XC-kernel
+contributions.
+
+For **triplets**, the Coulomb contribution drops out after spin adaptation, so
+only exchange and spin-dependent XC-kernel terms remain:
+
+\[
+A^{T}_{ia,jb}
+= \delta_{ij}\delta_{ab}(\varepsilon_a - \varepsilon_i)
+- c_x(ij|ab)
++ K^{T,xc}_{ia,jb}
+\]
+
+\[
+B^{T}_{ia,jb}
+= - c_x(ib|aj)
++ L^{T,xc}_{ia,jb}
+\]
+
+This is why triplet roots can sit much lower than singlets built from the same
+orbital pair: the repulsive Hartree response is absent in the triplet channel.
+
+For **UKS**, Planck does not attempt a singlet/triplet spin adaptation.
+Instead, it keeps separate alpha and beta excitation spaces and builds the full
+spin-conserving block problem
+
+\[
+\begin{pmatrix}
+A^{\alpha\alpha} & A^{\alpha\beta} \\
+A^{\beta\alpha}  & A^{\beta\beta}
+\end{pmatrix},
+\qquad
+\begin{pmatrix}
+B^{\alpha\alpha} & B^{\alpha\beta} \\
+B^{\beta\alpha}  & B^{\beta\beta}
+\end{pmatrix}
+\]
+
+The same-spin blocks contain Coulomb, hybrid exchange, and XC-kernel terms.
+The opposite-spin blocks contain Coulomb and XC-kernel coupling, but no exact
+exchange term because there is no alpha-beta Fock exchange in a standard
+spin-separated KS reference.
+
+The semilocal kernel enters through the functional derivative
+
+\[
+f_{xc}^{\sigma\tau}(\mathbf r,\mathbf r')
+= \frac{\delta v_{xc}^{\sigma}(\mathbf r)}
+       {\delta \rho_{\tau}(\mathbf r')}
+\]
+
+For LDA this depends only on the local spin densities. For GGA it also depends
+on the density gradients, so the response contains both \(\rho\)- and
+\(\nabla\rho\)-dependent pieces.  Rather than coding separate analytic
+expressions for every supported semilocal functional, Planck evaluates the XC
+AO matrix on the numerical grid and differentiates that matrix with respect to
+trial transition densities.  Conceptually, this is equivalent to applying the
+semilocal \(f_{xc}\) kernel to a first-order density response and projecting
+the result back into the occupied-virtual MO basis.
+
+With `lr_method casida`, Planck solves the full response problem through the
+standard symmetric Casida transformation.  Defining
+\(S = A - B\) and \(T = A + B\), the code forms the Hermitian problem
+
+\[
+S^{1/2} T S^{1/2} F = \omega^2 F
+\]
+
+then reconstructs \(X\) and \(Y\) from the transformed eigenvectors.  This is
+why the full-Casida path still reduces to a real symmetric diagonalization once
+\(A-B\) is positive definite.
+
+With `lr_method tda`, the backward amplitudes are discarded,
+\(Y = 0\), and only the Hermitian \(A\) block is diagonalized:
+
+\[
+A X = \omega X
+\]
+
+The TDA is cheaper and often qualitatively reasonable, but it neglects
+de-excitation coupling and therefore does not reproduce the full Casida roots
+exactly.
+
+Once a root is found, Planck builds the transition dipole from the
+occupied-virtual dipole blocks:
 
 \[
 \boldsymbol{\mu}^{(k)}_{\mathrm{tr}}
-= \sqrt{2}\sum_{ia} X^{(k)}_{ia}\,\langle i|\hat{\mathbf r}|a\rangle
+= \sum_{ia} (X^{(k)}_{ia} + Y^{(k)}_{ia})\,\langle i|\hat{\mathbf r}|a\rangle
 \]
 
-and the oscillator strength is reported as
+For spin-adapted closed-shell singlets, Planck applies the conventional
+\(\sqrt{2}\) factor when converting from the spatial-orbital amplitudes to the
+transition dipole. Closed-shell triplet roots therefore carry zero electric
+dipole oscillator strength in the current report. The oscillator strength is
+reported as
 
 \[
 f_k = \frac{2}{3}\,\omega_k\,\left|\boldsymbol{\mu}^{(k)}_{\mathrm{tr}}\right|^2
@@ -2864,19 +3005,24 @@ units.
 
 **Code path**
 
-`src/dft/driver.cpp` — `run_linear_response_tda()`
+`src/dft/driver.cpp` — `run_linear_response()`
 
 The solver reuses the converged KS reference already built by the SCF scaffold:
 
-1. confirm the reference is converged, closed-shell, and restricted
-2. split the MO coefficient matrix into occupied and virtual blocks
-3. transform AO ERIs into the \(ovov\) and \(oovv\) blocks needed by the
-   response kernel
-4. assemble the dense TDA matrix \(A\)
-5. diagonalize \(A\) with `Eigen::SelfAdjointEigenSolver`
-6. build transition dipoles from AO dipole integrals transformed to the
+1. confirm the reference is converged and resolve the spin channel requested by
+   `lr_spin`
+2. split the converged MO coefficients into occupied and virtual blocks for the
+   active spin space or spaces
+3. transform AO ERIs into the MO blocks needed for Coulomb and hybrid-exchange
+   response terms
+4. evaluate semilocal XC response contributions on the numerical grid by
+   differentiating the assembled XC AO matrix with respect to trial transition
+   densities
+5. assemble dense \(A\) and \(B\) blocks
+6. solve either the TDA eigenproblem or the full Casida transformed eigenproblem
+7. build transition dipoles from AO dipole integrals transformed to the
    occupied-virtual MO basis
-7. sort and print the dominant occupied \(\rightarrow\) virtual configurations
+8. sort and print the dominant occupied \(\rightarrow\) virtual configurations
    for each root
 
 The report printed by `print_linear_response_report()` includes the root index,
@@ -3467,7 +3613,7 @@ driver.cpp
 | GGA XC functionals (B88, PBE, PW91 exchange; LYP, P86, PBE, PW91 correlation) | Complete |
 | Arbitrary libxc functionals via integer ID | Complete |
 | Molecular grid (Treutler-Ahlrichs + Lebedev + Becke) | Complete |
-| Initial TD-DFT / linear response (closed-shell RKS, TDA-style singlets) | Complete |
+| TD-DFT / linear response (RKS singlet/triplet, UKS spin-conserving, Casida/TDA, semilocal XC kernels) | Complete |
 | DFT geometry optimization / gradients | Not implemented |
 | Global hybrid XC functionals (B3LYP, PBE0, compatible libxc IDs) | Complete |
 | Range-separated and double-hybrid XC functionals | Not supported |

--- a/docs/index.html
+++ b/docs/index.html
@@ -250,7 +250,7 @@
 <li class="toc-level-3"><a href="#xc-matrix-assembly">XC Matrix Assembly</a></li>
 <li class="toc-level-3"><a href="#ks-dft-scf-loop">KS-DFT SCF Loop</a></li>
 <li class="toc-level-3"><a href="#dft-code-map">DFT Code Map</a></li>
-<li class="toc-level-3"><a href="#initial-td-dft-linear-response">Initial TD-DFT / Linear Response</a></li>
+<li class="toc-level-3"><a href="#td-dft-linear-response">TD-DFT / Linear Response</a></li>
 <li class="toc-level-2"><a href="#19-molecular-properties">19. Molecular Properties</a></li>
 <li class="toc-level-3"><a href="#mulliken-population-analysis">Mulliken Population Analysis</a></li>
 <li class="toc-level-3"><a href="#l-wdin-population-analysis">Löwdin Population Analysis</a></li>
@@ -1797,46 +1797,138 @@ V^{xc}_{\mu\nu} = \sum_g w_g\, v_{\rho,g}\, \phi_\mu(\mathbf r_g)\, \phi_\nu(\ma
 <tr><td>KS-DFT main loop</td><td><code>src/dft/driver.cpp</code></td><td><code>DFT::Driver::run</code></td></tr>
 <tr><td>DFT entry point</td><td><code>src/dft/main.cpp</code></td><td><code>main</code></td></tr>
 </tbody></table></div>
-<h3 id="initial-td-dft-linear-response">Initial TD-DFT / Linear Response</h3>
+<h3 id="td-dft-linear-response">TD-DFT / Linear Response</h3>
 <p><strong>What is implemented</strong></p>
-<p>Planck currently provides an initial excited-state solver for <code>planck-dft</code> via <code>calculation tddft</code> (aliases: <code>td-dft</code>, <code>linearresponse</code>, <code>lr</code>).  The present implementation is intentionally narrow and teaching-oriented:</p>
+<p>Planck provides a TDDFT excited-state solver for <code>planck-dft</code> via <code>calculation tddft</code> (aliases: <code>td-dft</code>, <code>linearresponse</code>, <code>lr</code>) on top of the converged Kohn-Sham reference. The current implementation supports:</p>
 <ul>
-<li>closed-shell <strong>RKS only</strong></li>
-<li>singlet excitations only</li>
-<li><strong>TDA-style</strong> response build (the Hermitian <span class="math-inline">\(A\)</span> matrix is diagonalized; no full Casida <span class="math-inline">\(A/B\)</span> non-Hermitian solve yet)</li>
-<li>Hartree coupling is included</li>
-<li>global-hybrid exact exchange is included through the functional&#x27;s exact exchange coefficient</li>
-<li>semilocal XC response kernels <span class="math-inline">\(f_{xc}\)</span> are <strong>not</strong> yet included</li>
-<li>UKS/open-shell response is not yet implemented</li>
+<li>closed-shell <strong>RKS</strong> singlet and triplet response</li>
+<li>open-shell <strong>UKS</strong> spin-conserving response</li>
+<li><strong>full Casida</strong> response as the default solver</li>
+<li>optional <strong>TDA</strong> response via <code>lr_method tda</code></li>
+<li>Hartree coupling</li>
+<li>global-hybrid exact exchange through the functional exact-exchange fraction</li>
+<li>semilocal XC response kernels <span class="math-inline">\(f_{xc}\)</span> for the supported LDA and GGA libxc functionals</li>
 </ul>
-<p>So, despite the user-facing <code>tddft</code> keyword, the current method is best thought of as a first linear-response / TDA excited-state module layered on top of the converged Kohn-Sham orbitals.</p>
+<p>The implementation is still intentionally compact and dense-matrix based, but it is no longer limited to the original RKS singlet TDA scaffold.</p>
 <p><strong>Theory</strong></p>
-<p>For a closed-shell reference with occupied orbitals <span class="math-inline">\(i,j\)</span> and virtual orbitals <span class="math-inline">\(a,b\)</span>, Planck forms the orbital-rotation excitation basis <span class="math-inline">\(| i \rightarrow a \rangle\)</span> and builds the TDA matrix</p>
+<p>TD-DFT in Planck is formulated in the usual Kohn-Sham orbital-rotation basis. Starting from a converged KS determinant, we consider first-order amplitudes that mix occupied orbitals <span class="math-inline">\(i,j,\dots\)</span> with virtual orbitals <span class="math-inline">\(a,b,\dots\)</span>.  In that basis, the linear-response problem is written in terms of forward and backward amplitudes <span class="math-inline">\(X\)</span> and <span class="math-inline">\(Y\)</span>:</p>
 <p><span class="math-display">\[
-A_{ia,jb} = \delta_{ij}\delta_{ab}(\varepsilon_a - \varepsilon_i)
-          + 2(ia|jb)
-          - c_x (ij|ab)
+\begin{pmatrix}
+A & B \\
+B & A
+\end{pmatrix}
+\begin{pmatrix}
+X \\
+Y
+\end{pmatrix}
+=
+\omega
+\begin{pmatrix}
+1 & 0 \\
+0 & -1
+\end{pmatrix}
+\begin{pmatrix}
+X \\
+Y
+\end{pmatrix}
 \]</span></p>
-<p>where <span class="math-inline">\(c_x\)</span> is the global-hybrid exact-exchange fraction.  In this initial implementation the semilocal XC kernel contribution is omitted, so the response matrix contains only the orbital-energy gap term, the Coulomb coupling, and the hybrid exchange correction.</p>
-<p>Diagonalizing <span class="math-inline">\(A\)</span> gives the excitation energies <span class="math-inline">\(\omega_k\)</span> and the excitation amplitudes <span class="math-inline">\(X^{(k)}_{ia}\)</span>.  Transition dipoles are then evaluated from the occupied-virtual dipole blocks:</p>
+<p>The diagonal orbital-energy-gap part is simple:</p>
+<p><span class="math-display">\[
+A_{ia,jb}^{(0)} = \delta_{ij}\delta_{ab}(\varepsilon_a - \varepsilon_i),
+\qquad
+B_{ia,jb}^{(0)} = 0
+\]</span></p>
+<p>Everything interesting is in the interaction kernel.  In Planck, each matrix element is built from three physical pieces:</p>
+<ol>
+<li>Coulomb (Hartree) response</li>
+<li>exact-exchange response for global hybrids</li>
+<li>semilocal XC-kernel response <span class="math-inline">\(f_{xc}\)</span></li>
+</ol>
+<p>So the working matrices are</p>
+<p><span class="math-display">\[
+A = A^{(0)} + K^{J} + K^{x,\mathrm{hyb}} + K^{xc},
+\qquad
+B = B^{J} + B^{x,\mathrm{hyb}} + B^{xc}
+\]</span></p>
+<p>For a closed-shell RKS reference, Planck then spin-adapts these spatial-orbital blocks into singlet and triplet channels.</p>
+<p>For <strong>singlets</strong>, the Coulomb term survives and carries the familiar factor of two:</p>
+<p><span class="math-display">\[
+A^{S}_{ia,jb}
+= \delta_{ij}\delta_{ab}(\varepsilon_a - \varepsilon_i)
++ 2(ia|jb)
+- c_x(ij|ab)
++ K^{S,xc}_{ia,jb}
+\]</span></p>
+<p><span class="math-display">\[
+B^{S}_{ia,jb}
+= 2(ia|bj)
+- c_x(ib|aj)
++ L^{S,xc}_{ia,jb}
+\]</span></p>
+<p>where <span class="math-inline">\(c_x\)</span> is the global-hybrid exact-exchange fraction.  Here <span class="math-inline">\(K^{S,xc}\)</span> and <span class="math-inline">\(L^{S,xc}\)</span> are the singlet-projected semilocal XC-kernel contributions.</p>
+<p>For <strong>triplets</strong>, the Coulomb contribution drops out after spin adaptation, so only exchange and spin-dependent XC-kernel terms remain:</p>
+<p><span class="math-display">\[
+A^{T}_{ia,jb}
+= \delta_{ij}\delta_{ab}(\varepsilon_a - \varepsilon_i)
+- c_x(ij|ab)
++ K^{T,xc}_{ia,jb}
+\]</span></p>
+<p><span class="math-display">\[
+B^{T}_{ia,jb}
+= - c_x(ib|aj)
++ L^{T,xc}_{ia,jb}
+\]</span></p>
+<p>This is why triplet roots can sit much lower than singlets built from the same orbital pair: the repulsive Hartree response is absent in the triplet channel.</p>
+<p>For <strong>UKS</strong>, Planck does not attempt a singlet/triplet spin adaptation. Instead, it keeps separate alpha and beta excitation spaces and builds the full spin-conserving block problem</p>
+<p><span class="math-display">\[
+\begin{pmatrix}
+A^{\alpha\alpha} & A^{\alpha\beta} \\
+A^{\beta\alpha}  & A^{\beta\beta}
+\end{pmatrix},
+\qquad
+\begin{pmatrix}
+B^{\alpha\alpha} & B^{\alpha\beta} \\
+B^{\beta\alpha}  & B^{\beta\beta}
+\end{pmatrix}
+\]</span></p>
+<p>The same-spin blocks contain Coulomb, hybrid exchange, and XC-kernel terms. The opposite-spin blocks contain Coulomb and XC-kernel coupling, but no exact exchange term because there is no alpha-beta Fock exchange in a standard spin-separated KS reference.</p>
+<p>The semilocal kernel enters through the functional derivative</p>
+<p><span class="math-display">\[
+f_{xc}^{\sigma\tau}(\mathbf r,\mathbf r')
+= \frac{\delta v_{xc}^{\sigma}(\mathbf r)}
+       {\delta \rho_{\tau}(\mathbf r')}
+\]</span></p>
+<p>For LDA this depends only on the local spin densities. For GGA it also depends on the density gradients, so the response contains both <span class="math-inline">\(\rho\)</span>- and <span class="math-inline">\(\nabla\rho\)</span>-dependent pieces.  Rather than coding separate analytic expressions for every supported semilocal functional, Planck evaluates the XC AO matrix on the numerical grid and differentiates that matrix with respect to trial transition densities.  Conceptually, this is equivalent to applying the semilocal <span class="math-inline">\(f_{xc}\)</span> kernel to a first-order density response and projecting the result back into the occupied-virtual MO basis.</p>
+<p>With <code>lr_method casida</code>, Planck solves the full response problem through the standard symmetric Casida transformation.  Defining <span class="math-inline">\(S = A - B\)</span> and <span class="math-inline">\(T = A + B\)</span>, the code forms the Hermitian problem</p>
+<p><span class="math-display">\[
+S^{1/2} T S^{1/2} F = \omega^2 F
+\]</span></p>
+<p>then reconstructs <span class="math-inline">\(X\)</span> and <span class="math-inline">\(Y\)</span> from the transformed eigenvectors.  This is why the full-Casida path still reduces to a real symmetric diagonalization once <span class="math-inline">\(A-B\)</span> is positive definite.</p>
+<p>With <code>lr_method tda</code>, the backward amplitudes are discarded, <span class="math-inline">\(Y = 0\)</span>, and only the Hermitian <span class="math-inline">\(A\)</span> block is diagonalized:</p>
+<p><span class="math-display">\[
+A X = \omega X
+\]</span></p>
+<p>The TDA is cheaper and often qualitatively reasonable, but it neglects de-excitation coupling and therefore does not reproduce the full Casida roots exactly.</p>
+<p>Once a root is found, Planck builds the transition dipole from the occupied-virtual dipole blocks:</p>
 <p><span class="math-display">\[
 \boldsymbol{\mu}^{(k)}_{\mathrm{tr}}
-= \sqrt{2}\sum_{ia} X^{(k)}_{ia}\,\langle i|\hat{\mathbf r}|a\rangle
+= \sum_{ia} (X^{(k)}_{ia} + Y^{(k)}_{ia})\,\langle i|\hat{\mathbf r}|a\rangle
 \]</span></p>
-<p>and the oscillator strength is reported as</p>
+<p>For spin-adapted closed-shell singlets, Planck applies the conventional <span class="math-inline">\(\sqrt{2}\)</span> factor when converting from the spatial-orbital amplitudes to the transition dipole. Closed-shell triplet roots therefore carry zero electric dipole oscillator strength in the current report. The oscillator strength is reported as</p>
 <p><span class="math-display">\[
 f_k = \frac{2}{3}\,\omega_k\,\left|\boldsymbol{\mu}^{(k)}_{\mathrm{tr}}\right|^2
 \]</span></p>
 <p>with <span class="math-inline">\(\omega_k\)</span> in Hartree and <span class="math-inline">\(\boldsymbol{\mu}_{\mathrm{tr}}\)</span> in atomic units.</p>
 <p><strong>Code path</strong></p>
-<p><code>src/dft/driver.cpp</code> — <code>run_linear_response_tda()</code></p>
+<p><code>src/dft/driver.cpp</code> — <code>run_linear_response()</code></p>
 <p>The solver reuses the converged KS reference already built by the SCF scaffold:</p>
 <ol>
-<li>confirm the reference is converged, closed-shell, and restricted</li>
-<li>split the MO coefficient matrix into occupied and virtual blocks</li>
-<li>transform AO ERIs into the <span class="math-inline">\(ovov\)</span> and <span class="math-inline">\(oovv\)</span> blocks needed by the response kernel</li>
-<li>assemble the dense TDA matrix <span class="math-inline">\(A\)</span></li>
-<li>diagonalize <span class="math-inline">\(A\)</span> with <code>Eigen::SelfAdjointEigenSolver</code></li>
+<li>confirm the reference is converged and resolve the spin channel requested by <code>lr_spin</code></li>
+<li>split the converged MO coefficients into occupied and virtual blocks for the active spin space or spaces</li>
+<li>transform AO ERIs into the MO blocks needed for Coulomb and hybrid-exchange response terms</li>
+<li>evaluate semilocal XC response contributions on the numerical grid by differentiating the assembled XC AO matrix with respect to trial transition densities</li>
+<li>assemble dense <span class="math-inline">\(A\)</span> and <span class="math-inline">\(B\)</span> blocks</li>
+<li>solve either the TDA eigenproblem or the full Casida transformed eigenproblem</li>
 <li>build transition dipoles from AO dipole integrals transformed to the occupied-virtual MO basis</li>
 <li>sort and print the dominant occupied <span class="math-inline">\(\rightarrow\)</span> virtual configurations for each root</li>
 </ol>
@@ -2279,7 +2371,7 @@ driver.cpp
 <tr><td>GGA XC functionals (B88, PBE, PW91 exchange; LYP, P86, PBE, PW91 correlation)</td><td>Complete</td></tr>
 <tr><td>Arbitrary libxc functionals via integer ID</td><td>Complete</td></tr>
 <tr><td>Molecular grid (Treutler-Ahlrichs + Lebedev + Becke)</td><td>Complete</td></tr>
-<tr><td>Initial TD-DFT / linear response (closed-shell RKS, TDA-style singlets)</td><td>Complete</td></tr>
+<tr><td>TD-DFT / linear response (RKS singlet/triplet, UKS spin-conserving, Casida/TDA, semilocal XC kernels)</td><td>Complete</td></tr>
 <tr><td>DFT geometry optimization / gradients</td><td>Not implemented</td></tr>
 <tr><td>Global hybrid XC functionals (B3LYP, PBE0, compatible libxc IDs)</td><td>Complete</td></tr>
 <tr><td>Range-separated and double-hybrid XC functionals</td><td>Not supported</td></tr>

--- a/src/base/types.h
+++ b/src/base/types.h
@@ -128,6 +128,20 @@ namespace HartreeFock
         PBE
     };
 
+    enum class LinearResponseMethod
+    {
+        TDA,
+        Casida
+    };
+
+    enum class LinearResponseSpin
+    {
+        Auto,
+        Singlet,
+        Triplet,
+        SpinConserving
+    };
+
     enum class OptCoords
     {
         Cartesian, // Optimize in Cartesian coordinates (L-BFGS, default)
@@ -383,6 +397,8 @@ namespace HartreeFock
         int _exchange_id = 0;    // 0 => resolve from _exchange through libxc
         int _correlation_id = 0; // 0 => resolve from _correlation through libxc
         int _lr_nstates = 5;
+        LinearResponseMethod _lr_method = LinearResponseMethod::Casida;
+        LinearResponseSpin _lr_spin = LinearResponseSpin::Auto;
         bool _use_sao_blocking = true;
         bool _print_grid_summary = true;
         bool _save_checkpoint = false;

--- a/src/dft/driver.cpp
+++ b/src/dft/driver.cpp
@@ -54,6 +54,7 @@ namespace DFT::Driver
             int occupied = 0;
             int virtual_orbital = 0;
             double weight = 0.0;
+            std::string spin_label;
             std::string occupied_symmetry;
             std::string virtual_symmetry;
         };
@@ -849,20 +850,330 @@ namespace DFT::Driver
             return occupancy * occupied * occupied.transpose();
         }
 
+        struct ResponseExcitationSpace
+        {
+            std::string spin_label;
+            int n_occ = 0;
+            int n_virt = 0;
+            int mo_offset = 0;
+            Eigen::MatrixXd C_occ;
+            Eigen::MatrixXd C_virt;
+            Eigen::VectorXd occ_energies;
+            Eigen::VectorXd virt_energies;
+            std::vector<std::string> mo_symmetry;
+
+            [[nodiscard]] int nov() const noexcept
+            {
+                return n_occ * n_virt;
+            }
+
+            [[nodiscard]] int flat_index(int i, int a) const noexcept
+            {
+                return i * n_virt + a;
+            }
+        };
+
+        struct ResponseEigenpair
+        {
+            double omega = 0.0;
+            Eigen::VectorXd x;
+            Eigen::VectorXd y;
+        };
+
+        std::string linear_response_method_label(HartreeFock::LinearResponseMethod method)
+        {
+            switch (method)
+            {
+            case HartreeFock::LinearResponseMethod::TDA:
+                return "TDA";
+            case HartreeFock::LinearResponseMethod::Casida:
+                return "full Casida";
+            }
+
+            return "unknown";
+        }
+
+        std::string linear_response_spin_label(HartreeFock::LinearResponseSpin spin)
+        {
+            switch (spin)
+            {
+            case HartreeFock::LinearResponseSpin::Auto:
+                return "auto";
+            case HartreeFock::LinearResponseSpin::Singlet:
+                return "singlet";
+            case HartreeFock::LinearResponseSpin::Triplet:
+                return "triplet";
+            case HartreeFock::LinearResponseSpin::SpinConserving:
+                return "spin-conserving";
+            }
+
+            return "unknown";
+        }
+
+        Eigen::MatrixXd transition_density_matrix(
+            const Eigen::Ref<const Eigen::VectorXd> &occupied,
+            const Eigen::Ref<const Eigen::VectorXd> &virtual_orbital)
+        {
+            const Eigen::MatrixXd unsymmetrized = occupied * virtual_orbital.transpose();
+            return (0.5 * (unsymmetrized + unsymmetrized.transpose())).eval();
+        }
+
+        std::expected<XCMatrixContribution, std::string> evaluate_xc_matrix_from_spin_densities(
+            const PreparedSystem &prepared,
+            const Eigen::Ref<const Eigen::MatrixXd> &alpha_density,
+            const Eigen::Ref<const Eigen::MatrixXd> &beta_density,
+            const DFT::XC::Functional &exchange_functional,
+            const DFT::XC::Functional &correlation_functional)
+        {
+            auto xc_grid = evaluate_xc_on_grid(
+                prepared.molecular_grid,
+                prepared.ao_grid,
+                alpha_density,
+                beta_density,
+                exchange_functional,
+                correlation_functional);
+            if (!xc_grid)
+                return std::unexpected(xc_grid.error());
+
+            auto xc_matrix = assemble_xc_matrix(
+                prepared.molecular_grid,
+                prepared.ao_grid,
+                *xc_grid);
+            if (!xc_matrix)
+                return std::unexpected(xc_matrix.error());
+
+            return *xc_matrix;
+        }
+
+        std::expected<std::vector<std::vector<Eigen::MatrixXd>>, std::string> build_unrestricted_xc_kernel_blocks(
+            const PreparedSystem &prepared,
+            const std::vector<ResponseExcitationSpace> &spaces,
+            const Eigen::Ref<const Eigen::MatrixXd> &ground_alpha_density,
+            const Eigen::Ref<const Eigen::MatrixXd> &ground_beta_density,
+            const DFT::XC::Functional &exchange_functional,
+            const DFT::XC::Functional &correlation_functional)
+        {
+            const int nspaces = static_cast<int>(spaces.size());
+            std::vector<std::vector<Eigen::MatrixXd>> blocks(
+                static_cast<std::size_t>(nspaces),
+                std::vector<Eigen::MatrixXd>(static_cast<std::size_t>(nspaces)));
+
+            for (int target = 0; target < nspaces; ++target)
+                for (int source = 0; source < nspaces; ++source)
+                    blocks[static_cast<std::size_t>(target)][static_cast<std::size_t>(source)] =
+                        Eigen::MatrixXd::Zero(spaces[static_cast<std::size_t>(target)].nov(),
+                                              spaces[static_cast<std::size_t>(source)].nov());
+
+            for (int source = 0; source < nspaces; ++source)
+            {
+                const ResponseExcitationSpace &source_space = spaces[static_cast<std::size_t>(source)];
+                for (int j = 0; j < source_space.n_occ; ++j)
+                    for (int b = 0; b < source_space.n_virt; ++b)
+                    {
+                        const Eigen::MatrixXd delta_density =
+                            transition_density_matrix(source_space.C_occ.col(j), source_space.C_virt.col(b));
+                        const double delta_scale = std::max(1.0, delta_density.cwiseAbs().maxCoeff());
+                        const double step = 1.0e-5 / delta_scale;
+
+                        Eigen::MatrixXd alpha_plus = ground_alpha_density;
+                        Eigen::MatrixXd alpha_minus = ground_alpha_density;
+                        Eigen::MatrixXd beta_plus = ground_beta_density;
+                        Eigen::MatrixXd beta_minus = ground_beta_density;
+
+                        if (source == 0)
+                        {
+                            alpha_plus += step * delta_density;
+                            alpha_minus -= step * delta_density;
+                        }
+                        else
+                        {
+                            beta_plus += step * delta_density;
+                            beta_minus -= step * delta_density;
+                        }
+
+                        auto plus = evaluate_xc_matrix_from_spin_densities(
+                            prepared,
+                            alpha_plus,
+                            beta_plus,
+                            exchange_functional,
+                            correlation_functional);
+                        if (!plus)
+                            return std::unexpected("TDDFT XC kernel (+) evaluation failed: " + plus.error());
+
+                        auto minus = evaluate_xc_matrix_from_spin_densities(
+                            prepared,
+                            alpha_minus,
+                            beta_minus,
+                            exchange_functional,
+                            correlation_functional);
+                        if (!minus)
+                            return std::unexpected("TDDFT XC kernel (-) evaluation failed: " + minus.error());
+
+                        const Eigen::MatrixXd delta_v_alpha =
+                            (plus->alpha - minus->alpha) / (2.0 * step);
+                        const Eigen::MatrixXd delta_v_beta =
+                            (plus->beta - minus->beta) / (2.0 * step);
+
+                        const int source_column = source_space.flat_index(j, b);
+                        for (int target = 0; target < nspaces; ++target)
+                        {
+                            const ResponseExcitationSpace &target_space = spaces[static_cast<std::size_t>(target)];
+                            const Eigen::MatrixXd &delta_v = (target == 0) ? delta_v_alpha : delta_v_beta;
+                            const Eigen::MatrixXd projected =
+                                target_space.C_occ.transpose() * delta_v * target_space.C_virt;
+
+                            for (int i = 0; i < target_space.n_occ; ++i)
+                                for (int a = 0; a < target_space.n_virt; ++a)
+                                    blocks[static_cast<std::size_t>(target)][static_cast<std::size_t>(source)](
+                                        target_space.flat_index(i, a),
+                                        source_column) = projected(i, a);
+                        }
+                    }
+            }
+
+            return blocks;
+        }
+
+        std::expected<std::pair<Eigen::MatrixXd, Eigen::MatrixXd>, std::string> build_closed_shell_xc_kernel_blocks(
+            const PreparedSystem &prepared,
+            const ResponseExcitationSpace &space,
+            const Eigen::Ref<const Eigen::MatrixXd> &restricted_density,
+            const DFT::XC::Functional &exchange_functional,
+            const DFT::XC::Functional &correlation_functional)
+        {
+            const Eigen::MatrixXd ground_alpha = 0.5 * restricted_density;
+            const Eigen::MatrixXd ground_beta = 0.5 * restricted_density;
+            const std::vector<ResponseExcitationSpace> duplicated_spaces = {space, space};
+
+            auto blocks = build_unrestricted_xc_kernel_blocks(
+                prepared,
+                duplicated_spaces,
+                ground_alpha,
+                ground_beta,
+                exchange_functional,
+                correlation_functional);
+            if (!blocks)
+                return std::unexpected(blocks.error());
+
+            return std::make_pair(
+                (*blocks)[0][0],
+                (*blocks)[0][1]);
+        }
+
+        std::expected<std::vector<ResponseEigenpair>, std::string> solve_response_problem(
+            const Eigen::Ref<const Eigen::MatrixXd> &A,
+            const Eigen::Ref<const Eigen::MatrixXd> &B,
+            HartreeFock::LinearResponseMethod method,
+            int nroots)
+        {
+            if (A.rows() != A.cols() || B.rows() != B.cols() || A.rows() != B.rows())
+                return std::unexpected("TDDFT response matrices must be square and dimension-matched");
+
+            const int dimension = static_cast<int>(A.rows());
+            const int roots_to_keep = std::min(std::max(nroots, 1), dimension);
+            std::vector<ResponseEigenpair> roots;
+            roots.reserve(static_cast<std::size_t>(roots_to_keep));
+
+            if (method == HartreeFock::LinearResponseMethod::TDA)
+            {
+                Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> solver(0.5 * (A + A.transpose()));
+                if (solver.info() != Eigen::Success)
+                    return std::unexpected("TDA diagonalization failed");
+
+                for (int root = 0; root < roots_to_keep; ++root)
+                {
+                    roots.push_back(
+                        ResponseEigenpair{
+                            .omega = solver.eigenvalues()(root),
+                            .x = solver.eigenvectors().col(root),
+                            .y = Eigen::VectorXd::Zero(dimension)});
+                }
+                return roots;
+            }
+
+            const Eigen::MatrixXd S = 0.5 * ((A - B) + (A - B).transpose());
+            const Eigen::MatrixXd T = 0.5 * ((A + B) + (A + B).transpose());
+
+            Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> s_solver(S);
+            if (s_solver.info() != Eigen::Success)
+                return std::unexpected("Casida metric diagonalization failed");
+
+            const Eigen::VectorXd s_evals = s_solver.eigenvalues();
+            if (s_evals.minCoeff() <= 1.0e-10)
+            {
+                return std::unexpected(std::format(
+                    "Casida metric A-B is not positive definite (min eigenvalue = {:.3e})",
+                    s_evals.minCoeff()));
+            }
+
+            const Eigen::MatrixXd s_vectors = s_solver.eigenvectors();
+            const Eigen::VectorXd s_sqrt_diag = s_evals.array().sqrt();
+            const Eigen::VectorXd s_inv_sqrt_diag = s_sqrt_diag.array().inverse();
+            const Eigen::MatrixXd s_sqrt =
+                s_vectors * s_sqrt_diag.asDiagonal() * s_vectors.transpose();
+            const Eigen::MatrixXd s_inv_sqrt =
+                s_vectors * s_inv_sqrt_diag.asDiagonal() * s_vectors.transpose();
+
+            Eigen::MatrixXd casida = s_sqrt * T * s_sqrt;
+            casida = 0.5 * (casida + casida.transpose());
+
+            Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> solver(casida);
+            if (solver.info() != Eigen::Success)
+                return std::unexpected("Full Casida diagonalization failed");
+
+            int accepted = 0;
+            for (int root = 0; root < dimension && accepted < roots_to_keep; ++root)
+            {
+                const double omega_sq = solver.eigenvalues()(root);
+                if (omega_sq <= 1.0e-12)
+                    continue;
+
+                const double omega = std::sqrt(omega_sq);
+                const Eigen::VectorXd f = solver.eigenvectors().col(root);
+                Eigen::VectorXd x_plus_y = (s_sqrt * f) / std::sqrt(omega);
+                Eigen::VectorXd x_minus_y = (s_inv_sqrt * f) * std::sqrt(omega);
+                Eigen::VectorXd x = 0.5 * (x_plus_y + x_minus_y);
+                Eigen::VectorXd y = 0.5 * (x_plus_y - x_minus_y);
+
+                const double norm = x.squaredNorm() - y.squaredNorm();
+                if (std::abs(norm) > 1.0e-12)
+                {
+                    const double scale = 1.0 / std::sqrt(std::abs(norm));
+                    x *= scale;
+                    y *= scale;
+                }
+
+                roots.push_back(ResponseEigenpair{.omega = omega, .x = std::move(x), .y = std::move(y)});
+                ++accepted;
+            }
+
+            if (roots.empty())
+                return std::unexpected("Full Casida solve did not yield any positive excitation energies");
+
+            return roots;
+        }
+
         void print_linear_response_report(
             const std::vector<LinearResponseRoot> &roots,
+            const std::string &method_label,
+            const std::string &spin_label,
+            bool includes_semilocal_xc,
             double exact_exchange_coefficient)
         {
             HartreeFock::Logger::logging(
                 HartreeFock::LogLevel::Info,
                 "TDDFT / Linear Response :",
                 std::format(
-                    "TDA-style singlet solver with {:.6f} exact-exchange kernel coefficient",
+                    "{} {} solver with {:.6f} exact-exchange kernel coefficient",
+                    method_label,
+                    spin_label,
                     exact_exchange_coefficient));
             HartreeFock::Logger::logging(
                 HartreeFock::LogLevel::Info,
                 "TDDFT / Linear Response :",
-                "Semilocal XC response kernels are not included in this initial implementation");
+                includes_semilocal_xc
+                    ? "Semilocal XC response kernels are included"
+                    : "Semilocal XC response kernels are not included");
             HartreeFock::Logger::blank();
 
             std::cout << std::string(118, '-') << "\n"
@@ -904,12 +1215,12 @@ namespace DFT::Driver
                 {
                     const std::string occupied_label =
                         contribution.occupied_symmetry.empty()
-                            ? std::format("MO{}", contribution.occupied)
-                            : std::format("MO{} ({})", contribution.occupied, contribution.occupied_symmetry);
+                            ? std::format("{} MO{}", contribution.spin_label, contribution.occupied)
+                            : std::format("{} MO{} ({})", contribution.spin_label, contribution.occupied, contribution.occupied_symmetry);
                     const std::string virtual_label =
                         contribution.virtual_symmetry.empty()
-                            ? std::format("MO{}", contribution.virtual_orbital)
-                            : std::format("MO{} ({})", contribution.virtual_orbital, contribution.virtual_symmetry);
+                            ? std::format("{} MO{}", contribution.spin_label, contribution.virtual_orbital)
+                            : std::format("{} MO{} ({})", contribution.spin_label, contribution.virtual_orbital, contribution.virtual_symmetry);
 
                     HartreeFock::Logger::logging(
                         HartreeFock::LogLevel::Info,
@@ -923,121 +1234,357 @@ namespace DFT::Driver
             HartreeFock::Logger::blank();
         }
 
-        std::expected<std::vector<LinearResponseRoot>, std::string> run_linear_response_tda(
+        std::expected<std::vector<LinearResponseRoot>, std::string> run_linear_response(
             HartreeFock::Calculator &calculator,
-            const DFT::XC::Functional &exchange_functional)
+            const Options &options,
+            const DFT::XC::Functional &exchange_functional,
+            const DFT::XC::Functional &correlation_functional)
         {
             if (!calculator._info._is_converged)
-                return std::unexpected("TDDFT / linear response requires a converged RKS reference");
-            if (calculator._scf._scf != HartreeFock::SCFType::RHF || calculator._info._scf.is_uhf)
-                return std::unexpected("Initial TDDFT / linear response support currently requires a closed-shell RKS reference");
+                return std::unexpected("TDDFT / linear response requires a converged KS reference");
 
-            const int n_electrons = static_cast<int>(
-                calculator._molecule.atomic_numbers.cast<int>().sum() - calculator._molecule.charge);
-            if (n_electrons % 2 != 0)
-                return std::unexpected("Closed-shell RKS TDDFT / linear response requires an even number of electrons");
+            PreparedSystem prepared;
+            auto preset = grid_preset(to_grid_level(calculator._dft._grid));
+            if (!preset)
+                return std::unexpected("TDDFT grid preset resolution failed: " + preset.error());
+            prepared.grid_preset = *preset;
+            prepared.shell_pairs = build_shellpairs(calculator._shells);
+
+            auto molecular_grid = MakeMolecularGrid(
+                calculator._molecule,
+                to_grid_level(calculator._dft._grid));
+            if (!molecular_grid)
+                return std::unexpected("TDDFT molecular grid construction failed: " + molecular_grid.error());
+            prepared.molecular_grid = std::move(*molecular_grid);
+
+            auto ao_grid = evaluate_ao_basis_on_grid(calculator._shells, prepared.molecular_grid);
+            if (!ao_grid)
+                return std::unexpected("TDDFT AO grid evaluation failed: " + ao_grid.error());
+            prepared.ao_grid = std::move(*ao_grid);
+
+            const bool unrestricted = calculator._scf._scf == HartreeFock::SCFType::UHF;
+            if (!unrestricted && calculator._scf._scf != HartreeFock::SCFType::RHF)
+                return std::unexpected("TDDFT / linear response currently supports RKS and UKS references only");
+
+            HartreeFock::LinearResponseSpin spin_mode = calculator._dft._lr_spin;
+            if (spin_mode == HartreeFock::LinearResponseSpin::Auto)
+                spin_mode = unrestricted ? HartreeFock::LinearResponseSpin::SpinConserving
+                                         : HartreeFock::LinearResponseSpin::Singlet;
+
+            if (unrestricted &&
+                (spin_mode == HartreeFock::LinearResponseSpin::Singlet ||
+                 spin_mode == HartreeFock::LinearResponseSpin::Triplet))
+            {
+                return std::unexpected(
+                    "UKS linear response currently supports spin-conserving roots only; singlet/triplet spin adaptation is restricted to closed-shell RKS");
+            }
 
             const Eigen::Index nbasis = static_cast<Eigen::Index>(calculator._shells.nbasis());
-            const int n_occ = n_electrons / 2;
-            const int n_virt = static_cast<int>(nbasis) - n_occ;
-            if (n_occ <= 0 || n_virt <= 0)
-                return std::unexpected("TDDFT / linear response requires at least one occupied and one virtual orbital");
+            std::vector<ResponseExcitationSpace> spaces;
+            spaces.reserve(unrestricted ? 2 : 1);
 
-            const int nov = n_occ * n_virt;
-            const int nroots = std::min(std::max(calculator._dft._lr_nstates, 1), nov);
+            if (!unrestricted)
+            {
+                const int n_electrons = static_cast<int>(
+                    calculator._molecule.atomic_numbers.cast<int>().sum() - calculator._molecule.charge);
+                if (n_electrons % 2 != 0)
+                    return std::unexpected("Closed-shell RKS TDDFT / linear response requires an even number of electrons");
 
-            const Eigen::MatrixXd &coefficients = calculator._info._scf.alpha.mo_coefficients;
-            const Eigen::VectorXd &energies = calculator._info._scf.alpha.mo_energies;
-            const std::vector<std::string> &mo_symmetry = calculator._info._scf.alpha.mo_symmetry;
+                const int n_occ = n_electrons / 2;
+                const int n_virt = static_cast<int>(nbasis) - n_occ;
+                if (n_occ <= 0 || n_virt <= 0)
+                    return std::unexpected("TDDFT / linear response requires at least one occupied and one virtual orbital");
 
-            const Eigen::MatrixXd C_occ = coefficients.leftCols(n_occ);
-            const Eigen::MatrixXd C_virt = coefficients.middleCols(n_occ, n_virt);
+                const Eigen::MatrixXd &coefficients = calculator._info._scf.alpha.mo_coefficients;
+                const Eigen::VectorXd &energies = calculator._info._scf.alpha.mo_energies;
+                spaces.push_back(
+                    ResponseExcitationSpace{
+                        .spin_label = (spin_mode == HartreeFock::LinearResponseSpin::Triplet) ? "T" : "S",
+                        .n_occ = n_occ,
+                        .n_virt = n_virt,
+                        .mo_offset = 0,
+                        .C_occ = coefficients.leftCols(n_occ),
+                        .C_virt = coefficients.middleCols(n_occ, n_virt),
+                        .occ_energies = energies.head(n_occ),
+                        .virt_energies = energies.tail(n_virt),
+                        .mo_symmetry = calculator._info._scf.alpha.mo_symmetry});
+            }
+            else
+            {
+                const int n_electrons = static_cast<int>(
+                    calculator._molecule.atomic_numbers.cast<int>().sum() - calculator._molecule.charge);
+                const int n_unpaired = static_cast<int>(calculator._molecule.multiplicity) - 1;
+                const int n_alpha = (n_electrons + n_unpaired) / 2;
+                const int n_beta = (n_electrons - n_unpaired) / 2;
+                const int n_virt_alpha = static_cast<int>(nbasis) - n_alpha;
+                const int n_virt_beta = static_cast<int>(nbasis) - n_beta;
+                if (n_alpha <= 0 || n_beta < 0 || n_virt_alpha <= 0 || n_virt_beta <= 0)
+                    return std::unexpected("UKS TDDFT / linear response requires occupied and virtual alpha/beta spaces");
 
-            std::vector<double> eri_local;
+                const Eigen::MatrixXd &coeff_alpha = calculator._info._scf.alpha.mo_coefficients;
+                const Eigen::VectorXd &eps_alpha = calculator._info._scf.alpha.mo_energies;
+                const Eigen::MatrixXd &coeff_beta = calculator._info._scf.beta.mo_coefficients;
+                const Eigen::VectorXd &eps_beta = calculator._info._scf.beta.mo_energies;
+
+                spaces.push_back(
+                    ResponseExcitationSpace{
+                        .spin_label = "alpha",
+                        .n_occ = n_alpha,
+                        .n_virt = n_virt_alpha,
+                        .mo_offset = 0,
+                        .C_occ = coeff_alpha.leftCols(n_alpha),
+                        .C_virt = coeff_alpha.middleCols(n_alpha, n_virt_alpha),
+                        .occ_energies = eps_alpha.head(n_alpha),
+                        .virt_energies = eps_alpha.tail(n_virt_alpha),
+                        .mo_symmetry = calculator._info._scf.alpha.mo_symmetry});
+                spaces.push_back(
+                    ResponseExcitationSpace{
+                        .spin_label = "beta",
+                        .n_occ = n_beta,
+                        .n_virt = n_virt_beta,
+                        .mo_offset = 0,
+                        .C_occ = coeff_beta.leftCols(n_beta),
+                        .C_virt = coeff_beta.middleCols(n_beta, n_virt_beta),
+                        .occ_energies = eps_beta.head(n_beta),
+                        .virt_energies = eps_beta.tail(n_virt_beta),
+                        .mo_symmetry = calculator._info._scf.beta.mo_symmetry});
+            }
+
+            const int total_dimension = std::accumulate(
+                spaces.begin(),
+                spaces.end(),
+                0,
+                [](int acc, const ResponseExcitationSpace &space)
+                { return acc + space.nov(); });
+            if (total_dimension <= 0)
+                return std::unexpected("TDDFT / linear response built an empty excitation space");
+
+            int offset = 0;
+            for (ResponseExcitationSpace &space : spaces)
+            {
+                space.mo_offset = offset;
+                offset += space.nov();
+            }
+
+            const int nroots = std::min(std::max(calculator._dft._lr_nstates, 1), total_dimension);
             const auto shell_pairs = build_shellpairs(calculator._shells);
+            std::vector<double> eri_local;
             const std::vector<double> &eri = HartreeFock::Correlation::ensure_eri(
                 calculator,
                 shell_pairs,
                 eri_local,
                 "TDDFT / Linear Response :");
 
-            const std::vector<double> mo_ia_jb =
-                HartreeFock::Correlation::transform_eri(eri, static_cast<std::size_t>(nbasis), C_occ, C_virt, C_occ, C_virt);
-            const std::vector<double> mo_ij_ab =
-                HartreeFock::Correlation::transform_eri(eri, static_cast<std::size_t>(nbasis), C_occ, C_occ, C_virt, C_virt);
-
-            auto idx_ia = [n_virt](int i, int a) -> int
-            {
-                return i * n_virt + a;
-            };
-            auto idx_ia_jb = [n_occ, n_virt](int i, int a, int j, int b) -> std::size_t
-            {
-                return ((static_cast<std::size_t>(i) * n_virt + a) * n_occ + j) * n_virt + b;
-            };
-            auto idx_ij_ab = [n_occ, n_virt](int i, int j, int a, int b) -> std::size_t
-            {
-                return ((static_cast<std::size_t>(i) * n_occ + j) * n_virt + a) * n_virt + b;
-            };
-
             const double exact_exchange_coefficient =
                 exchange_functional.is_hybrid() ? exchange_functional.exact_exchange_coefficient() : 0.0;
 
-            Eigen::VectorXd diagonal = Eigen::VectorXd::Zero(nov);
-            for (int i = 0; i < n_occ; ++i)
-                for (int a = 0; a < n_virt; ++a)
-                {
-                    const int ia = idx_ia(i, a);
-                    diagonal(ia) =
-                        energies(n_occ + a) - energies(i) +
-                        2.0 * mo_ia_jb[idx_ia_jb(i, a, i, a)] -
-                        exact_exchange_coefficient * mo_ij_ab[idx_ij_ab(i, i, a, a)];
-                }
+            Eigen::MatrixXd A = Eigen::MatrixXd::Zero(total_dimension, total_dimension);
+            Eigen::MatrixXd B = Eigen::MatrixXd::Zero(total_dimension, total_dimension);
 
-            const auto apply_tda_matrix = [&](const Eigen::Ref<const Eigen::VectorXd> &trial) -> Eigen::VectorXd
+            const auto fill_diagonal_gap = [&](const ResponseExcitationSpace &space)
             {
-                Eigen::VectorXd sigma = Eigen::VectorXd::Zero(nov);
-                for (int i = 0; i < n_occ; ++i)
-                    for (int a = 0; a < n_virt; ++a)
-                    {
-                        const int ia = idx_ia(i, a);
-                        double value = (energies(n_occ + a) - energies(i)) * trial(ia);
-                        for (int j = 0; j < n_occ; ++j)
-                            for (int b = 0; b < n_virt; ++b)
-                            {
-                                const int jb = idx_ia(j, b);
-                                value += 2.0 * mo_ia_jb[idx_ia_jb(i, a, j, b)] * trial(jb);
-                                value -= exact_exchange_coefficient * mo_ij_ab[idx_ij_ab(i, j, a, b)] * trial(jb);
-                            }
-                        sigma(ia) = value;
-                    }
-                return sigma;
+                for (int i = 0; i < space.n_occ; ++i)
+                    for (int a = 0; a < space.n_virt; ++a)
+                        A(space.mo_offset + space.flat_index(i, a), space.mo_offset + space.flat_index(i, a)) =
+                            space.virt_energies(a) - space.occ_energies(i);
             };
 
+            if (!unrestricted)
+            {
+                const ResponseExcitationSpace &space = spaces.front();
+                fill_diagonal_gap(space);
+
+                const std::vector<double> j_a = HartreeFock::Correlation::transform_eri(
+                    eri,
+                    static_cast<std::size_t>(nbasis),
+                    space.C_occ,
+                    space.C_virt,
+                    space.C_occ,
+                    space.C_virt);
+                const std::vector<double> j_b = HartreeFock::Correlation::transform_eri(
+                    eri,
+                    static_cast<std::size_t>(nbasis),
+                    space.C_occ,
+                    space.C_virt,
+                    space.C_virt,
+                    space.C_occ);
+                const std::vector<double> k_a = HartreeFock::Correlation::transform_eri(
+                    eri,
+                    static_cast<std::size_t>(nbasis),
+                    space.C_occ,
+                    space.C_occ,
+                    space.C_virt,
+                    space.C_virt);
+                const std::vector<double> k_b = HartreeFock::Correlation::transform_eri(
+                    eri,
+                    static_cast<std::size_t>(nbasis),
+                    space.C_occ,
+                    space.C_virt,
+                    space.C_virt,
+                    space.C_occ);
+
+                auto response_exchange = DFT::XC::Functional::create(
+                    calculator._dft._exchange_id,
+                    DFT::XC::Spin::Polarized);
+                if (!response_exchange)
+                    return std::unexpected("TDDFT response exchange-functional initialization failed: " + response_exchange.error());
+
+                auto response_correlation = DFT::XC::Functional::create(
+                    calculator._dft._correlation_id,
+                    DFT::XC::Spin::Polarized);
+                if (!response_correlation)
+                    return std::unexpected("TDDFT response correlation-functional initialization failed: " + response_correlation.error());
+
+                auto kxc_blocks = build_closed_shell_xc_kernel_blocks(
+                    prepared,
+                    space,
+                    calculator._info._scf.alpha.density,
+                    *response_exchange,
+                    *response_correlation);
+                if (!kxc_blocks)
+                    return std::unexpected(kxc_blocks.error());
+                auto [kxc_same, kxc_cross] = *kxc_blocks;
+
+                const Eigen::MatrixXd kxc =
+                    (spin_mode == HartreeFock::LinearResponseSpin::Triplet)
+                        ? (kxc_same - kxc_cross).eval()
+                        : (kxc_same + kxc_cross).eval();
+                const double coulomb_factor =
+                    (spin_mode == HartreeFock::LinearResponseSpin::Triplet) ? 0.0 : 2.0;
+
+                auto idx_j = [&](int i, int a, int j, int b) -> std::size_t
+                {
+                    return ((static_cast<std::size_t>(i) * space.n_virt + a) * space.n_occ + j) * space.n_virt + b;
+                };
+                auto idx_k = [&](int i, int j, int a, int b) -> std::size_t
+                {
+                    return ((static_cast<std::size_t>(i) * space.n_occ + j) * space.n_virt + a) * space.n_virt + b;
+                };
+
+                for (int i = 0; i < space.n_occ; ++i)
+                    for (int a = 0; a < space.n_virt; ++a)
+                    {
+                        const int ia = space.mo_offset + space.flat_index(i, a);
+                        for (int j = 0; j < space.n_occ; ++j)
+                            for (int b = 0; b < space.n_virt; ++b)
+                            {
+                                const int jb = space.mo_offset + space.flat_index(j, b);
+                                A(ia, jb) += coulomb_factor * j_a[idx_j(i, a, j, b)];
+                                B(ia, jb) += coulomb_factor * j_b[idx_j(i, a, b, j)];
+                                A(ia, jb) -= exact_exchange_coefficient * k_a[idx_k(i, j, a, b)];
+                                B(ia, jb) -= exact_exchange_coefficient * k_b[idx_j(i, a, b, j)];
+                                A(ia, jb) += kxc(space.flat_index(i, a), space.flat_index(j, b));
+                                B(ia, jb) += kxc(space.flat_index(i, a), space.flat_index(j, b));
+                            }
+                    }
+            }
+            else
+            {
+                for (const ResponseExcitationSpace &space : spaces)
+                    fill_diagonal_gap(space);
+
+                auto kxc_blocks = build_unrestricted_xc_kernel_blocks(
+                    prepared,
+                    spaces,
+                    calculator._info._scf.alpha.density,
+                    calculator._info._scf.beta.density,
+                    exchange_functional,
+                    correlation_functional);
+                if (!kxc_blocks)
+                    return std::unexpected(kxc_blocks.error());
+
+                for (int target = 0; target < static_cast<int>(spaces.size()); ++target)
+                {
+                    const ResponseExcitationSpace &target_space = spaces[static_cast<std::size_t>(target)];
+                    for (int source = 0; source < static_cast<int>(spaces.size()); ++source)
+                    {
+                        const ResponseExcitationSpace &source_space = spaces[static_cast<std::size_t>(source)];
+                        const std::vector<double> j_a = HartreeFock::Correlation::transform_eri(
+                            eri,
+                            static_cast<std::size_t>(nbasis),
+                            target_space.C_occ,
+                            target_space.C_virt,
+                            source_space.C_occ,
+                            source_space.C_virt);
+                        const std::vector<double> j_b = HartreeFock::Correlation::transform_eri(
+                            eri,
+                            static_cast<std::size_t>(nbasis),
+                            target_space.C_occ,
+                            target_space.C_virt,
+                            source_space.C_virt,
+                            source_space.C_occ);
+
+                        std::vector<double> k_a;
+                        std::vector<double> k_b;
+                        if (target == source)
+                        {
+                            k_a = HartreeFock::Correlation::transform_eri(
+                                eri,
+                                static_cast<std::size_t>(nbasis),
+                                target_space.C_occ,
+                                target_space.C_occ,
+                                target_space.C_virt,
+                                target_space.C_virt);
+                            k_b = HartreeFock::Correlation::transform_eri(
+                                eri,
+                                static_cast<std::size_t>(nbasis),
+                                target_space.C_occ,
+                                target_space.C_virt,
+                                target_space.C_virt,
+                                target_space.C_occ);
+                        }
+
+                        auto idx_j = [&](int i, int a, int j, int b) -> std::size_t
+                        {
+                            return ((static_cast<std::size_t>(i) * target_space.n_virt + a) * source_space.n_occ + j) * source_space.n_virt + b;
+                        };
+                        auto idx_k = [&](int i, int j, int a, int b) -> std::size_t
+                        {
+                            return ((static_cast<std::size_t>(i) * source_space.n_occ + j) * target_space.n_virt + a) * source_space.n_virt + b;
+                        };
+
+                        for (int i = 0; i < target_space.n_occ; ++i)
+                            for (int a = 0; a < target_space.n_virt; ++a)
+                            {
+                                const int ia = target_space.mo_offset + target_space.flat_index(i, a);
+                                for (int j = 0; j < source_space.n_occ; ++j)
+                                    for (int b = 0; b < source_space.n_virt; ++b)
+                                    {
+                                        const int jb = source_space.mo_offset + source_space.flat_index(j, b);
+                                        A(ia, jb) += j_a[idx_j(i, a, j, b)];
+                                        B(ia, jb) += j_b[idx_j(i, a, b, j)];
+                                        if (target == source)
+                                        {
+                                            A(ia, jb) -= exact_exchange_coefficient * k_a[idx_k(i, j, a, b)];
+                                            B(ia, jb) -= exact_exchange_coefficient * k_b[idx_j(i, a, b, j)];
+                                        }
+                                        A(ia, jb) += (*kxc_blocks)[static_cast<std::size_t>(target)][static_cast<std::size_t>(source)](
+                                            target_space.flat_index(i, a),
+                                            source_space.flat_index(j, b));
+                                        B(ia, jb) += (*kxc_blocks)[static_cast<std::size_t>(target)][static_cast<std::size_t>(source)](
+                                            target_space.flat_index(i, a),
+                                            source_space.flat_index(j, b));
+                                    }
+                            }
+                    }
+                }
+            }
+
+            A = 0.5 * (A + A.transpose());
+            B = 0.5 * (B + B.transpose());
+
             HartreeFock::Logger::logging(
                 HartreeFock::LogLevel::Info,
-                "TDDFT / Davidson :",
-                std::format("Solving {} lowest roots in a {}-dimensional excitation space", nroots, nov));
-
-            auto davidson = davidson_lowest_eigenpairs(
-                nov,
-                nroots,
-                diagonal,
-                apply_tda_matrix,
-                1.0e-8,
-                100,
-                std::max(6 * nroots, 24));
-            if (!davidson)
-                return std::unexpected(davidson.error());
-
-            HartreeFock::Logger::logging(
-                HartreeFock::LogLevel::Info,
-                "TDDFT / Davidson :",
+                "TDDFT / Dense Solve :",
                 std::format(
-                    "{} after {} iterations (max residual {:.3e})",
-                    davidson->converged ? "Converged" : "Stopped",
-                    davidson->iterations,
-                    davidson->residual_norms.size() > 0 ? davidson->residual_norms.maxCoeff() : 0.0));
-            HartreeFock::Logger::blank();
+                    "Building {} {} roots in a {}-dimensional excitation space",
+                    linear_response_method_label(calculator._dft._lr_method),
+                    linear_response_spin_label(spin_mode),
+                    total_dimension));
+
+            auto eigenpairs = solve_response_problem(A, B, calculator._dft._lr_method, nroots);
+            if (!eigenpairs)
+                return std::unexpected(eigenpairs.error());
 
             const HartreeFock::MultipoleMatrices multipoles =
                 HartreeFock::ObaraSaika::_compute_multipole_matrices(
@@ -1045,44 +1592,81 @@ namespace DFT::Driver
                     static_cast<std::size_t>(nbasis),
                     Eigen::Vector3d::Zero());
 
-            std::array<Eigen::MatrixXd, 3> mo_dipole_ov = {
-                C_occ.transpose() * multipoles.dipole[0] * C_virt,
-                C_occ.transpose() * multipoles.dipole[1] * C_virt,
-                C_occ.transpose() * multipoles.dipole[2] * C_virt};
+            std::vector<std::array<Eigen::MatrixXd, 3>> mo_dipole_ov;
+            mo_dipole_ov.reserve(spaces.size());
+            for (const ResponseExcitationSpace &space : spaces)
+            {
+                mo_dipole_ov.push_back(
+                    {space.C_occ.transpose() * multipoles.dipole[0] * space.C_virt,
+                     space.C_occ.transpose() * multipoles.dipole[1] * space.C_virt,
+                     space.C_occ.transpose() * multipoles.dipole[2] * space.C_virt});
+            }
 
             std::vector<LinearResponseRoot> roots;
-            roots.reserve(static_cast<std::size_t>(nroots));
+            roots.reserve(eigenpairs->size());
 
-            for (int root = 0; root < nroots; ++root)
+            for (int root_index = 0; root_index < static_cast<int>(eigenpairs->size()); ++root_index)
             {
-                const Eigen::VectorXd amplitudes = davidson->eigenvectors.col(root);
+                const ResponseEigenpair &pair = (*eigenpairs)[static_cast<std::size_t>(root_index)];
+                const Eigen::VectorXd transition_amplitudes = pair.x + pair.y;
                 Eigen::Vector3d transition_dipole = Eigen::Vector3d::Zero();
-
-                for (int i = 0; i < n_occ; ++i)
-                    for (int a = 0; a < n_virt; ++a)
-                    {
-                        const double amplitude = amplitudes(idx_ia(i, a));
-                        transition_dipole.x() += std::sqrt(2.0) * amplitude * mo_dipole_ov[0](i, a);
-                        transition_dipole.y() += std::sqrt(2.0) * amplitude * mo_dipole_ov[1](i, a);
-                        transition_dipole.z() += std::sqrt(2.0) * amplitude * mo_dipole_ov[2](i, a);
-                    }
-
                 std::vector<LinearResponseContribution> contributions;
-                contributions.reserve(static_cast<std::size_t>(nov));
-                for (int i = 0; i < n_occ; ++i)
-                    for (int a = 0; a < n_virt; ++a)
-                    {
-                        const double amplitude = amplitudes(idx_ia(i, a));
-                        contributions.push_back(
-                            LinearResponseContribution{
-                                .occupied = i + 1,
-                                .virtual_orbital = n_occ + a + 1,
-                                .weight = amplitude * amplitude,
-                                .occupied_symmetry =
-                                    (static_cast<std::size_t>(i) < mo_symmetry.size()) ? mo_symmetry[static_cast<std::size_t>(i)] : "",
-                                .virtual_symmetry =
-                                    (static_cast<std::size_t>(n_occ + a) < mo_symmetry.size()) ? mo_symmetry[static_cast<std::size_t>(n_occ + a)] : ""});
-                    }
+                contributions.reserve(static_cast<std::size_t>(total_dimension));
+
+                for (std::size_t space_index = 0; space_index < spaces.size(); ++space_index)
+                {
+                    const ResponseExcitationSpace &space = spaces[space_index];
+                    const auto &dipoles = mo_dipole_ov[space_index];
+                    for (int i = 0; i < space.n_occ; ++i)
+                        for (int a = 0; a < space.n_virt; ++a)
+                        {
+                            const int flat = space.mo_offset + space.flat_index(i, a);
+                            const double amplitude = transition_amplitudes(flat);
+                            if (!unrestricted)
+                            {
+                                if (spin_mode == HartreeFock::LinearResponseSpin::Triplet)
+                                {
+                                    // Electric dipole transitions vanish in the spin-adapted triplet block.
+                                }
+                                else
+                                {
+                                    transition_dipole.x() += std::sqrt(2.0) * amplitude * dipoles[0](i, a);
+                                    transition_dipole.y() += std::sqrt(2.0) * amplitude * dipoles[1](i, a);
+                                    transition_dipole.z() += std::sqrt(2.0) * amplitude * dipoles[2](i, a);
+                                }
+                            }
+                            else
+                            {
+                                transition_dipole.x() += amplitude * dipoles[0](i, a);
+                                transition_dipole.y() += amplitude * dipoles[1](i, a);
+                                transition_dipole.z() += amplitude * dipoles[2](i, a);
+                            }
+
+                            const double contribution_weight = pair.x(flat) * pair.x(flat) + pair.y(flat) * pair.y(flat);
+                            contributions.push_back(
+                                LinearResponseContribution{
+                                    .occupied = i + 1,
+                                    .virtual_orbital = space.n_occ + a + 1,
+                                    .weight = contribution_weight,
+                                    .spin_label = space.spin_label,
+                                    .occupied_symmetry =
+                                        (static_cast<std::size_t>(i) < space.mo_symmetry.size()) ? space.mo_symmetry[static_cast<std::size_t>(i)] : "",
+                                    .virtual_symmetry =
+                                        (static_cast<std::size_t>(space.n_occ + a) < space.mo_symmetry.size()) ? space.mo_symmetry[static_cast<std::size_t>(space.n_occ + a)] : ""});
+                        }
+                }
+
+                const double total_weight = std::accumulate(
+                    contributions.begin(),
+                    contributions.end(),
+                    0.0,
+                    [](double acc, const LinearResponseContribution &contribution)
+                    { return acc + contribution.weight; });
+                if (total_weight > 1.0e-12)
+                {
+                    for (LinearResponseContribution &contribution : contributions)
+                        contribution.weight /= total_weight;
+                }
 
                 std::ranges::sort(
                     contributions,
@@ -1093,21 +1677,27 @@ namespace DFT::Driver
                 if (contributions.size() > 3)
                     contributions.resize(3);
 
-                const double excitation_energy = davidson->eigenvalues(root);
                 const double oscillator_strength =
-                    std::max(0.0, (2.0 / 3.0) * excitation_energy * transition_dipole.squaredNorm());
+                    (spin_mode == HartreeFock::LinearResponseSpin::Triplet)
+                        ? 0.0
+                        : std::max(0.0, (2.0 / 3.0) * pair.omega * transition_dipole.squaredNorm());
 
                 roots.push_back(
                     LinearResponseRoot{
-                        .root = root + 1,
-                        .excitation_energy = excitation_energy,
-                        .excitation_energy_ev = excitation_energy * HARTREE_TO_EV,
+                        .root = root_index + 1,
+                        .excitation_energy = pair.omega,
+                        .excitation_energy_ev = pair.omega * HARTREE_TO_EV,
                         .transition_dipole = transition_dipole,
                         .oscillator_strength = oscillator_strength,
                         .dominant_contributions = std::move(contributions)});
             }
 
-            print_linear_response_report(roots, exact_exchange_coefficient);
+            print_linear_response_report(
+                roots,
+                linear_response_method_label(calculator._dft._lr_method),
+                linear_response_spin_label(spin_mode),
+                true,
+                exact_exchange_coefficient);
             return roots;
         }
 
@@ -2228,7 +2818,11 @@ namespace DFT::Driver
             if (!result->converged)
                 return *result;
 
-            auto response = run_linear_response_tda(calculator, functionals->exchange);
+            auto response = run_linear_response(
+                calculator,
+                options,
+                functionals->exchange,
+                functionals->correlation);
             if (!response)
                 return std::unexpected(response.error());
             return *result;

--- a/src/io/io.cpp
+++ b/src/io/io.cpp
@@ -381,6 +381,38 @@ namespace HartreeFock::IO
         return lookup_enum(_table, value, "Invalid XC correlation functional : ");
     }
 
+    template <>
+    std::expected<HartreeFock::LinearResponseMethod, std::string>
+    map_string_enum<HartreeFock::LinearResponseMethod>(const std::string &value)
+    {
+        static const std::unordered_map<std::string, HartreeFock::LinearResponseMethod> _table =
+            {
+                {"tda", HartreeFock::LinearResponseMethod::TDA},
+                {"casida", HartreeFock::LinearResponseMethod::Casida},
+                {"full", HartreeFock::LinearResponseMethod::Casida},
+                {"full_casida", HartreeFock::LinearResponseMethod::Casida},
+                {"full-casida", HartreeFock::LinearResponseMethod::Casida}};
+
+        return lookup_enum(_table, value, "Invalid linear-response method : ");
+    }
+
+    template <>
+    std::expected<HartreeFock::LinearResponseSpin, std::string>
+    map_string_enum<HartreeFock::LinearResponseSpin>(const std::string &value)
+    {
+        static const std::unordered_map<std::string, HartreeFock::LinearResponseSpin> _table =
+            {
+                {"auto", HartreeFock::LinearResponseSpin::Auto},
+                {"singlet", HartreeFock::LinearResponseSpin::Singlet},
+                {"triplet", HartreeFock::LinearResponseSpin::Triplet},
+                {"spinconserving", HartreeFock::LinearResponseSpin::SpinConserving},
+                {"spin_conserving", HartreeFock::LinearResponseSpin::SpinConserving},
+                {"spin-conserving", HartreeFock::LinearResponseSpin::SpinConserving},
+                {"unrestricted", HartreeFock::LinearResponseSpin::SpinConserving}};
+
+        return lookup_enum(_table, value, "Invalid linear-response spin mode : ");
+    }
+
     std::expected<void, std::string> _parse_control(const std::vector<std::string> &lines, HartreeFock::CalculationType &calculation, HartreeFock::OptionsBasis &basis, HartreeFock::OptionsOutput &output)
     {
         // (key, value) pairs
@@ -896,6 +928,38 @@ namespace HartreeFock::IO
                      dft._lr_nstates = std::stoi(value);
                      if (dft._lr_nstates < 1)
                          return std::unexpected("nstates must be >= 1");
+                     return std::expected<void, std::string>{};
+                 }},
+                {"lr_method", [&dft](const std::string &value) -> std::expected<void, std::string>
+                 {
+                     auto parsed = map_string_enum<HartreeFock::LinearResponseMethod>(value);
+                     if (!parsed)
+                         return std::unexpected(parsed.error());
+                     dft._lr_method = *parsed;
+                     return std::expected<void, std::string>{};
+                 }},
+                {"tddft_method", [&dft](const std::string &value) -> std::expected<void, std::string>
+                 {
+                     auto parsed = map_string_enum<HartreeFock::LinearResponseMethod>(value);
+                     if (!parsed)
+                         return std::unexpected(parsed.error());
+                     dft._lr_method = *parsed;
+                     return std::expected<void, std::string>{};
+                 }},
+                {"lr_spin", [&dft](const std::string &value) -> std::expected<void, std::string>
+                 {
+                     auto parsed = map_string_enum<HartreeFock::LinearResponseSpin>(value);
+                     if (!parsed)
+                         return std::unexpected(parsed.error());
+                     dft._lr_spin = *parsed;
+                     return std::expected<void, std::string>{};
+                 }},
+                {"tddft_spin", [&dft](const std::string &value) -> std::expected<void, std::string>
+                 {
+                     auto parsed = map_string_enum<HartreeFock::LinearResponseSpin>(value);
+                     if (!parsed)
+                         return std::unexpected(parsed.error());
+                     dft._lr_spin = *parsed;
                      return std::expected<void, std::string>{};
                  }}};
 

--- a/tests/inputs/regression/dft/h2_dft_tddft_triplet_pbe.hfinp
+++ b/tests/inputs/regression/dft/h2_dft_tddft_triplet_pbe.hfinp
@@ -1,0 +1,39 @@
+%begin_control
+    basis       sto-3g
+    calculation tddft
+    verbosity   normal
+    basis_type  cartesian
+%end_control
+
+%begin_scf
+    scf_type    rhf
+    use_diis    .true.
+    diis_dim    6
+    engine      os
+    guess       hcore
+    max_cycles  50
+    tol_energy  1.0e-8
+    tol_density 1.0e-8
+%end_scf
+
+%begin_dft
+    grid                coarse
+    exchange            pbe
+    correlation         pbe
+    lr_nstates          1
+    lr_spin             triplet
+    print_grid_summary  .false.
+%end_dft
+
+%begin_geom
+    coord_type  cartesian
+    coord_units angstrom
+    use_symm    .true.
+%end_geom
+
+%begin_coords
+2
+0   1
+H     0.000000     0.000000    -0.370000
+H     0.000000     0.000000     0.370000
+%end_coords

--- a/tests/inputs/regression/dft/water_triplet_uks_tddft_pbe_sto3g.hfinp
+++ b/tests/inputs/regression/dft/water_triplet_uks_tddft_pbe_sto3g.hfinp
@@ -1,0 +1,41 @@
+%begin_control
+    basis       sto-3g
+    calculation tddft
+    verbosity   normal
+    basis_type  cartesian
+%end_control
+
+%begin_scf
+    scf_type    uhf
+    use_diis    .true.
+    diis_dim    6
+    engine      os
+    guess       hcore
+    level_shift 0.3
+    max_cycles  80
+    tol_energy  1.0e-8
+    tol_density 1.0e-8
+%end_scf
+
+%begin_dft
+    grid                coarse
+    exchange            pbe
+    correlation         pbe
+    lr_nstates          3
+    lr_spin             spin_conserving
+    print_grid_summary  .false.
+%end_dft
+
+%begin_geom
+    coord_type  cartesian
+    coord_units angstrom
+    use_symm    .true.
+%end_geom
+
+%begin_coords
+3
+0   3
+O     0.000000    0.000000     0.117176
+H     0.000000    0.756950    -0.468703
+H     0.000000   -0.756950    -0.468703
+%end_coords

--- a/tests/regression_cases.json
+++ b/tests/regression_cases.json
@@ -474,14 +474,50 @@
       "expected_exit_code": 0,
       "contains": [
         "Reference :                   RKS",
-        "TDDFT / Linear Response :     TDA-style singlet solver",
+        "TDDFT / Linear Response :     full Casida singlet solver",
         "Root  1 dominant configurations:",
         "DFT Energy :"
       ],
       "checks": [
         {"type": "metric_eq", "metric": "point_group", "expected": "Dinfh"},
         {"type": "metric_close", "metric": "dft_total_energy", "expected": -1.1497054828, "atol": 1e-9},
-        {"type": "metric_close", "metric": "lr_root1_energy_ev", "expected": 29.991901, "atol": 1e-6}
+        {"type": "metric_close", "metric": "lr_root1_energy_ev", "expected": 25.406411, "atol": 1e-6}
+      ]
+    },
+    {
+      "id": "h2_dft_tddft_triplet_pbe_sto3g",
+      "input": "tests/inputs/regression/dft/h2_dft_tddft_triplet_pbe.hfinp",
+      "executable": "planck-dft",
+      "tags": ["smoke", "extended"],
+      "expected_exit_code": 0,
+      "contains": [
+        "Reference :                   RKS",
+        "TDDFT / Linear Response :     full Casida triplet solver",
+        "Root  1 dominant configurations:",
+        "DFT Energy :"
+      ],
+      "checks": [
+        {"type": "metric_eq", "metric": "point_group", "expected": "Dinfh"},
+        {"type": "metric_close", "metric": "dft_total_energy", "expected": -1.1497054828, "atol": 1e-9},
+        {"type": "metric_close", "metric": "lr_root1_energy_ev", "expected": 16.500027, "atol": 1e-6}
+      ]
+    },
+    {
+      "id": "water_triplet_uks_tddft_pbe_sto3g",
+      "input": "tests/inputs/regression/dft/water_triplet_uks_tddft_pbe_sto3g.hfinp",
+      "executable": "planck-dft",
+      "tags": ["smoke", "extended"],
+      "expected_exit_code": 0,
+      "contains": [
+        "Reference :                   UKS",
+        "TDDFT / Linear Response :     full Casida spin-conserving solver",
+        "Root  1 dominant configurations:",
+        "DFT Energy :"
+      ],
+      "checks": [
+        {"type": "metric_eq", "metric": "point_group", "expected": "C2v"},
+        {"type": "metric_close", "metric": "dft_total_energy", "expected": -74.8467253782, "atol": 1e-9},
+        {"type": "metric_close", "metric": "lr_root1_energy_ev", "expected": 3.122993, "atol": 1e-6}
       ]
     },
     {


### PR DESCRIPTION
Replaces the initial TDA-only singlet driver in planck-dft with a general linear-response framework that supports both the full A/B Casida problem and the older Hermitian TDA approximation, selectable from the input deck.

Solver
------
- Add `solve_response_problem` in src/dft/driver.cpp implementing both the TDA path (diagonalize symmetrized A) and the full Casida path (form S = A-B and T = A+B, take S^{1/2}, diagonalize S^{1/2} T S^{1/2}, recover X/Y with the standard <X|X> - <Y|Y> = 1 normalization). Casida is the new default; TDA is retained as `lr_method tda`.
- Extend the excitation space machinery via `ResponseExcitationSpace` so RKS uses one (occ, virt) block and UKS uses two (alpha, beta) blocks glued into a single response matrix with explicit spin labels on each contribution.
- Add singlet vs. triplet construction for closed-shell RKS by combining the (ia|jb) Coulomb-like and exchange-like MO integrals with the right spin-coupling factors, and route exact-exchange scaling through `exact_exchange_coefficient` for global hybrids in both spin channels.
- Add UKS spin-conserving response: builds the alpha-alpha, beta-beta, and cross alpha-beta blocks of A and B from spin-resolved MO integral transforms and the spin-dependent XC kernel.

Semilocal XC kernels
--------------------
- Add `build_unrestricted_xc_kernel_blocks` and the closed-shell wrapper `build_closed_shell_xc_kernel_blocks` to evaluate the XC response kernel by central finite difference of the spin-resolved KS XC matrix around the converged ground-state densities. The step size is scaled by the magnitude of each transition density to keep the difference well-conditioned.
- Wire those kernel blocks into A and B for both RKS (singlet/triplet) and UKS (spin-conserving) response, removing the previous "semilocal XC kernels not included" caveat for supported LDA/GGA functionals.
- Update the linear-response report to print the actual method/spin label and to advertise that semilocal XC kernels are now included.

Input plumbing
--------------
- Add `LinearResponseMethod` (TDA, Casida) and `LinearResponseSpin` (Auto, Singlet, Triplet, SpinConserving) enums in src/base/types.h along with the matching `_lr_method` and `_lr_spin` fields on the DFT options struct.
- Add `lr_method`/`tddft_method` and `lr_spin`/`tddft_spin` keywords to the DFT block parser in src/io/io.cpp, with string aliases (`full`, `full_casida`, `spin_conserving`, `unrestricted`, ...) and reusable `map_string_enum<>` specializations.
- Default behavior: `lr_method casida`, `lr_spin auto` -> singlet for RKS and spin-conserving for UKS.

Regressions and inputs
----------------------
- Update the existing `h2_dft_tddft_singlet_pbe_sto3g` regression to the new full-Casida singlet excitation energy (29.99 eV TDA value replaced by 25.41 eV Casida value) and the new banner text.
- Add `h2_dft_tddft_triplet_pbe_sto3g` (RKS triplet H2/PBE) and `water_triplet_uks_tddft_pbe_sto3g` (UKS spin-conserving triplet water/PBE) regression cases, including the matching `.hfinp` inputs under tests/inputs/regression/dft/.

Documentation
-------------
- README and QUICKSTART now describe the full TDDFT capability (Casida/TDA, singlet/triplet RKS, spin-conserving UKS, semilocal kernels) and document the new `lr_method`/`lr_spin` keywords in the DFT-block reference table.
- docs/PLANCK_TEACHING_GUIDE.md and docs/index.html refreshed to match the new solver options, defaults, and example inputs.