### PR TITLE
Add TDDFT root selection, wavelengths, and UV-Vis spectrum output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ python/dist
 tests/inputs/regression/open_shell/water_radical_cation_rohf_restart_sto3g.hfchk
 tests/inputs/regression/open_shell/water_triplet_uhf_restart_sto3g.hfchk
 CODE_REVIEW.md
+tests/inputs/regression/dft/h2_dft_tddft_pbe.uvvis.dat

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A quantum chemistry program implementing restricted, unrestricted, and restricte
 
 - **RHF / ROHF / UHF** — closed-shell, restricted open-shell, and unrestricted Hartree-Fock; ROHF uses a Roothaan-type effective Fock construction with aufbau orbital reordering and DIIS convergence
 - **RKS / UKS (Kohn-Sham DFT)** — closed-shell and open-shell Kohn-Sham SCF via the `planck-dft` executable; LDA, GGA, and global hybrid exchange-correlation functionals through libxc; four grid quality presets (Coarse/Normal/Fine/UltraFine); arbitrary libxc functionals via integer ID
-- **TDDFT / linear response** — full Casida and optional TDA excited-state roots on top of converged KS orbitals, with RKS singlet/triplet support, UKS spin-conserving response, semilocal XC kernels, transition dipoles, and oscillator strengths
+- **TDDFT / linear response** — full Casida and optional TDA excited-state roots on top of converged KS orbitals, with RKS singlet/triplet support, UKS spin-conserving response, semilocal XC kernels, transition dipoles, oscillator strengths, wavelengths, and Gaussian-broadened UV-Vis spectra
 - **Two integral engines** — Obara-Saika for low angular momentum; Rys quadrature for high angular momentum; automatic engine selection per shell quartet (`engine auto`)
 - **Electric multipole moments** — dipole and quadrupole moment analysis after SCF convergence for both `hartree-fock` and `planck-dft`
 - **Mulliken population analysis** — atomic gross populations, net charges, and (for UHF/ROHF) spin populations; printed when `print_populations true` or verbosity is `verbose`/`debug`
@@ -217,7 +217,8 @@ Kohn-Sham DFT settings. Only read by `planck-dft`; ignored by `hartree-fock`. Th
 | `correlation` | enum | `vwn`/`vwn5`, `lyp`, `p86`, `pw91`, `pbe` | `pbe` | Correlation functional |
 | `exchange_id` | int | any libxc integer ID | — | Use an arbitrary libxc exchange functional by its integer identifier. Overrides `exchange`. |
 | `correlation_id` | int | any libxc integer ID | — | Use an arbitrary libxc correlation functional by its integer identifier. Overrides `correlation`. |
-| `lr_nstates` / `tddft_nstates` / `nstates` | int | ≥ 1 | `5` | Number of excited states to report for `calculation tddft` / `linearresponse`. |
+| `lr_nstates` / `tddft_nstates` / `nstates` / `nroots` | int | ≥ 1 | `5` | Number of TDDFT roots to solve for `calculation tddft` / `linearresponse`. |
+| `root` | int | ≥ 1 | all solved roots | Optional 1-based TDDFT root selector. When set, Planck still solves enough roots to reach the requested state but reports only that root. |
 | `lr_method` / `tddft_method` | enum | `casida`, `full`, `tda` | `casida` | Linear-response solver form. `casida`/`full` solves the full \(A/B\) problem; `tda` diagonalizes the Hermitian \(A\) block only. |
 | `lr_spin` / `tddft_spin` | enum | `auto`, `singlet`, `triplet`, `spin_conserving` | `auto` | Spin channel for TDDFT response. `auto` resolves to `singlet` for RKS and `spin_conserving` for UKS. `triplet` is currently available for closed-shell RKS only. |
 | `use_sao_blocking` | bool | `.true.`, `.false.` | `.true.` | Enable symmetry-adapted AO blocking for the Coulomb matrix assembly. |

--- a/docs/PLANCK_TEACHING_GUIDE.md
+++ b/docs/PLANCK_TEACHING_GUIDE.md
@@ -3003,6 +3003,110 @@ f_k = \frac{2}{3}\,\omega_k\,\left|\boldsymbol{\mu}^{(k)}_{\mathrm{tr}}\right|^2
 with \(\omega_k\) in Hartree and \(\boldsymbol{\mu}_{\mathrm{tr}}\) in atomic
 units.
 
+**How `nroots` and `root` work**
+
+The TDDFT eigenproblem is built in a finite occupied-virtual excitation space.
+If there are \(N_{\mathrm{exc}}\) spin-adapted or spin-resolved single
+excitations after the RKS/UKS block construction, then the dense response
+matrix has dimension \(N_{\mathrm{exc}}\), and at most that many positive
+excitation energies can be returned.  Planck exposes two user controls:
+
+- `nroots` (aliases: `lr_nstates`, `tddft_nstates`, `nstates`) asks the solver
+  to compute the lowest \(n\) roots
+- `root` asks the report layer to keep only one specific 1-based root index
+
+Mathematically, if the requested number of states is
+\(n_{\mathrm{req}}\) and the requested printed root is
+\(r_{\mathrm{req}}\), Planck chooses the number of roots to solve as
+
+\[
+n_{\mathrm{solve}}
+= \min\!\left(N_{\mathrm{exc}},
+\max\!\left(n_{\mathrm{req}}, \max(r_{\mathrm{req}}, 1)\right)\right)
+\]
+
+This rule is important.  A request such as `nroots 3` means "compute the three
+lowest roots and report all three."  A request such as `root 5` means "even if
+the default state count is smaller, solve at least five roots so that root 5
+actually exists, then print only root 5."  In other words, `root` is a
+selection filter on top of the solved manifold, not a different eigenproblem.
+
+After diagonalization, Planck sorts the accepted positive-energy roots by
+increasing \(\omega_k\), assigns user-facing root numbers \(1,2,\dots\), and
+stores for each root
+
+\[
+\left\{\omega_k,\; \omega_k(\mathrm{eV}),\; \lambda_k(\mathrm{nm}),\;
+f_k,\; \boldsymbol{\mu}^{(k)}_{\mathrm{tr}}\right\}
+\]
+
+The selected `root` is then taken from that sorted list.  This is why the
+printed root index remains the physical excitation ordering rather than being
+renumbered to 1 when only one state is reported.
+
+For the full Casida path, the code solves a symmetric eigenproblem in
+\(\omega^2\), discards non-positive \(\omega^2\), reconstructs \(X\) and \(Y\),
+and accepts the lowest positive \(\omega\) values until
+\(n_{\mathrm{solve}}\) roots have been collected.  For the TDA path, the code
+simply takes the lowest \(n_{\mathrm{solve}}\) eigenpairs of \(A\).
+
+**Wavelengths, oscillator strengths, and UV-Vis spectra**
+
+Each discrete TDDFT excitation corresponds to a stick in the absorption
+spectrum.  Planck converts the excitation energy from Hartree to eV and to a
+vacuum wavelength through
+
+\[
+\omega_k(\mathrm{eV}) = \omega_k(\mathrm{Eh}) \times 27.211386\ldots
+\]
+
+\[
+\lambda_k(\mathrm{nm}) = \frac{1239.841984\ldots}{\omega_k(\mathrm{eV})}
+\]
+
+The quantity reported in the TDDFT root table is the electric-dipole
+oscillator strength
+
+\[
+f_k = \frac{2}{3}\,\omega_k\,\left|\boldsymbol{\mu}^{(k)}_{\mathrm{tr}}\right|^2
+\]
+
+so the raw theoretical absorption spectrum is a sum of delta functions,
+
+\[
+I(E) = \sum_k f_k\,\delta(E - \omega_k)
+\]
+
+which is not directly plottable as a smooth experimental-looking UV-Vis band
+shape.  Planck therefore broadens each discrete line with a Gaussian of fixed
+width \(\sigma\) in eV.  The plotted spectrum on the energy grid is
+
+\[
+I_{\sigma}(E)
+= \sum_k f_k
+\exp\!\left[
+-\frac{1}{2}\left(\frac{E-\omega_k(\mathrm{eV})}{\sigma}\right)^2
+\right]
+\]
+
+The implementation currently uses a fixed width of
+\(\sigma = 0.150\ \mathrm{eV}\) and evaluates this broadened spectrum on a
+uniform 400-point energy grid spanning the solved roots with a small margin.
+The resulting table is written to `*.uvvis.dat` with columns
+\(E\) (eV), \(\lambda\) (nm), and intensity (arbitrary units).  The units are
+"arbitrary" because Planck is reporting a broadened stick spectrum suitable for
+visualization, not an absolute molar absorptivity.
+
+Two practical details follow from that construction:
+
+1. The UV-Vis curve is built from **all solved roots**, not only from the
+   optionally selected printed `root`.  If the user asks for `root 2`, Planck
+   still uses the whole solved manifold when generating the broadened spectrum.
+2. The peak heights in the broadened curve are controlled jointly by the
+   oscillator strengths \(f_k\) and by the chosen broadening \(\sigma\).  A
+   dark state with very small \(f_k\) contributes negligibly even if its
+   excitation energy lies in the plotted window.
+
 **Code path**
 
 `src/dft/driver.cpp` — `run_linear_response()`
