### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches: [ "devel" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/HemanthHaridas/planck-refactored/security/code-scanning/4](https://github.com/HemanthHaridas/planck-refactored/security/code-scanning/4)

Add an explicit `permissions` block to the workflow root so it applies to all jobs (including `build`) without changing behavior. For this file, the minimal required permission is:

- `contents: read`

This preserves existing functionality (`actions/checkout` and build/test steps) while enforcing least privilege for `GITHUB_TOKEN`.

Edit `.github/workflows/cmake-multi-platform.yml` by inserting `permissions:` after the `on:` trigger section and before `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
