### PR TITLE
Document wavefunction stability in README and fix bold rendering in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A quantum chemistry program implementing restricted, unrestricted, and restricte
 - **Conventional and Direct SCF** — ERI tensor stored once (conventional) or recomputed per iteration (direct); auto-selection based on system size
 - **DIIS** — convergence acceleration with optional automatic subspace restart
 - **Level shifting** — virtual orbital energy raising for open-shell convergence
+- **Wavefunction stability analysis** — orbital-Hessian eigenvalue check after SCF for three RHF channels (real-internal singlet `A+B`, complex-internal singlet `A−B`, and external triplet `A^T−B^T` for RHF→UHF) and two UHF channels (spin-conserving internal and a diagonal-approximation external GHF check). When an instability is detected, optional detect-and-follow rotates the orbitals along the lowest unstable mode (using a two-step broken-symmetry guess for triplet RHF→UHF: π/8 β HOMO–LUMO mix + adaptive eigenvector rotation) and re-converges SCF
 - **Symmetry detection** — point group via libmsym; standard-orientation coordinates
 - **MO symmetry** — irreducible representation labels assigned to each converged orbital; non-Abelian groups automatically use the largest Abelian subgroup; linear molecules handled separately
 - **Post-HF** — RMP2 and UMP2 correlation energy corrections; RMP2 natural orbital analysis; analytic RMP2 and UMP2 nuclear gradients; RCCSD for canonical closed-shell RHF references; teaching-oriented determinant-space UCCSD/UCCSDT prototypes for small UHF systems; RCCSDT with automatic backend dispatch across three tiers (determinant-space prototype, tensor production solver, tensor-optimized ccgen-driven backend); CASSCF and RASSCF multireference active-space calculations
@@ -208,6 +209,8 @@ SCF procedure and convergence settings.
 | `threshold` | int | ≥ 1 | `100` | Basis function count cutoff used by `scf_mode auto` to decide between conventional and direct. |
 | `guess` | enum | `hcore`, `sad`, `density`, `full` | `hcore` | Initial density guess. `sad`: Superposition of Atomic Densities. `density`: load density matrix from checkpoint. `full`: restore geometry and density from checkpoint. Falls back to `hcore` if the checkpoint is missing or incompatible. Cross-basis projection is applied automatically when the checkpoint basis differs from the current basis. |
 | `save_checkpoint` | bool | `.true.`, `.false.` | `.true.` | Write a `.hfchk` checkpoint file after successful convergence |
+| `stability_check` | bool | `.true.`, `.false.` | `.false.` | Run wavefunction stability analysis after SCF convergence. Builds the orbital Hessian in occupied-virtual MO space and reports the lowest eigenvalue of each channel (three RHF channels for closed-shell references, two UHF channels for unrestricted references). Negative eigenvalues indicate an orbital rotation that lowers the energy. Cost: \(O((n_v \cdot n_o)^2)\) memory per channel. |
+| `stability_follow` | bool | `.true.`, `.false.` | `.false.` | When an instability is detected, rotate the orbitals along the lowest unstable mode and re-run SCF. For external triplet RHF→UHF instabilities, Planck promotes the calculator to UHF and applies a two-step broken-symmetry guess (π/8 β HOMO–LUMO mix + adaptive ±step·R rotation). For internal instabilities, the rotation is applied within the same SCF type. Implies `stability_check`. |
 
 ### Section: `%begin_dft`
 