@@ -3019,16 +3123,25 @@ The solver reuses the converged KS reference already built by the SCF scaffold:
    differentiating the assembled XC AO matrix with respect to trial transition
    densities
 5. assemble dense \(A\) and \(B\) blocks
-6. solve either the TDA eigenproblem or the full Casida transformed eigenproblem
+6. choose the solved root count from the excitation-space dimension,
+   `nroots`, and optional `root`, then solve either the TDA eigenproblem or
+   the full Casida transformed eigenproblem
 7. build transition dipoles from AO dipole integrals transformed to the
    occupied-virtual MO basis
-8. sort and print the dominant occupied \(\rightarrow\) virtual configurations
-   for each root
+8. convert each accepted root into excitation energies in Hartree/eV,
+   wavelengths in nm, and oscillator strengths
+9. optionally filter the printed report to the selected `root`, while keeping
+   the physical root index
+10. build a Gaussian-broadened UV-Vis spectrum from the solved roots, write
+    `*.uvvis.dat`, and print the peak summary plus dominant
+    occupied \(\rightarrow\) virtual configurations for each reported root
 
 The report printed by `print_linear_response_report()` includes the root index,
 excitation energy in Hartree and eV, oscillator strength, Cartesian transition
 dipole components, the dipole norm in Debye, and the three largest
-configuration weights.
+configuration weights.  The UV-Vis helper `print_uvvis_spectrum_report()`
+then writes the broadened spectrum file and prints the strongest broadened
+peaks in energy and wavelength units.
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1919,6 +1919,56 @@ A X = \omega X
 f_k = \frac{2}{3}\,\omega_k\,\left|\boldsymbol{\mu}^{(k)}_{\mathrm{tr}}\right|^2
 \]</span></p>
 <p>with <span class="math-inline">\(\omega_k\)</span> in Hartree and <span class="math-inline">\(\boldsymbol{\mu}_{\mathrm{tr}}\)</span> in atomic units.</p>
+<p><strong>How <code>nroots</code> and <code>root</code> work</strong></p>
+<p>The TDDFT eigenproblem is built in a finite occupied-virtual excitation space. If there are <span class="math-inline">\(N_{\mathrm{exc}}\)</span> spin-adapted or spin-resolved single excitations after the RKS/UKS block construction, then the dense response matrix has dimension <span class="math-inline">\(N_{\mathrm{exc}}\)</span>, and at most that many positive excitation energies can be returned.  Planck exposes two user controls:</p>
+<ul>
+<li><code>nroots</code> (aliases: <code>lr_nstates</code>, <code>tddft_nstates</code>, <code>nstates</code>) asks the solver to compute the lowest <span class="math-inline">\(n\)</span> roots</li>
+<li><code>root</code> asks the report layer to keep only one specific 1-based root index</li>
+</ul>
+<p>Mathematically, if the requested number of states is <span class="math-inline">\(n_{\mathrm{req}}\)</span> and the requested printed root is <span class="math-inline">\(r_{\mathrm{req}}\)</span>, Planck chooses the number of roots to solve as</p>
+<p><span class="math-display">\[
+n_{\mathrm{solve}}
+= \min\!\left(N_{\mathrm{exc}},
+\max\!\left(n_{\mathrm{req}}, \max(r_{\mathrm{req}}, 1)\right)\right)
+\]</span></p>
+<p>This rule is important.  A request such as <code>nroots 3</code> means &quot;compute the three lowest roots and report all three.&quot;  A request such as <code>root 5</code> means &quot;even if the default state count is smaller, solve at least five roots so that root 5 actually exists, then print only root 5.&quot;  In other words, <code>root</code> is a selection filter on top of the solved manifold, not a different eigenproblem.</p>
+<p>After diagonalization, Planck sorts the accepted positive-energy roots by increasing <span class="math-inline">\(\omega_k\)</span>, assigns user-facing root numbers <span class="math-inline">\(1,2,\dots\)</span>, and stores for each root</p>
+<p><span class="math-display">\[
+\left\{\omega_k,\; \omega_k(\mathrm{eV}),\; \lambda_k(\mathrm{nm}),\;
+f_k,\; \boldsymbol{\mu}^{(k)}_{\mathrm{tr}}\right\}
+\]</span></p>
+<p>The selected <code>root</code> is then taken from that sorted list.  This is why the printed root index remains the physical excitation ordering rather than being renumbered to 1 when only one state is reported.</p>
+<p>For the full Casida path, the code solves a symmetric eigenproblem in <span class="math-inline">\(\omega^2\)</span>, discards non-positive <span class="math-inline">\(\omega^2\)</span>, reconstructs <span class="math-inline">\(X\)</span> and <span class="math-inline">\(Y\)</span>, and accepts the lowest positive <span class="math-inline">\(\omega\)</span> values until <span class="math-inline">\(n_{\mathrm{solve}}\)</span> roots have been collected.  For the TDA path, the code simply takes the lowest <span class="math-inline">\(n_{\mathrm{solve}}\)</span> eigenpairs of <span class="math-inline">\(A\)</span>.</p>
+<p><strong>Wavelengths, oscillator strengths, and UV-Vis spectra</strong></p>
+<p>Each discrete TDDFT excitation corresponds to a stick in the absorption spectrum.  Planck converts the excitation energy from Hartree to eV and to a vacuum wavelength through</p>
+<p><span class="math-display">\[
+\omega_k(\mathrm{eV}) = \omega_k(\mathrm{Eh}) \times 27.211386\ldots
+\]</span></p>
+<p><span class="math-display">\[
+\lambda_k(\mathrm{nm}) = \frac{1239.841984\ldots}{\omega_k(\mathrm{eV})}
+\]</span></p>
+<p>The quantity reported in the TDDFT root table is the electric-dipole oscillator strength</p>
+<p><span class="math-display">\[
+f_k = \frac{2}{3}\,\omega_k\,\left|\boldsymbol{\mu}^{(k)}_{\mathrm{tr}}\right|^2
+\]</span></p>
+<p>so the raw theoretical absorption spectrum is a sum of delta functions,</p>
+<p><span class="math-display">\[
+I(E) = \sum_k f_k\,\delta(E - \omega_k)
+\]</span></p>
+<p>which is not directly plottable as a smooth experimental-looking UV-Vis band shape.  Planck therefore broadens each discrete line with a Gaussian of fixed width <span class="math-inline">\(\sigma\)</span> in eV.  The plotted spectrum on the energy grid is</p>
+<p><span class="math-display">\[
+I_{\sigma}(E)
+= \sum_k f_k
+\exp\!\left[
+-\frac{1}{2}\left(\frac{E-\omega_k(\mathrm{eV})}{\sigma}\right)^2
+\right]
+\]</span></p>
+<p>The implementation currently uses a fixed width of <span class="math-inline">\(\sigma = 0.150\ \mathrm{eV}\)</span> and evaluates this broadened spectrum on a uniform 400-point energy grid spanning the solved roots with a small margin. The resulting table is written to <code>*.uvvis.dat</code> with columns <span class="math-inline">\(E\)</span> (eV), <span class="math-inline">\(\lambda\)</span> (nm), and intensity (arbitrary units).  The units are &quot;arbitrary&quot; because Planck is reporting a broadened stick spectrum suitable for visualization, not an absolute molar absorptivity.</p>
+<p>Two practical details follow from that construction:</p>
+<ol>
+<li>The UV-Vis curve is built from <strong>all solved roots</strong>, not only from the optionally selected printed <code>root</code>.  If the user asks for <code>root 2</code>, Planck still uses the whole solved manifold when generating the broadened spectrum.</li>
+<li>The peak heights in the broadened curve are controlled jointly by the oscillator strengths <span class="math-inline">\(f_k\)</span> and by the chosen broadening <span class="math-inline">\(\sigma\)</span>.  A dark state with very small <span class="math-inline">\(f_k\)</span> contributes negligibly even if its excitation energy lies in the plotted window.</li>
+</ol>
 <p><strong>Code path</strong></p>
 <p><code>src/dft/driver.cpp</code> — <code>run_linear_response()</code></p>
 <p>The solver reuses the converged KS reference already built by the SCF scaffold:</p>
@@ -1928,11 +1978,13 @@ f_k = \frac{2}{3}\,\omega_k\,\left|\boldsymbol{\mu}^{(k)}_{\mathrm{tr}}\right|^2
 <li>transform AO ERIs into the MO blocks needed for Coulomb and hybrid-exchange response terms</li>
 <li>evaluate semilocal XC response contributions on the numerical grid by differentiating the assembled XC AO matrix with respect to trial transition densities</li>
 <li>assemble dense <span class="math-inline">\(A\)</span> and <span class="math-inline">\(B\)</span> blocks</li>
-<li>solve either the TDA eigenproblem or the full Casida transformed eigenproblem</li>
+<li>choose the solved root count from the excitation-space dimension, <code>nroots</code>, and optional <code>root</code>, then solve either the TDA eigenproblem or the full Casida transformed eigenproblem</li>
 <li>build transition dipoles from AO dipole integrals transformed to the occupied-virtual MO basis</li>
-<li>sort and print the dominant occupied <span class="math-inline">\(\rightarrow\)</span> virtual configurations for each root</li>
+<li>convert each accepted root into excitation energies in Hartree/eV, wavelengths in nm, and oscillator strengths</li>
+<li>optionally filter the printed report to the selected <code>root</code>, while keeping the physical root index</li>
+<li>build a Gaussian-broadened UV-Vis spectrum from the solved roots, write <code>*.uvvis.dat</code>, and print the peak summary plus dominant occupied <span class="math-inline">\(\rightarrow\)</span> virtual configurations for each reported root</li>
 </ol>
-<p>The report printed by <code>print_linear_response_report()</code> includes the root index, excitation energy in Hartree and eV, oscillator strength, Cartesian transition dipole components, the dipole norm in Debye, and the three largest configuration weights.</p>
+<p>The report printed by <code>print_linear_response_report()</code> includes the root index, excitation energy in Hartree and eV, oscillator strength, Cartesian transition dipole components, the dipole norm in Debye, and the three largest configuration weights.  The UV-Vis helper <code>print_uvvis_spectrum_report()</code> then writes the broadened spectrum file and prints the strongest broadened peaks in energy and wavelength units.</p>
 <hr>
 <h2 id="19-molecular-properties">19. Molecular Properties</h2>
 <p>After SCF convergence Planck can compute several molecular properties from the converged density matrix. Dipole and quadrupole moments are printed automatically; population and bond-order reports are printed when <code>print_populations true</code> or the output <code>verbosity</code> is <code>verbose</code> / <code>debug</code>. This section covers the theory behind each property and the code path that evaluates it.</p>

--- a/src/base/types.h
+++ b/src/base/types.h
@@ -397,6 +397,7 @@ namespace HartreeFock
         int _exchange_id = 0;    // 0 => resolve from _exchange through libxc
         int _correlation_id = 0; // 0 => resolve from _correlation through libxc
         int _lr_nstates = 5;
+        int _lr_root = 0; // 0 => report all solved roots; otherwise select 1-based root index
         LinearResponseMethod _lr_method = LinearResponseMethod::Casida;
         LinearResponseSpin _lr_spin = LinearResponseSpin::Auto;
         bool _use_sao_blocking = true;

--- a/src/dft/driver.cpp
+++ b/src/dft/driver.cpp
@@ -5,7 +5,11 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <filesystem>
+#include <fstream>
 #include <format>
+#include <iomanip>
+#include <limits>
 #include <numeric>
 #include <string>
 
@@ -64,9 +68,17 @@ namespace DFT::Driver
             int root = 0;
             double excitation_energy = 0.0;
             double excitation_energy_ev = 0.0;
+            double wavelength_nm = 0.0;
             Eigen::Vector3d transition_dipole = Eigen::Vector3d::Zero();
             double oscillator_strength = 0.0;
             std::vector<LinearResponseContribution> dominant_contributions;
+        };
+
+        struct UVVisSpectrumPoint
+        {
+            double energy_ev = 0.0;
+            double wavelength_nm = 0.0;
+            double intensity = 0.0;
         };
 
         struct DavidsonEigenpairResult
@@ -910,6 +922,196 @@ namespace DFT::Driver
             return "unknown";
         }
 