@@ -601,6 +604,53 @@ H     0.000000    0.756950    -0.468703
 H     0.000000   -0.756950    -0.468703
 %end_coords
 ```
+
+### Wavefunction stability — twisted ethylene, 3-21G
+
+<p align="justify">
+Set <code>stability_check .true.</code> to print the orbital-Hessian lowest eigenvalues after SCF convergence. Set <code>stability_follow .true.</code> to additionally rotate along any unstable mode and re-converge — this is the standard escape path when HCore lands on a broken-symmetry stationary point. Twisted ethylene is the canonical demonstration: HCore + <code>use_symm .false.</code> reaches a charge-localized RHF that is real-internally unstable, complex-internally unstable, and triplet-externally unstable; the follow promotes to UHF and re-converges to a real spin-broken stationary point.
+</p>
+
+```
+%begin_control
+    basis       3-21g
+    calculation energy
+    verbosity   normal
+    basis_type  cartesian
+%end_control
+
+%begin_scf
+    scf_type           rhf
+    use_diis           .true.
+    diis_dim           8
+    engine             os
+    guess              hcore
+    max_cycles         100
+    stability_check    .true.
+    stability_follow   .true.
+%end_scf
+
+%begin_geom
+    coord_type  cartesian
+    coord_units angstrom
+    use_symm    .false.
+%end_geom
+
+%begin_coords
+6
+0   1
+C    -0.669500    0.000000    0.000000
+C     0.669500    0.000000    0.000000
+H    -1.233698    0.927942    0.000000
+H    -1.233698   -0.927942    0.000000
+H     1.233698    0.000000    0.927942
+H     1.233698    0.000000   -0.927942
+%end_coords
+```
+
+<p align="justify">
+The teaching guide chapter <em>Wavefunction Stability Analysis</em> derives the three RHF channels, explains the SVD-based orbital rotation, and walks through a four-basis sweep that isolates a DIIS limit-cycle pathology specific to STO-3G with the HCore guess.
+</p>
 
 ### Analytic gradient — water, STO-3G
 

--- a/docs/PLANCK_TEACHING_GUIDE.md
+++ b/docs/PLANCK_TEACHING_GUIDE.md
@@ -747,15 +747,15 @@ Three observations are useful for teaching:
    minimal basis only sees the external triplet instability, λ ≈ −2.6 × 10⁻³.
    No second RHF basin is visible because the basis cannot represent the
    broken-symmetry RHF.
-2. **3-21G is the only basis where guess choice splits which RHF basin is
-   reached.** Pre-follow, HCore lands on a real-internally unstable RHF
-   stationary point (a saddle on the RHF manifold) and SAD lands on the
-   true RHF minimum 36 mEh lower. 6-31G and cc-pVDZ both have enough flex-
-   ibility that DIIS funnels both guesses into the same RHF basin (they
-   converge to identical Fock matrices to all printed digits).
-3. **For 6-31G and cc-pVDZ the converged RHF is itself real-internally
-   unstable.** The guess didn't matter because there's only one RHF basin
-   reachable from either guess — but that basin is not even an RHF minimum.
+2. **3-21G is the only basis where guess choice splits which RHF basin is reached.**
+   Pre-follow, HCore lands on a real-internally unstable RHF stationary point
+   (a saddle on the RHF manifold) and SAD lands on the true RHF minimum 36
+   mEh lower. 6-31G and cc-pVDZ both have enough flexibility that DIIS funnels
+   both guesses into the same RHF basin (they converge to identical Fock
+   matrices to all printed digits).
+3. **For 6-31G and cc-pVDZ the converged RHF is itself real-internally unstable.**
+   The guess didn't matter because there's only one RHF basin reachable from
+   either guess — but that basin is not even an RHF minimum.
 
 **After follow with `stability_follow .true., max_cycles 300, use_diis .true.`**:
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -727,8 +727,8 @@ n_o\)</span>) by the standard SVD trick: writing <span class="math-inline">\(R =
 <p>Three observations are useful for teaching:</p>
 <ol>
 <li><strong>STO-3G is too small to expose the real-internal RHF instability.</strong> The minimal basis only sees the external triplet instability, λ ≈ −2.6 × 10⁻³. No second RHF basin is visible because the basis cannot represent the broken-symmetry RHF.</li>
-<li>**3-21G is the only basis where guess choice splits which RHF basin is reached.** Pre-follow, HCore lands on a real-internally unstable RHF stationary point (a saddle on the RHF manifold) and SAD lands on the true RHF minimum 36 mEh lower. 6-31G and cc-pVDZ both have enough flex- ibility that DIIS funnels both guesses into the same RHF basin (they converge to identical Fock matrices to all printed digits).</li>
-<li>**For 6-31G and cc-pVDZ the converged RHF is itself real-internally unstable.** The guess didn&#x27;t matter because there&#x27;s only one RHF basin reachable from either guess — but that basin is not even an RHF minimum.</li>
+<li><strong>3-21G is the only basis where guess choice splits which RHF basin is reached.</strong> Pre-follow, HCore lands on a real-internally unstable RHF stationary point (a saddle on the RHF manifold) and SAD lands on the true RHF minimum 36 mEh lower. 6-31G and cc-pVDZ both have enough flexibility that DIIS funnels both guesses into the same RHF basin (they converge to identical Fock matrices to all printed digits).</li>
+<li><strong>For 6-31G and cc-pVDZ the converged RHF is itself real-internally unstable.</strong> The guess didn&#x27;t matter because there&#x27;s only one RHF basin reachable from either guess — but that basin is not even an RHF minimum.</li>
 </ol>
 <p><strong>After follow with <code>stability_follow .true., max_cycles 300, use_diis .true.</code></strong>:</p>
 <div class="table-wrap"><table>


### PR DESCRIPTION
README.md additions:

  - New Features bullet describing wavefunction stability analysis. Lists all five channels Planck implements (three RHF: real-internal A^S+B^S, complex-internal A^S-B^S, external triplet A^T-B^T; two UHF: spin-conserving internal and diagonal-approximation external GHF) and the detect-and-follow behavior, including the two-step broken-symmetry guess (π/8 β HOMO-LUMO mix + adaptive ±step·R rotation) used for the triplet RHF→UHF channel.

  - Two new rows in the %begin_scf keyword table: stability_check and stability_follow, both defaulting to .false. The descriptions cover cost (O((n_v·n_o)^2) memory per channel) and the follow strategy split between triplet RHF→UHF (broken-symmetry guess + UHF promotion) and internal instabilities (rotation within the same SCF type).

  - New runnable example "Wavefunction stability — twisted ethylene, 3-21G" using the same canonical demonstration molecule from the teaching guide case study, with a forward-link to the teaching guide chapter for the math derivation and the four-basis sweep.

docs/PLANCK_TEACHING_GUIDE.md fixes:

  - Two list-item bold spans in the new "Twisted Ethylene, Guess Sensitivity, and the STO-3G Pathology" case study were wrapping across hard line breaks, causing the markdown renderer to emit literal **…** in the HTML. Same anti-pattern as the earlier h4 fix: list-item continuations break <strong>. Collapsed both bold opens- and-closes onto single lines (items #2 and #3 of "Three observations are useful for teaching").

  - One soft-hyphen linebreak artifact ("flex- ibility") resulting from a hand-wrapped paragraph collapsed into the natural word "flexibility".

docs/index.html regenerated from the corrected markdown via docs/build_teaching_site.py. Verified: zero literal **…** survivors in the HTML, both previously-broken bold spans now emit as <strong>.