+        constexpr double EV_NM_CONVERSION = 1239.8419843320026;
+        constexpr double UVVIS_BROADENING_EV = 0.15;
+        constexpr int UVVIS_SPECTRUM_POINTS = 400;
+
+        double energy_ev_to_wavelength_nm(double energy_ev)
+        {
+            if (energy_ev <= 1.0e-12)
+                return 0.0;
+            return EV_NM_CONVERSION / energy_ev;
+        }
+
+        std::vector<UVVisSpectrumPoint> build_uvvis_spectrum(
+            const std::vector<LinearResponseRoot> &roots,
+            double sigma_ev = UVVIS_BROADENING_EV,
+            int npoints = UVVIS_SPECTRUM_POINTS)
+        {
+            std::vector<UVVisSpectrumPoint> spectrum;
+            if (roots.empty() || sigma_ev <= 0.0 || npoints < 2)
+                return spectrum;
+
+            double min_energy = std::numeric_limits<double>::infinity();
+            double max_energy = 0.0;
+            for (const LinearResponseRoot &root : roots)
+            {
+                if (root.excitation_energy_ev <= 1.0e-8)
+                    continue;
+                min_energy = std::min(min_energy, root.excitation_energy_ev);
+                max_energy = std::max(max_energy, root.excitation_energy_ev);
+            }
+
+            if (!std::isfinite(min_energy) || max_energy <= 0.0)
+                return spectrum;
+
+            const double start_ev = std::max(0.05, min_energy - 4.0 * sigma_ev);
+            const double end_ev = std::max(start_ev + 8.0 * sigma_ev, max_energy + 4.0 * sigma_ev);
+            const double step_ev = (end_ev - start_ev) / static_cast<double>(npoints - 1);
+
+            spectrum.reserve(static_cast<std::size_t>(npoints));
+            for (int point = 0; point < npoints; ++point)
+            {
+                const double energy_ev = start_ev + step_ev * static_cast<double>(point);
+                double intensity = 0.0;
+                for (const LinearResponseRoot &root : roots)
+                {
+                    if (root.excitation_energy_ev <= 1.0e-8)
+                        continue;
+                    const double delta = (energy_ev - root.excitation_energy_ev) / sigma_ev;
+                    intensity += root.oscillator_strength * std::exp(-0.5 * delta * delta);
+                }
+
+                spectrum.push_back(
+                    UVVisSpectrumPoint{
+                        .energy_ev = energy_ev,
+                        .wavelength_nm = energy_ev_to_wavelength_nm(energy_ev),
+                        .intensity = intensity});
+            }
+
+            return spectrum;
+        }
+
+        std::vector<UVVisSpectrumPoint> extract_uvvis_peaks(
+            const std::vector<UVVisSpectrumPoint> &spectrum,
+            std::size_t max_peaks = 5,
+            double min_separation_ev = UVVIS_BROADENING_EV / 4.0)
+        {
+            std::vector<UVVisSpectrumPoint> peaks;
+            if (spectrum.size() < 3)
+                return peaks;
+
+            for (std::size_t i = 1; i + 1 < spectrum.size(); ++i)
+            {
+                if (spectrum[i].intensity >= spectrum[i - 1].intensity &&
+                    spectrum[i].intensity >= spectrum[i + 1].intensity &&
+                    spectrum[i].intensity > 1.0e-12)
+                {
+                    peaks.push_back(spectrum[i]);
+                }
+            }
+
+            std::ranges::sort(
+                peaks,
+                [](const UVVisSpectrumPoint &lhs, const UVVisSpectrumPoint &rhs)
+                {
+                    return lhs.intensity > rhs.intensity;
+                });
+
+            std::vector<UVVisSpectrumPoint> unique_peaks;
+            unique_peaks.reserve(std::min(max_peaks, peaks.size()));
+            for (const UVVisSpectrumPoint &peak : peaks)
+            {
+                const bool too_close = std::ranges::any_of(
+                    unique_peaks,
+                    [&](const UVVisSpectrumPoint &accepted)
+                    {
+                        return std::abs(accepted.energy_ev - peak.energy_ev) < min_separation_ev;
+                    });
+                if (too_close)
+                    continue;
+
+                unique_peaks.push_back(peak);
+                if (unique_peaks.size() >= max_peaks)
+                    break;
+            }
+            std::ranges::sort(
+                unique_peaks,
+                [](const UVVisSpectrumPoint &lhs, const UVVisSpectrumPoint &rhs)
+                {
+                    return lhs.energy_ev < rhs.energy_ev;
+                });
+            return unique_peaks;
+        }
+
+        std::expected<std::filesystem::path, std::string> write_uvvis_spectrum_file(
+            const HartreeFock::Calculator &calculator,
+            const std::vector<UVVisSpectrumPoint> &spectrum,
+            double sigma_ev = UVVIS_BROADENING_EV)
+        {
+            if (spectrum.empty())
+                return std::unexpected("no UV-Vis spectrum points were generated");
+
+            std::filesystem::path path = calculator._checkpoint_path;
+            path.replace_extension(".uvvis.dat");
+            std::ofstream out(path);
+            if (!out)
+                return std::unexpected("failed to open UV-Vis spectrum output file");
+
+            out << "# Gaussian-broadened UV-Vis spectrum\n";
+            out << std::format("# sigma_eV = {:.6f}\n", sigma_ev);
+            out << "# Energy_eV Wavelength_nm Intensity_arb\n";
+            out << std::fixed << std::setprecision(8);
+            for (const UVVisSpectrumPoint &point : spectrum)
+            {
+                out << std::setw(14) << point.energy_ev
+                    << std::setw(16) << point.wavelength_nm
+                    << std::setw(18) << point.intensity
+                    << "\n";
+            }
+
+            return path;
+        }
+
+        void print_uvvis_spectrum_report(
+            const HartreeFock::Calculator &calculator,
+            const std::vector<LinearResponseRoot> &roots)
+        {
+            const std::vector<UVVisSpectrumPoint> spectrum = build_uvvis_spectrum(roots);
+            if (spectrum.empty())
+                return;
+
+            auto spectrum_path = write_uvvis_spectrum_file(calculator, spectrum);
+            if (spectrum_path)
+            {
+                HartreeFock::Logger::logging(
+                    HartreeFock::LogLevel::Info,
+                    "UV-Vis Spectrum :",
+                    std::format(
+                        "Wrote {} Gaussian-broadened points to {} (sigma = {:.3f} eV)",
+                        spectrum.size(),
+                        spectrum_path->string(),
+                        UVVIS_BROADENING_EV));
+            }
+            else
+            {
+                HartreeFock::Logger::logging(
+                    HartreeFock::LogLevel::Warning,
+                    "UV-Vis Spectrum :",
+                    "Spectrum file write failed: " + spectrum_path.error());
+            }
+
+            const std::vector<UVVisSpectrumPoint> peaks = extract_uvvis_peaks(spectrum);
+            if (peaks.empty())
+                return;
+
+            std::cout << std::string(66, '-') << "\n"
+                      << std::setw(14) << "Peak (eV)"
+                      << std::setw(16) << "Lambda (nm)"
+                      << std::setw(18) << "Intensity (arb)"
+                      << "\n"
+                      << std::string(66, '-') << "\n";
+            for (const UVVisSpectrumPoint &peak : peaks)
+            {
+                std::cout << std::setw(14) << std::fixed << std::setprecision(6) << peak.energy_ev
+                          << std::setw(16) << std::fixed << std::setprecision(3) << peak.wavelength_nm
+                          << std::setw(18) << std::fixed << std::setprecision(6) << peak.intensity
+                          << "\n";
+            }
+            std::cout << std::string(66, '-') << "\n";
+            HartreeFock::Logger::blank();
+        }
+
         Eigen::MatrixXd transition_density_matrix(
             const Eigen::Ref<const Eigen::VectorXd> &occupied,
             const Eigen::Ref<const Eigen::VectorXd> &virtual_orbital)
@@ -1176,17 +1378,18 @@ namespace DFT::Driver
                     : "Semilocal XC response kernels are not included");
             HartreeFock::Logger::blank();
 
-            std::cout << std::string(118, '-') << "\n"
+            std::cout << std::string(132, '-') << "\n"
                       << std::setw(6) << "Root"
                       << std::setw(16) << "Omega (Eh)"
                       << std::setw(14) << "Omega (eV)"
+                      << std::setw(14) << "Lambda (nm)"
                       << std::setw(14) << "f"
                       << std::setw(16) << "mu_x (au)"
                       << std::setw(16) << "mu_y (au)"
                       << std::setw(16) << "mu_z (au)"
                       << std::setw(20) << "|mu| (Debye)"
                       << "\n"
-                      << std::string(118, '-') << "\n";
+                      << std::string(132, '-') << "\n";
 
             for (const LinearResponseRoot &root : roots)
             {
@@ -1194,6 +1397,7 @@ namespace DFT::Driver
                 std::cout << std::setw(6) << root.root
                           << std::setw(16) << std::fixed << std::setprecision(8) << root.excitation_energy
                           << std::setw(14) << std::fixed << std::setprecision(6) << root.excitation_energy_ev
+                          << std::setw(14) << std::fixed << std::setprecision(3) << root.wavelength_nm
                           << std::setw(14) << std::fixed << std::setprecision(6) << root.oscillator_strength
                           << std::setw(16) << std::fixed << std::setprecision(6) << root.transition_dipole.x()
                           << std::setw(16) << std::fixed << std::setprecision(6) << root.transition_dipole.y()
@@ -1202,7 +1406,7 @@ namespace DFT::Driver
                           << "\n";
             }
 
-            std::cout << std::string(118, '-') << "\n";
+            std::cout << std::string(132, '-') << "\n";
 
             for (const LinearResponseRoot &root : roots)
             {
@@ -1366,7 +1570,19 @@ namespace DFT::Driver
                 offset += space.nov();
             }
 
-            const int nroots = std::min(std::max(calculator._dft._lr_nstates, 1), total_dimension);
+            const int requested_nroots = std::max(calculator._dft._lr_nstates, 1);
+            const int requested_root = calculator._dft._lr_root;
+            if (requested_root > 0 && requested_root > total_dimension)
+            {
+                return std::unexpected(std::format(
+                    "Requested TDDFT root {} exceeds the excitation-space dimension {}",
+                    requested_root,
+                    total_dimension));
+            }
+
+            const int nroots = std::min(
+                std::max(requested_nroots, std::max(requested_root, 1)),
+                total_dimension);
             const auto shell_pairs = build_shellpairs(calculator._shells);
             std::vector<double> eri_local;
             const std::vector<double> &eri = HartreeFock::Correlation::ensure_eri(
@@ -1577,9 +1793,10 @@ namespace DFT::Driver
                 HartreeFock::LogLevel::Info,
                 "TDDFT / Dense Solve :",
                 std::format(
-                    "Building {} {} roots in a {}-dimensional excitation space",
+                    "Building {} {} response with {} solved roots in a {}-dimensional excitation space",
                     linear_response_method_label(calculator._dft._lr_method),
                     linear_response_spin_label(spin_mode),
+                    nroots,
                     total_dimension));
 
             auto eigenpairs = solve_response_problem(A, B, calculator._dft._lr_method, nroots);
@@ -1687,18 +1904,34 @@ namespace DFT::Driver
                         .root = root_index + 1,
                         .excitation_energy = pair.omega,
                         .excitation_energy_ev = pair.omega * HARTREE_TO_EV,
+                        .wavelength_nm = energy_ev_to_wavelength_nm(pair.omega * HARTREE_TO_EV),
                         .transition_dipole = transition_dipole,
                         .oscillator_strength = oscillator_strength,
                         .dominant_contributions = std::move(contributions)});
             }
 
+            std::vector<LinearResponseRoot> reported_roots = roots;
+            if (requested_root > 0)
+            {
+                if (requested_root > static_cast<int>(roots.size()))
+                {
+                    return std::unexpected(std::format(
+                        "Requested TDDFT root {} was not found among the {} solved roots",
+                        requested_root,
+                        roots.size()));
+                }
+
+                reported_roots = {roots[static_cast<std::size_t>(requested_root - 1)]};
+            }
+
             print_linear_response_report(
-                roots,
+                reported_roots,
                 linear_response_method_label(calculator._dft._lr_method),
                 linear_response_spin_label(spin_mode),
                 true,
                 exact_exchange_coefficient);
-            return roots;
+            print_uvvis_spectrum_report(calculator, roots);
+            return reported_roots;
         }
 
         std::expected<Result, std::string> run_ks_scf_scaffold(

--- a/src/io/io.cpp
+++ b/src/io/io.cpp
@@ -930,6 +930,20 @@ namespace HartreeFock::IO
                          return std::unexpected("nstates must be >= 1");
                      return std::expected<void, std::string>{};
                  }},
+                {"nroots", [&dft](const std::string &value) -> std::expected<void, std::string>
+                 {
+                     dft._lr_nstates = std::stoi(value);
+                     if (dft._lr_nstates < 1)
+                         return std::unexpected("nroots must be >= 1");
+                     return std::expected<void, std::string>{};
+                 }},
+                {"root", [&dft](const std::string &value) -> std::expected<void, std::string>
+                 {
+                     dft._lr_root = std::stoi(value);
+                     if (dft._lr_root < 1)
+                         return std::unexpected("root must be >= 1");
+                     return std::expected<void, std::string>{};
+                 }},
                 {"lr_method", [&dft](const std::string &value) -> std::expected<void, std::string>
                  {
                      auto parsed = map_string_enum<HartreeFock::LinearResponseMethod>(value);

--- a/tests/inputs/regression/dft/water_triplet_uks_tddft_root2_pbe_sto3g.hfinp
+++ b/tests/inputs/regression/dft/water_triplet_uks_tddft_root2_pbe_sto3g.hfinp
@@ -1,0 +1,42 @@
+%begin_control
+    basis       sto-3g
+    calculation tddft
+    verbosity   normal
+    basis_type  cartesian
+%end_control
+
+%begin_scf
+    scf_type    uhf
+    use_diis    .true.
+    diis_dim    6
+    engine      os
+    guess       hcore
+    level_shift 0.3
+    max_cycles  80
+    tol_energy  1.0e-8
+    tol_density 1.0e-8
+%end_scf
+
+%begin_dft
+    grid                coarse
+    exchange            pbe
+    correlation         pbe
+    nroots              3
+    root                2
+    lr_spin             spin_conserving
+    print_grid_summary  .false.
+%end_dft
+
+%begin_geom
+    coord_type  cartesian
+    coord_units angstrom
+    use_symm    .true.
+%end_geom
+
+%begin_coords
+3
+0   3
+O     0.000000    0.000000     0.117176
+H     0.000000    0.756950    -0.468703
+H     0.000000   -0.756950    -0.468703
+%end_coords

--- a/tests/regression_cases.json
+++ b/tests/regression_cases.json
@@ -475,6 +475,7 @@
       "contains": [
         "Reference :                   RKS",
         "TDDFT / Linear Response :     full Casida singlet solver",
+        "UV-Vis Spectrum :",
         "Root  1 dominant configurations:",
         "DFT Energy :"
       ],
@@ -518,6 +519,23 @@
         {"type": "metric_eq", "metric": "point_group", "expected": "C2v"},
         {"type": "metric_close", "metric": "dft_total_energy", "expected": -74.8467253782, "atol": 1e-9},
         {"type": "metric_close", "metric": "lr_root1_energy_ev", "expected": 3.122993, "atol": 1e-6}
+      ]
+    },
+    {
+      "id": "water_triplet_uks_tddft_root2_pbe_sto3g",
+      "input": "tests/inputs/regression/dft/water_triplet_uks_tddft_root2_pbe_sto3g.hfinp",
+      "executable": "planck-dft",
+      "tags": ["smoke", "extended"],
+      "expected_exit_code": 0,
+      "contains": [
+        "Reference :                   UKS",
+        "TDDFT / Dense Solve :         Building full Casida spin-conserving response with 3 solved roots",
+        "Root  2 dominant configurations:",
+        "DFT Energy :"
+      ],
+      "checks": [
+        {"type": "metric_eq", "metric": "point_group", "expected": "C2v"},
+        {"type": "metric_close", "metric": "dft_total_energy", "expected": -74.8467253782, "atol": 1e-9}
       ]
     },
     {

--- a/visualizer/__init__.py
+++ b/visualizer/__init__.py
@@ -1,2 +1,10 @@
-from .parser import parse_log, ParsedRun
-from .app import create_app
+from .parser import ParsedRun, parse_log
+
+
+def create_app(*args, **kwargs):
+    from .app import create_app as _create_app
+
+    return _create_app(*args, **kwargs)
+
+
+__all__ = ["ParsedRun", "parse_log", "create_app"]

--- a/visualizer/app.py
+++ b/visualizer/app.py
@@ -82,8 +82,8 @@ def _run_to_json(run: ParsedRun, log_path: str) -> dict:
         "sphere_radii": [_SPH_R_Z.get(a.Z, 0.55) for a in atoms],
         "num_atoms": len(atoms),
         "num_electrons": n_elec,
-        "charge": 0,
-        "multiplicity": 1,
+        "charge": run.charge if run.charge is not None else 0,
+        "multiplicity": run.multiplicity if run.multiplicity is not None else 1,
     }
 
     # SCF
@@ -187,6 +187,43 @@ def _run_to_json(run: ParsedRun, log_path: str) -> dict:
             ),
         }
 
+    # TDDFT / UV-Vis
+    tddft_data = None
+    if run.tddft_roots or run.uvvis_points or run.uvvis_peaks:
+        tddft_data = {
+            "roots": [
+                {
+                    "root": root.root,
+                    "omega_eh": float(root.omega_eh),
+                    "omega_ev": float(root.omega_ev),
+                    "wavelength_nm": float(root.wavelength_nm),
+                    "oscillator_strength": float(root.oscillator_strength),
+                }
+                for root in run.tddft_roots
+            ],
+            "uvvis_points": [
+                {
+                    "energy_ev": float(point.energy_ev),
+                    "wavelength_nm": float(point.wavelength_nm),
+                    "intensity": float(point.intensity),
+                }
+                for point in run.uvvis_points
+            ],
+            "uvvis_peaks": [
+                {
+                    "energy_ev": float(point.energy_ev),
+                    "wavelength_nm": float(point.wavelength_nm),
+                    "intensity": float(point.intensity),
+                }
+                for point in run.uvvis_peaks
+            ],
+            "uvvis_sigma_ev": (
+                float(run.uvvis_sigma_ev)
+                if run.uvvis_sigma_ev is not None else None
+            ),
+            "uvvis_spectrum_path": run.uvvis_spectrum_path,
+        }
+
     return {
         "status": "done",
         "level": run.scf_type or "RHF",
@@ -202,6 +239,7 @@ def _run_to_json(run: ParsedRun, log_path: str) -> dict:
         "casscf": casscf_data,
         "geopt": geopt_data,
         "freq": freq_data,
+        "tddft": tddft_data,
     }
 
 

--- a/visualizer/parser.py
+++ b/visualizer/parser.py
@@ -99,6 +99,22 @@ class CASRoot:
 
 
 @dataclass
+class TDDFTRoot:
+    root: int
+    omega_eh: float
+    omega_ev: float
+    wavelength_nm: float
+    oscillator_strength: float
+
+
+@dataclass
+class UVVisPoint:
+    energy_ev: float
+    wavelength_nm: float
+    intensity: float
+
+
+@dataclass
 class ParsedRun:
     # --- metadata ---
     calculation_type: Optional[str] = None
@@ -159,6 +175,13 @@ class ParsedRun:
     casscf_total_energy: Optional[float] = None
     casscf_sa_roots: list[CASRoot] = field(default_factory=list)
 
+    # --- TDDFT / UV-Vis ---
+    tddft_roots: list[TDDFTRoot] = field(default_factory=list)
+    uvvis_points: list[UVVisPoint] = field(default_factory=list)
+    uvvis_peaks: list[UVVisPoint] = field(default_factory=list)
+    uvvis_sigma_ev: Optional[float] = None
+    uvvis_spectrum_path: Optional[str] = None
+
 
 # ---------------------------------------------------------------------------
 # Compiled regexes
@@ -184,7 +207,7 @@ _LOG_RE = re.compile(
 )
 
 # 110-dash separator (SCF table header/footer).
-_DASH110_RE = re.compile(r'^-{110}\s*$')
+_DASH_RE = re.compile(r'^-+\s*$')
 
 # SCF iteration row.
 _SCF_ITER_RE = re.compile(
@@ -281,6 +304,26 @@ _CASSCF_TOTAL_ENERGY_RE = re.compile(
 _CASSCF_SA_ROOT_RE = re.compile(
     r'^\s*Root\s+(\d+)\s+([-+\d.eE]+)\s+Eh\s+\(weight\s+([\d.eE+\-]+)\)'
 )
+_TDDFT_ROOT_HEADER_RE = re.compile(
+    r'^Root\s+Omega \(Eh\)\s+Omega \(eV\)\s+Lambda \(nm\)\s+f\b'
+)
+_TDDFT_ROOT_ROW_RE = re.compile(
+    r'^\s*(\d+)'
+    r'\s+([-+\d.eE]+)'
+    r'\s+([-+\d.eE]+)'
+    r'\s+([-+\d.eE]+)'
+    r'\s+([-+\d.eE]+)'
+    r'(?:\s+.*)?$'
+)
+_UVVIS_WRITE_RE = re.compile(
+    r'Wrote\s+\d+\s+Gaussian-broadened points to\s+(\S+)\s+\(sigma =\s+([-+\d.eE]+)\s+eV\)'
+)
+_UVVIS_PEAK_HEADER_RE = re.compile(
+    r'^Peak \(eV\)\s+Lambda \(nm\)\s+Intensity \(arb\)\s*$'
+)
+_UVVIS_PEAK_ROW_RE = re.compile(
+    r'^\s*([-+\d.eE]+)\s+([-+\d.eE]+)\s+([-+\d.eE]+)\s*$'
+)
 
 
 # ---------------------------------------------------------------------------
@@ -298,6 +341,8 @@ class _State(Enum):
     GRADIENT = auto()
     STEP_GEOM = auto()
     NORMAL_MODE = auto()
+    TDDFT_ROOTS = auto()
+    UVVIS_PEAKS = auto()
 
 
 @dataclass(frozen=True)
@@ -319,6 +364,8 @@ class _ParseContext:
     cas_dashes: int = 0
     in_cas_nat_occ: bool = False
     pending_grad_atom: Optional[int] = None
+    tddft_root_dashes: int = 0
+    uvvis_peak_dashes: int = 0
 
 
 _TEXT_LABEL_FIELDS: dict[str, str] = {
@@ -442,7 +489,7 @@ def _set_gradient_summary(run: ParsedRun, field_name: str, message: str) -> None
 
 
 def _consume_separator_line(ctx: _ParseContext, raw: str) -> bool:
-    if not _DASH110_RE.match(raw):
+    if not _DASH_RE.match(raw):
         return False
 
     if ctx.state == _State.SCF_TABLE:
@@ -457,6 +504,18 @@ def _consume_separator_line(ctx: _ParseContext, raw: str) -> bool:
         if ctx.cas_dashes >= 2:
             ctx.state = _State.INIT
             ctx.cas_done = True
+        return True
+
+    if ctx.state == _State.TDDFT_ROOTS:
+        ctx.tddft_root_dashes += 1
+        if ctx.tddft_root_dashes >= 2:
+            ctx.state = _State.INIT
+        return True
+
+    if ctx.state == _State.UVVIS_PEAKS:
+        ctx.uvvis_peak_dashes += 1
+        if ctx.uvvis_peak_dashes >= 2:
+            ctx.state = _State.INIT
         return True
 
     if not ctx.scf_done and ctx.scf_armed:
@@ -483,6 +542,34 @@ def _consume_table_row(ctx: _ParseContext, raw: str) -> bool:
         match = _SCF_ITER_RE.match(raw)
         if match:
             ctx.run.casscf_iters.append(_parse_casscf_row(match))
+            return True
+        return False
+
+    if ctx.state == _State.TDDFT_ROOTS:
+        match = _TDDFT_ROOT_ROW_RE.match(raw)
+        if match:
+            ctx.run.tddft_roots.append(
+                TDDFTRoot(
+                    root=int(match.group(1)),
+                    omega_eh=float(match.group(2)),
+                    omega_ev=float(match.group(3)),
+                    wavelength_nm=float(match.group(4)),
+                    oscillator_strength=float(match.group(5)),
+                )
+            )
+            return True
+        return False
+
+    if ctx.state == _State.UVVIS_PEAKS:
+        match = _UVVIS_PEAK_ROW_RE.match(raw)
+        if match:
+            ctx.run.uvvis_peaks.append(
+                UVVisPoint(
+                    energy_ev=float(match.group(1)),
+                    wavelength_nm=float(match.group(2)),
+                    intensity=float(match.group(3)),
+                )
+            )
             return True
         return False
 
@@ -631,6 +718,13 @@ def _consume_named_line(ctx: _ParseContext, line: _StructuredLine) -> bool:
             ctx.run.zpe_kcal = float(match.group(2))
         return True
 
+    if line.label == "UV-Vis Spectrum :":
+        match = _UVVIS_WRITE_RE.search(line.message)
+        if match:
+            ctx.run.uvvis_spectrum_path = match.group(1)
+            ctx.run.uvvis_sigma_ev = float(match.group(2))
+        return True
+
     if line.label == "Normal Mode Displacements :":
         ctx.state = _State.INIT
         return True
@@ -651,6 +745,18 @@ def _consume_named_line(ctx: _ParseContext, line: _StructuredLine) -> bool:
 
 
 def _consume_blank_line(ctx: _ParseContext, message: str) -> None:
+    stripped = message.strip()
+
+    if _TDDFT_ROOT_HEADER_RE.match(stripped):
+        ctx.state = _State.TDDFT_ROOTS
+        ctx.tddft_root_dashes = 0
+        return
+
+    if _UVVIS_PEAK_HEADER_RE.match(stripped):
+        ctx.state = _State.UVVIS_PEAKS
+        ctx.uvvis_peak_dashes = 0
+        return
+
     if ctx.state == _State.INPUT_COORDS:
         atom = _try_coord(message)
         if atom:
@@ -730,6 +836,95 @@ def _reset_section_state_on_unhandled_label(ctx: _ParseContext) -> None:
         ctx.pending_grad_atom = None
 
 
+def _consume_message_line(ctx: _ParseContext, text: str) -> bool:
+    stripped = text.strip()
+    if not stripped:
+        return False
+
+    if _TDDFT_ROOT_HEADER_RE.match(stripped):
+        ctx.state = _State.TDDFT_ROOTS
+        ctx.tddft_root_dashes = 0
+        return True
+
+    if _UVVIS_PEAK_HEADER_RE.match(stripped):
+        ctx.state = _State.UVVIS_PEAKS
+        ctx.uvvis_peak_dashes = 0
+        return True
+
+    if ctx.state == _State.TDDFT_ROOTS:
+        match = _TDDFT_ROOT_ROW_RE.match(stripped)
+        if match:
+            ctx.run.tddft_roots.append(
+                TDDFTRoot(
+                    root=int(match.group(1)),
+                    omega_eh=float(match.group(2)),
+                    omega_ev=float(match.group(3)),
+                    wavelength_nm=float(match.group(4)),
+                    oscillator_strength=float(match.group(5)),
+                )
+            )
+            return True
+
+    if ctx.state == _State.UVVIS_PEAKS:
+        match = _UVVIS_PEAK_ROW_RE.match(stripped)
+        if match:
+            ctx.run.uvvis_peaks.append(
+                UVVisPoint(
+                    energy_ev=float(match.group(1)),
+                    wavelength_nm=float(match.group(2)),
+                    intensity=float(match.group(3)),
+                )
+            )
+            return True
+
+    return False
+
+
+def _resolve_uvvis_path(log_path: Path, spectrum_path: str) -> Optional[Path]:
+    candidate = Path(spectrum_path)
+    if candidate.is_absolute() and candidate.exists():
+        return candidate
+
+    candidates = [
+        log_path.parent / spectrum_path,
+        candidate,
+    ]
+    for resolved in candidates:
+        if resolved.exists():
+            return resolved.resolve()
+    return None
+
+
+def _load_uvvis_points(log_path: Path, run: ParsedRun) -> None:
+    if not run.uvvis_spectrum_path:
+        return
+
+    spectrum_path = _resolve_uvvis_path(log_path, run.uvvis_spectrum_path)
+    if spectrum_path is None:
+        return
+
+    points: list[UVVisPoint] = []
+    try:
+        for raw in spectrum_path.read_text(encoding="utf-8").splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            match = _UVVIS_PEAK_ROW_RE.match(line)
+            if not match:
+                continue
+            points.append(
+                UVVisPoint(
+                    energy_ev=float(match.group(1)),
+                    wavelength_nm=float(match.group(2)),
+                    intensity=float(match.group(3)),
+                )
+            )
+    except OSError:
+        return
+
+    run.uvvis_points = points
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -741,9 +936,10 @@ def parse_log(path: str | Path) -> ParsedRun:
     raw-table rows, structured labels, and section-local blank rows each
     have dedicated handlers so state transitions are easier to follow.
     """
+    log_path = Path(path)
     ctx = _ParseContext()
 
-    for raw in Path(path).read_text(encoding="utf-8").splitlines():
+    for raw in log_path.read_text(encoding="utf-8").splitlines():
         if _consume_separator_line(ctx, raw):
             continue
 
@@ -757,6 +953,9 @@ def parse_log(path: str | Path) -> ParsedRun:
         if line is None:
             continue
 
+        if _consume_message_line(ctx, raw):
+            continue
+
         if line.label:
             if _consume_named_line(ctx, line):
                 continue
@@ -768,4 +967,5 @@ def parse_log(path: str | Path) -> ParsedRun:
     ctx.run.n_imaginary = sum(
         1 for mode in ctx.run.freq_modes if mode.frequency < 0
     )
+    _load_uvvis_points(log_path, ctx.run)
     return ctx.run

--- a/visualizer/templates/index.html
+++ b/visualizer/templates/index.html
@@ -375,6 +375,7 @@
           <button class="tab-btn" id="btn-tab-casscf" data-tab="casscf" onclick="showTab('casscf', this)" style="display:none">CASSCF</button>
           <button class="tab-btn" id="btn-tab-geopt"  data-tab="geopt"  onclick="showTab('geopt',  this)" style="display:none">Geopt Trajectory</button>
           <button class="tab-btn" id="btn-tab-vib"    data-tab="vib"    onclick="showTab('vib',    this)" style="display:none">Vibrations</button>
+          <button class="tab-btn" id="btn-tab-uvvis"  data-tab="uvvis"  onclick="showTab('uvvis',  this)" style="display:none">UV-Vis Spectrum</button>
         </div>
         <div id="plots-panels">
           <div class="tab-panel active" id="tab-scf">    <canvas id="c-scf"></canvas></div>
@@ -397,6 +398,7 @@
               <div id="vib-mode-list" class="vib-mode-list"></div>
             </div>
           </div>
+          <div class="tab-panel"        id="tab-uvvis">  <canvas id="c-uvvis"></canvas></div>
         </div>
       </div>
 
@@ -1181,13 +1183,101 @@ function renderGeoptChart(geopt) {
   });
 }
 
+function renderUVVisChart(tddft) {
+  destroyChart('uvvis');
+  const points = tddft.uvvis_points || [];
+  const roots = tddft.roots || [];
+  if (!points.length) return;
+
+  const ctx = document.getElementById('c-uvvis').getContext('2d');
+  const lineData = points.map(point => ({
+    x: point.wavelength_nm,
+    y: point.intensity,
+  }));
+  const sticks = roots
+    .filter(root => root.oscillator_strength > 0)
+    .map((root, idx) => ({
+      label: idx === 0 ? 'Oscillator strengths' : '',
+      data: [
+        {x: root.wavelength_nm, y: 0},
+        {x: root.wavelength_nm, y: root.oscillator_strength},
+      ],
+      borderColor: '#f0883e',
+      borderWidth: 1.5,
+      pointRadius: 0,
+      showLine: true,
+      fill: false,
+      _showLegend: idx === 0,
+    }));
+
+  charts['uvvis'] = new Chart(ctx, {
+    type: 'scatter',
+    data: {
+      datasets: [
+        {
+          type: 'line',
+          label: 'Broadened spectrum',
+          data: lineData,
+          parsing: false,
+          borderColor: '#58a6ff',
+          backgroundColor: 'rgba(88,166,255,0.10)',
+          borderWidth: 2,
+          pointRadius: 0,
+          tension: 0.18,
+          fill: true,
+        },
+        ...sticks,
+      ],
+    },
+    options: {
+      ...BASE_OPTS,
+      plugins: {
+        ...BASE_OPTS.plugins,
+        legend: {
+          labels: {
+            font: MF,
+            color: TICK_COLOR,
+            boxWidth: 8,
+            padding: 8,
+            filter: item => item.datasetIndex === 0 || sticks[item.datasetIndex - 1]?._showLegend,
+          },
+        },
+        tooltip: {
+          ...BASE_OPTS.plugins.tooltip,
+          callbacks: {
+            label: context => {
+              const {x, y} = context.parsed;
+              if (context.datasetIndex === 0) {
+                return ` λ = ${x.toFixed(2)} nm, I = ${y.toFixed(4)} arb`;
+              }
+              const root = roots[context.datasetIndex - 1];
+              return ` Root ${root.root}: λ = ${x.toFixed(2)} nm, f = ${y.toFixed(4)}`;
+            },
+          },
+        },
+      },
+      scales: {
+        x: {
+          ...BASE_OPTS.scales.x,
+          reverse: true,
+          title: {display: true, text: 'Wavelength (nm)', font: MF, color: TICK_COLOR},
+        },
+        y: {
+          ...BASE_OPTS.scales.y,
+          title: {display: true, text: 'Intensity / oscillator strength', font: MF, color: TICK_COLOR},
+        },
+      },
+    },
+  });
+}
+
 /* ═══════════════════════════════════════════════════════════════════════════
    RESULTS PANEL
 ═══════════════════════════════════════════════════════════════════════════ */
 function fmt(v, d=8) { return (v == null) ? '—' : v.toFixed(d); }
 
 function renderResults(data) {
-  const {level, basis, scf, mp2, casscf, geopt, molecule} = data;
+  const {level, basis, scf, mp2, casscf, geopt, molecule, tddft} = data;
   const isMP2 = level==='RMP2' || level==='UMP2';
   if (!scf && !geopt && !molecule) return;
 
@@ -1317,6 +1407,28 @@ function renderResults(data) {
     </div>`;
   }
 
+  if (tddft && tddft.roots && tddft.roots.length) {
+    const brightest = [...tddft.roots].sort(
+      (a, b) => b.oscillator_strength - a.oscillator_strength
+    )[0];
+    html += `<div class="r-card">
+      <div class="r-title">TDDFT / UV-Vis</div>
+      <div class="r-row"><span class="r-lbl">Excited roots</span>
+        <span class="r-val">${tddft.roots.length}</span></div>
+      ${tddft.uvvis_sigma_ev != null ? `<div class="r-row"><span class="r-lbl">Broadening</span>
+        <span class="r-val">${tddft.uvvis_sigma_ev.toFixed(3)} eV</span></div>` : ''}
+      ${brightest ? `<div class="r-divider"></div>
+      <div class="r-row"><span class="r-lbl">Brightest root</span>
+        <span class="r-val teal">#${brightest.root}</span></div>
+      <div class="r-row"><span class="r-lbl">Excitation</span>
+        <span class="r-val">${brightest.omega_ev.toFixed(4)} eV</span></div>
+      <div class="r-row"><span class="r-lbl">Wavelength</span>
+        <span class="r-val">${brightest.wavelength_nm.toFixed(2)} nm</span></div>
+      <div class="r-row"><span class="r-lbl">f</span>
+        <span class="r-val">${brightest.oscillator_strength.toFixed(4)}</span></div>` : ''}
+    </div>`;
+  }
+
   document.getElementById('results-data').innerHTML = html;
   document.getElementById('results-empty').style.display = 'none';
   document.getElementById('results-data').style.display  = 'block';
@@ -1360,7 +1472,7 @@ async function loadFromAPI() {
 }
 
 function applyData(data) {
-  const {level, basis, molecule, scf, mp2, casscf, geopt, freq,
+  const {level, basis, molecule, scf, mp2, casscf, geopt, freq, tddft,
          point_group, calculation_type, log_file} = data;
 
   // Populate info panel
@@ -1411,6 +1523,14 @@ function applyData(data) {
   if (freq) {
     renderVibPanel(freq);
     showTab('vib', document.querySelector('[data-tab="vib"]'));
+  }
+
+  // UV-Vis spectrum
+  const hasUVVis = tddft && tddft.uvvis_points && tddft.uvvis_points.length > 0;
+  document.getElementById('btn-tab-uvvis').style.display = hasUVVis ? '' : 'none';
+  if (hasUVVis) {
+    renderUVVisChart(tddft);
+    showTab('uvvis', document.querySelector('[data-tab="uvvis"]'));
   }
 
   renderResults(data);

--- a/visualizer/test_parser.py
+++ b/visualizer/test_parser.py
@@ -8,6 +8,8 @@ or directly:
 """
 
 import sys
+import tempfile
+import textwrap
 from pathlib import Path
 
 # Allow running from repo root without installation
@@ -368,6 +370,66 @@ def test_sa_casscf_root_energies():
     assert abs(roots[0].weight - 0.500) < 1e-3
     assert roots[1].root == 1
     assert abs(roots[1].energy - -74.5800888009) < 1e-7
+
+
+# ── TDDFT / UV-Vis ───────────────────────────────────────────────────────────
+
+def test_tddft_uvvis_from_log():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+
+        spectrum = tmp_path / "sample.uvvis.dat"
+        spectrum.write_text(
+            textwrap.dedent(
+                """\
+                # Gaussian-broadened UV-Vis spectrum
+                # sigma_eV = 0.150000
+                # Energy_eV Wavelength_nm Intensity_arb
+                   4.10000000    302.40000000      0.12500000
+                   4.20000000    295.20000000      0.25000000
+                """
+            ),
+            encoding="utf-8",
+        )
+
+        log = tmp_path / "sample.log"
+        log.write_text(
+            textwrap.dedent(
+                """\
+                [INF] TDDFT / Linear Response :     Semilocal XC response kernels are included
+
+                ------------------------------------------------------------------------------------------------------------------------------------
+                Root  Omega (Eh)      Omega (eV)    Lambda (nm)   f             mu_x (au)       mu_y (au)       mu_z (au)       |mu| (Debye)
+                ------------------------------------------------------------------------------------------------------------------------------------
+                1     0.15068731      4.100000      302.400       0.125000      0.000000        0.000000        0.456789        1.160000
+                2     0.15436261      4.200000      295.200       0.250000      0.000000        0.000000        0.612345        1.560000
+                ------------------------------------------------------------------------------------------------------------------------------------
+
+                [INF] UV-Vis Spectrum :             Wrote 400 Gaussian-broadened points to sample.uvvis.dat (sigma = 0.150 eV)
+                ------------------------------------------------------------------
+                Peak (eV)     Lambda (nm)     Intensity (arb)
+                ------------------------------------------------------------------
+                4.200000      295.200         0.250000
+                ------------------------------------------------------------------
+                """
+            ),
+            encoding="utf-8",
+        )
+
+        run = parse_log(log)
+        assert len(run.tddft_roots) == 2
+        assert run.tddft_roots[0].root == 1
+        assert abs(run.tddft_roots[0].omega_ev - 4.1) < 1e-8
+        assert abs(run.tddft_roots[1].wavelength_nm - 295.2) < 1e-8
+        assert abs(run.tddft_roots[1].oscillator_strength - 0.25) < 1e-8
+
+        assert run.uvvis_spectrum_path == "sample.uvvis.dat"
+        assert abs(run.uvvis_sigma_ev - 0.15) < 1e-8
+        assert len(run.uvvis_peaks) == 1
+        assert abs(run.uvvis_peaks[0].energy_ev - 4.2) < 1e-8
+        assert len(run.uvvis_points) == 2
+        assert abs(run.uvvis_points[0].wavelength_nm - 302.4) < 1e-8
+        assert abs(run.uvvis_points[1].intensity - 0.25) < 1e-8
 
 
 # ── Runner ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Extend the DFT linear-response driver so users can request a specific excited state and obtain a plottable absorption spectrum, then surface the new data through the parser and the web visualizer.

Driver and input (src/dft/driver.cpp, src/io/io.cpp, src/base/types.h)
- Add an `nroots` alias for `lr_nstates` and a new 1-based `root` keyword that filters the printed report to a single excited state while still solving enough roots for the requested index to exist
- Compute per-root vacuum wavelengths in nm and add a Lambda (nm) column to the linear-response report table
- Build a Gaussian-broadened UV-Vis spectrum (sigma = 0.150 eV, 400 uniform energy points) from all solved roots, write it to `<checkpoint>.uvvis.dat`, and print the strongest broadened peaks
- Return explicit errors when the requested root exceeds either the excitation-space dimension or the number of solved roots
- Store `_lr_root` on the DFT options struct and validate the new `nroots` / `root` keys in the input parser

Regression coverage (tests/)
- New `water_triplet_uks_tddft_root2_pbe_sto3g` case exercises the UKS spin-conserving Casida path with `nroots 3` + `root 2` and pins the DFT total energy plus the new "UV-Vis Spectrum :" log line and "Building ... with 3 solved roots" diagnostic
- Add the existing TDDFT regression's UV-Vis output file to the ignore list so it does not get committed during local runs

Visualizer (visualizer/)
- Parse the new TDDFT root table, the UV-Vis peak table, and the `*.uvvis.dat` spectrum file referenced from the log; expose them as `TDDFTRoot` / `UVVisPoint` records on `ParsedRun`
- Generalise the dash-separator regex so the wider 132-column TDDFT table is recognised alongside the existing 110-column SCF table
- Add a UV-Vis tab to the web app that renders the broadened spectrum with oscillator-strength sticks and a brightest-root summary card; surface charge / multiplicity from the parsed run
- Make `create_app` import lazily from `visualizer.__init__` so the parser tests can import without pulling in Flask
- Add a parser unit test covering TDDFT roots, the UV-Vis peak table, and on-disk spectrum file resolution

Documentation (README.md, docs/PLANCK_TEACHING_GUIDE.md, docs/index.html)
- Document the new `nroots` / `root` keywords and the Gaussian-broadened UV-Vis output, including the relationship between solved roots, reported roots, and the broadened spectrum