### PR TITLE
Add CIAH-style uphill basin-escape controls and dual SAD SA-CASSCF regressions.

### DIFF
--- a/docs/CASSCF_STATUS.md
+++ b/docs/CASSCF_STATUS.md
@@ -129,27 +129,28 @@ Tolerance: 1e-5 Eh (all pass well within this).
 
 Note: PySCF references for water and ethylene were updated to use the
 hcore-start converged values (both codes agree from this starting point).
-The water SA-2 SAD-start minimum (−74.7877865139 Eh, 13 mEh lower) has not
-been validated in Planck — see P3.
+The water SA-2 SAD-start minimum (−74.7877865139 Eh) is now matched in Planck
+when uphill acceptance is enabled (`mcscf_accept_uphill .true.`) — see P3.
 
 ---
 
 ## Remaining Work (Priority Order)
 
-### P0: SA stationarity assertion in the regression runner
+### P0: SA stationarity assertion in the regression runner — DONE (2026-05-01)
 
-`run_regressions.py` parses `casscf_sa_gnorm` (`sa_g=...` in the log) but
-never asserts it is below `tol_mcscf_grad` (default 1e-5). SA convergence
-should be a hard test criterion, not just a scraped metric.
+Two SA cases now gate on `casscf_sa_gnorm ≤ 1e-5` via the existing
+`metric_le` check type, alongside `casscf_total_energy` against the PySCF
+reference:
 
-**Deliverables:**
-- In `regression_cases.json`, for all SA test cases, add a `lte` check on
-  `casscf_sa_gnorm` with threshold 1e-5.
-- Also verify the final macro iteration did not fire the plateau escape path
-  (no `[WRN]` about plateau in the last pass). This can be a `files_not_contain`
-  type check if the runner supports it, or a manual grep in a wrapper script.
+- `water_casscf_sa2_sto3g` — water CAS(4,4)/STO-3G, 2 roots; final `sa_g ≈ 1.6e-08`.
+- `ethylene_casscf_sa2_sto3g` — ethylene CAS(4,4)/STO-3G, 2 roots, D2d; final `sa_g ≈ 3.9e-07`.
 
-**File:** `tests/run_regressions.py`, `tests/regression_cases.json`
+A future polish item is asserting that the final macro iteration did not
+fire the plateau escape path (no `[WRN]` about plateau). This would need a
+`files_not_contain` (or `not_contains_in_last_n_lines`) check type added to
+the runner.
+
+**File:** `tests/regression_cases.json`
 
 ---
 
@@ -181,19 +182,40 @@ FD-Newton path.
 
 ---
 
-### P3: Water SA-2 SAD-start validation
+### P3: Water SA-2 SAD-start validation — CLOSED (2026-05-02)
 
-From the hcore start, Planck and PySCF agree at −74.7751378 Eh. The PySCF
-SAD-start minimum (−74.7877865 Eh, 13 mEh lower) has not been tested in
-Planck. The SAD minimum may be the global SA minimum.
+We keep **both** SAD-start fixtures in regressions:
 
-**Deliverables:**
-- Add a water SA-2 input that uses the default (SAD) guess.
-- Run Planck; compare to PySCF SAD-start −74.7877865139 Eh.
-- If Planck finds the lower minimum: update the gate value and document.
-- If Planck stalls at the higher minimum: record as a known optimizer
-  limitation (the SA optimizer finds only local minima from some starting
-  points) and track as a future correctness item.
+1. `water_cas44_sto3g_sa2_sad.hfinp` (original behavior, no uphill)
+   - converges to **−74.7751377977 Eh** (upper/local SA basin).
+2. `water_cas44_sto3g_sa2_sad_uphill.hfinp` (`mcscf_accept_uphill .true.`)
+   - converges to **−74.7877864784 Eh**, matching the PySCF SAD-start value
+     **−74.7877865139 Eh** within `3.6e-08 Eh` (deeper basin).
+
+Both are gated in `tests/regression_cases.json` as:
+- `water_casscf_sa2_sto3g_sad_guess`
+- `water_casscf_sa2_sto3g_sad_guess_uphill`
+
+### Why both are kept
+
+- They validate **two intentional optimizer modes** (strict monotone vs
+  uphill-enabled basin escape), both of which are currently supported.
+- They protect against accidental regressions that would either:
+  - break the historical monotone landing (`−74.7751377977 Eh`), or
+  - break the PySCF-matching uphill landing (`−74.7877864784 Eh`).
+- They provide a stable A/B harness for future optimizer changes, so we can
+  distinguish "basin policy changed" from "numerical bug introduced".
+
+### Learnings
+
+- The water SA-2 SAD case is genuinely **multi-basin** under the current
+  orbital parameterization and trust-region controls.
+- The core blocker was not Hessian quality alone; it was **acceptance policy**:
+  allowing bounded uphill steps enables the barrier-crossing move.
+- Matching PySCF on this case requires not just AH/CIAH machinery, but also a
+  compatible step-acceptance strategy.
+- Keeping both fixtures codifies this: same method family, different accepted
+  basin depending on acceptance mode.
 
 ---
 

--- a/docs/PLANCK_TEACHING_GUIDE.md
+++ b/docs/PLANCK_TEACHING_GUIDE.md
@@ -2877,6 +2877,40 @@ reducing the true orbital gradient (stagnation), the driver switches to direct
 orbital-gradient probe steps and single-pair directional probes, letting the
 exact CASSCF energy screen pick the productive rotations.
 
+#### Why uphill climbing was required (water SA-2, SAD start)
+
+The water CAS(4,4)/STO-3G SA-2 SAD-start case is a useful teaching example
+because it has two nearby SA stationary basins:
+
+- **Upper/local basin** around `-74.7751377977 Eh`
+- **Deeper basin** around `-74.7877865 Eh` (PySCF SAD-start minimum)
+
+With strictly monotone acceptance, the optimizer can get trapped in the upper
+basin even when the SA gradient is tiny. The reason is specific to
+state-averaging: the weighted SA gradient can cancel across roots
+(\(g_{\mathrm{SA}}=\sum_r w_r g_r \approx 0\)) while individual per-root
+gradients are still sizable. In that regime, the physically useful move is
+often a **small uphill step** in \(E_{\mathrm{SA}}\) that crosses a barrier;
+the next macro step then descends into the deeper well.
+
+This is exactly what the PySCF CIAH/newton trajectory does on this system:
+it accepts a bounded uphill move and then takes a larger downhill move into the
+lower-energy basin. To mirror that behavior, Planck exposes
+`mcscf_accept_uphill` with an energy cap `mcscf_uphill_max_eh`.
+
+Planck now keeps two regression fixtures for this one input family:
+
+- `water_cas44_sto3g_sa2_sad.hfinp` (default monotone mode) validates the
+  historical upper-basin landing near `-74.7751377977 Eh`.
+- `water_cas44_sto3g_sa2_sad_uphill.hfinp` (`mcscf_accept_uphill .true.`)
+  validates the basin-escape path and lands near `-74.7877864784 Eh`,
+  matching PySCF SAD-start to within `~3.6e-08 Eh`.
+
+Keeping both is intentional: it teaches that AH/CIAH quality alone is not the
+whole story in SA-CASSCF; **acceptance policy is part of the algorithm**.
+The paired fixtures also prevent accidental drift in either mode
+(strict-monotone robustness or uphill-enabled global-basin reachability).
+
 The CI density matrices (1-RDM and 2-RDM) are built using exact
 creation/annihilation operators in the spin-orbital determinant basis with a
 determinant lookup table, ensuring the CI eigenvalue, density matrices, and

--- a/docs/index.html
+++ b/docs/index.html
@@ -1798,6 +1798,20 @@ F^{gen}_{pq} = \sum_r h_{pr} D_{rq} + \sum_{rst} (pr|st) d_{qrst}
 <h3 id="convergence-and-robustness">Convergence and Robustness</h3>
 <p>The orbital macro-step uses <strong>merit-function-based step selection</strong>: multiple candidate orbital steps (augmented-Hessian result, first micro-step, gradient fallback, and their pairwise averages) are each evaluated by a full CASSCF energy computation, and the step that minimizes <span class="math-inline">\(m = E_{\text{CAS}} + w\,\|\mathbf g\|^2\)</span> is accepted. This avoids the sign ambiguity that plagued earlier Cayley-map implementations and removes any dependence on DIIS extrapolation.</p>
 <p>When repeated macro-iterations accept only negligibly small steps without reducing the true orbital gradient (stagnation), the driver switches to direct orbital-gradient probe steps and single-pair directional probes, letting the exact CASSCF energy screen pick the productive rotations.</p>
+<h4 id="why-uphill-climbing-was-required-water-sa-2-sad-start">Why uphill climbing was required (water SA-2, SAD start)</h4>
+<p>The water CAS(4,4)/STO-3G SA-2 SAD-start case is a useful teaching example because it has two nearby SA stationary basins:</p>
+<ul>
+<li><strong>Upper/local basin</strong> around <code>-74.7751377977 Eh</code></li>
+<li><strong>Deeper basin</strong> around <code>-74.7877865 Eh</code> (PySCF SAD-start minimum)</li>
+</ul>
+<p>With strictly monotone acceptance, the optimizer can get trapped in the upper basin even when the SA gradient is tiny. The reason is specific to state-averaging: the weighted SA gradient can cancel across roots (<span class="math-inline">\(g_{\mathrm{SA}}=\sum_r w_r g_r \approx 0\)</span>) while individual per-root gradients are still sizable. In that regime, the physically useful move is often a <strong>small uphill step</strong> in <span class="math-inline">\(E_{\mathrm{SA}}\)</span> that crosses a barrier; the next macro step then descends into the deeper well.</p>
+<p>This is exactly what the PySCF CIAH/newton trajectory does on this system: it accepts a bounded uphill move and then takes a larger downhill move into the lower-energy basin. To mirror that behavior, Planck exposes <code>mcscf_accept_uphill</code> with an energy cap <code>mcscf_uphill_max_eh</code>.</p>
+<p>Planck now keeps two regression fixtures for this one input family:</p>
+<ul>
+<li><code>water_cas44_sto3g_sa2_sad.hfinp</code> (default monotone mode) validates the historical upper-basin landing near <code>-74.7751377977 Eh</code>.</li>
+<li><code>water_cas44_sto3g_sa2_sad_uphill.hfinp</code> (<code>mcscf_accept_uphill .true.</code>) validates the basin-escape path and lands near <code>-74.7877864784 Eh</code>, matching PySCF SAD-start to within <code>~3.6e-08 Eh</code>.</li>
+</ul>
+<p>Keeping both is intentional: it teaches that AH/CIAH quality alone is not the whole story in SA-CASSCF; <strong>acceptance policy is part of the algorithm</strong>. The paired fixtures also prevent accidental drift in either mode (strict-monotone robustness or uphill-enabled global-basin reachability).</p>
 <p>The CI density matrices (1-RDM and 2-RDM) are built using exact creation/annihilation operators in the spin-orbital determinant basis with a determinant lookup table, ensuring the CI eigenvalue, density matrices, and reconstructed energy are mutually consistent for all active-space sizes.</p>
 <p>At convergence, the active-space 1-RDM is diagonalized to yield <strong>natural orbitals</strong> with occupation numbers reported in descending order (<code>_cas_nat_occ</code>).</p>
 <p>Validation energies (RHF/STO-3G geometry unless noted):</p>

--- a/src/base/types.h
+++ b/src/base/types.h
@@ -484,6 +484,13 @@ namespace HartreeFock
         double tol_mcscf_energy = 1e-8;
         double tol_mcscf_grad = 1e-5;
 
+        // MCSCF orbital trust region. mcscf_max_rot caps the largest
+        // element of κ in each macro step (default 0.20). The Frobenius
+        // norm cap is held at 4× this value. Larger values let the
+        // optimizer take larger core-active rotations and may reach
+        // deeper SA basins; smaller values are more conservative.
+        double mcscf_max_rot = 0.20;
+
         // CASSCF / SA-CASSCF
         int nactele = 0; // number of active electrons
         int nactorb = 0; // number of active orbitals
@@ -503,6 +510,20 @@ namespace HartreeFock
 
         bool mcscf_debug_numeric_newton = false; // debug-only numeric Newton fallback
         bool mcscf_debug_commutator_rhs = false; // debug-only approximate commutator-only CI-response RHS
+
+        // Opt-in CIAH-style uphill step acceptance for SA-CASSCF basin escape.
+        // When false (default), the candidate selector is strictly monotone on
+        // (energy, merit, gradient) and convergence is gated on the SA gradient
+        // alone — bit-identical to historical behavior. When true, the selector
+        // additionally accepts trial steps whose quadratic model predicts a
+        // downhill move (model-trust filter), and convergence additionally
+        // requires the maximum per-root orbital gradient to be small. Useful
+        // for cases where the SA-weighted gradient vanishes while individual
+        // roots are still far from stationary (see docs/CASSCF_STATUS.md P3).
+        bool mcscf_accept_uphill = false;
+        // When mcscf_accept_uphill is on, this caps the largest uphill ΔE
+        // (Hartree) the model-trust filter will tolerate per macro step.
+        double mcscf_uphill_max_eh = 5e-3;
     };
 
     struct OptionsOutput

--- a/src/io/io.cpp
+++ b/src/io/io.cpp
@@ -751,6 +751,22 @@ namespace HartreeFock::IO
                      active_space.tol_mcscf_grad = std::stod(v);
                      return std::expected<void, std::string>{};
                  }},
+                {"mcscf_max_rot", [&active_space](const std::string &v) -> std::expected<void, std::string>
+                 {
+                     const double parsed = std::stod(v);
+                     if (!(parsed > 0.0))
+                         return std::unexpected("mcscf_max_rot must be positive");
+                     active_space.mcscf_max_rot = parsed;
+                     return std::expected<void, std::string>{};
+                 }},
+                {"mcscf_uphill_max_eh", [&active_space](const std::string &v) -> std::expected<void, std::string>
+                 {
+                     const double parsed = std::stod(v);
+                     if (!(parsed > 0.0))
+                         return std::unexpected("mcscf_uphill_max_eh must be positive");
+                     active_space.mcscf_uphill_max_eh = parsed;
+                     return std::expected<void, std::string>{};
+                 }},
 
                 {"ci_max_dim", [&active_space](const std::string &v) -> std::expected<void, std::string>
                  {
@@ -820,6 +836,7 @@ namespace HartreeFock::IO
 
             if (key == "use_diis" || key == "save_checkpoint" ||
                 key == "mcscf_debug_numeric_newton" || key == "mcscf_debug_commutator_rhs" ||
+                key == "mcscf_accept_uphill" ||
                 key == "stability_check" || key == "stability_follow")
             {
                 if (!(_iss >> value))
@@ -837,6 +854,8 @@ namespace HartreeFock::IO
                     active_space.mcscf_debug_numeric_newton = *parsed;
                 else if (key == "mcscf_debug_commutator_rhs")
                     active_space.mcscf_debug_commutator_rhs = *parsed;
+                else if (key == "mcscf_accept_uphill")
+                    active_space.mcscf_accept_uphill = *parsed;
                 else if (key == "stability_check")
                     scf._stability_check = *parsed;
                 else

--- a/src/post_hf/casscf/aug-hessian-orbital.cpp
+++ b/src/post_hf/casscf/aug-hessian-orbital.cpp
@@ -1,0 +1,290 @@
+#include "post_hf/casscf/aug-hessian-orbital.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace HartreeFock::Correlation::CASSCF
+{
+    namespace
+    {
+        // True when use_sym is on, both pair endpoints carry an irrep label,
+        // and those labels disagree. Symmetry-forbidden pairs are excluded
+        // from the variational parameter set so the AH solver never sees
+        // them as nonzero.
+        bool pair_blocked_by_symmetry(
+            const RotPair          &pair,
+            const std::vector<int> &mo_irreps,
+            bool                    use_sym)
+        {
+            if (!use_sym || mo_irreps.empty())
+                return false;
+            const int ip = (pair.p < static_cast<int>(mo_irreps.size())) ? mo_irreps[pair.p] : -1;
+            const int iq = (pair.q < static_cast<int>(mo_irreps.size())) ? mo_irreps[pair.q] : -1;
+            return ip >= 0 && iq >= 0 && ip != iq;
+        }
+
+        // Cap kappa element-wise at max_rot, mirroring the trust-region
+        // policy already used by augmented_hessian_step and
+        // diagonal_preconditioned_orbital_step. The CIAH solver itself does
+        // not impose a step cap; that is done here at the boundary.
+        Eigen::MatrixXd cap_step_norm(Eigen::MatrixXd kappa, double max_rot)
+        {
+            if (max_rot <= 0.0)
+                return kappa;
+            if (!kappa.allFinite())
+                return Eigen::MatrixXd::Zero(kappa.rows(), kappa.cols());
+            const double max_elem = kappa.cwiseAbs().maxCoeff();
+            if (max_elem > max_rot)
+                kappa *= max_rot / max_elem;
+            return kappa;
+        }
+    } // namespace
+
+    Eigen::VectorXd pack_rotation_matrix(
+        const Eigen::MatrixXd       &kappa,
+        const std::vector<RotPair>  &pairs,
+        const std::vector<int>      &mo_irreps,
+        bool                         use_sym)
+    {
+        const int npairs = static_cast<int>(pairs.size());
+        Eigen::VectorXd packed = Eigen::VectorXd::Zero(npairs);
+        if (kappa.size() == 0)
+            return packed;
+        for (int k = 0; k < npairs; ++k)
+        {
+            const auto &pair = pairs[static_cast<std::size_t>(k)];
+            if (pair_blocked_by_symmetry(pair, mo_irreps, use_sym))
+                continue;
+            packed(k) = kappa(pair.p, pair.q);
+        }
+        return packed;
+    }
+
+    Eigen::MatrixXd unpack_rotation_vector(
+        const Eigen::VectorXd       &x,
+        const std::vector<RotPair>  &pairs,
+        int                          nbasis)
+    {
+        Eigen::MatrixXd kappa = Eigen::MatrixXd::Zero(nbasis, nbasis);
+        const int npairs = static_cast<int>(pairs.size());
+        if (x.size() != npairs)
+            return kappa;
+        for (int k = 0; k < npairs; ++k)
+        {
+            const auto &pair = pairs[static_cast<std::size_t>(k)];
+            const double value = x(k);
+            kappa(pair.p, pair.q) =  value;
+            kappa(pair.q, pair.p) = -value;
+        }
+        return kappa;
+    }
+
+    AugHessianHopFn make_orbital_hessian_action(
+        const OrbitalHessianContext  *context,
+        const Eigen::MatrixXd        &F_I_mo,
+        const Eigen::MatrixXd        &F_A_mo,
+        int                           n_core,
+        int                           n_act,
+        int                           n_virt,
+        const std::vector<RotPair>   &pairs,
+        const std::vector<int>       &mo_irreps,
+        bool                          use_sym)
+    {
+        const int nbasis = n_core + n_act + n_virt;
+        // Capture by reference; the caller owns lifetime. Inside the closure
+        // we materialize the trial kappa, call delta_g_sa_action, then pack
+        // the result back into the AH solver's flat layout.
+        return [context,
+                &F_I_mo,
+                &F_A_mo,
+                n_core,
+                n_act,
+                n_virt,
+                nbasis,
+                &pairs,
+                &mo_irreps,
+                use_sym](const Eigen::VectorXd &x) -> Eigen::VectorXd {
+            const Eigen::MatrixXd R = unpack_rotation_vector(x, pairs, nbasis);
+            const Eigen::MatrixXd HR = delta_g_sa_action(
+                R,
+                context,
+                F_I_mo,
+                F_A_mo,
+                n_core,
+                n_act,
+                n_virt,
+                mo_irreps,
+                use_sym);
+            return pack_rotation_matrix(HR, pairs, mo_irreps, use_sym);
+        };
+    }
+
+    AugHessianGradFn make_orbital_gradient(
+        const Eigen::MatrixXd        &g_orb,
+        const std::vector<RotPair>   &pairs,
+        const std::vector<int>       &mo_irreps,
+        bool                          use_sym)
+    {
+        // Snapshot the gradient by value so the closure remains safe even
+        // if the caller's source matrix is reassigned between AH micro
+        // iterations.
+        Eigen::MatrixXd g_copy = g_orb;
+        return [g_copy = std::move(g_copy),
+                &pairs,
+                &mo_irreps,
+                use_sym]() -> Eigen::VectorXd {
+            return pack_rotation_matrix(g_copy, pairs, mo_irreps, use_sym);
+        };
+    }
+
+    AugHessianPrecondFn make_orbital_preconditioner(
+        const Eigen::MatrixXd        &F_I_mo,
+        const Eigen::MatrixXd        &F_A_mo,
+        const std::vector<RotPair>   &pairs,
+        const std::vector<int>       &mo_irreps,
+        bool                          use_sym,
+        double                        level_shift,
+        double                        denom_floor)
+    {
+        const int npairs = static_cast<int>(pairs.size());
+        // Pre-compute the diagonal Hessian denominators once: the F_sum
+        // matrix does not change inside a single CIAH call. The AH Ritz
+        // value is folded in per-call via `e`, matching the PySCF
+        // precond(x, e) = x / (h_diag - (e - level_shift)) shape.
+        Eigen::VectorXd h_diag(npairs);
+        const Eigen::MatrixXd F_sum = F_I_mo + F_A_mo;
+        for (int k = 0; k < npairs; ++k)
+        {
+            const auto &pair = pairs[static_cast<std::size_t>(k)];
+            if (pair_blocked_by_symmetry(pair, mo_irreps, use_sym))
+                h_diag(k) = 1.0;
+            else
+                h_diag(k) = hess_diag(F_sum, pair.p, pair.q);
+        }
+
+        return [h_diag = std::move(h_diag),
+                level_shift,
+                denom_floor,
+                &pairs,
+                &mo_irreps,
+                use_sym](const Eigen::VectorXd &x, double e) -> Eigen::VectorXd {
+            Eigen::VectorXd out(x.size());
+            for (Eigen::Index k = 0; k < x.size(); ++k)
+            {
+                const auto &pair = pairs[static_cast<std::size_t>(k)];
+                if (pair_blocked_by_symmetry(pair, mo_irreps, use_sym))
+                {
+                    out(k) = 0.0;
+                    continue;
+                }
+                double denom = (h_diag(k) + level_shift) - e;
+                // Mirror the floor used by augmented_hessian_step /
+                // diagonal_preconditioned_orbital_step so a near-zero
+                // denominator cannot produce an exploding correction.
+                if (std::abs(denom) < denom_floor)
+                    denom = (denom >= 0.0) ? denom_floor : -denom_floor;
+                out(k) = x(k) / denom;
+            }
+            // Renormalize to unit length: the bordered Davidson grows the
+            // Krylov basis from preconditioned residuals, so feeding back a
+            // raw direction (rather than its scale) keeps the subspace
+            // well-conditioned.
+            const double norm = out.norm();
+            if (std::isfinite(norm) && norm > 0.0)
+                out /= norm;
+            return out;
+        };
+    }
+
+    OrbitalAugHessianStep solve_orbital_augmented_hessian_step(
+        const Eigen::MatrixXd        &g_orb,
+        const Eigen::MatrixXd        &F_I_mo,
+        const Eigen::MatrixXd        &F_A_mo,
+        const OrbitalHessianContext  *context,
+        int                           n_core,
+        int                           n_act,
+        int                           n_virt,
+        double                        level_shift,
+        double                        max_rot,
+        const std::vector<int>       &mo_irreps,
+        bool                          use_sym,
+        const AugHessianOptions      &opts)
+    {
+        OrbitalAugHessianStep result;
+        const int nbasis = n_core + n_act + n_virt;
+        result.kappa = Eigen::MatrixXd::Zero(nbasis, nbasis);
+
+        const std::vector<RotPair> pairs = non_redundant_pairs(n_core, n_act, n_virt);
+        if (pairs.empty())
+            return result;
+
+        AugHessianGradFn    g_op    = make_orbital_gradient (g_orb,   pairs, mo_irreps, use_sym);
+        AugHessianHopFn     h_op    = make_orbital_hessian_action(
+            context, F_I_mo, F_A_mo, n_core, n_act, n_virt, pairs, mo_irreps, use_sym);
+        AugHessianPrecondFn precond = make_orbital_preconditioner(
+            F_I_mo, F_A_mo, pairs, mo_irreps, use_sym, level_shift);
+
+        // PySCF CIAH behavior: apply the AH step in a few "micro" updates,
+        // updating the gradient estimate as g <- g + H*dx between solves.
+        // This improves robustness in flat / ill-conditioned regions relative
+        // to taking one monolithic AH step.
+        const Eigen::VectorXd g0 = g_op();
+        Eigen::VectorXd g_est = g0;
+        const double g0_norm = g0.norm();
+
+        auto cap_packed_step = [&](Eigen::VectorXd x) -> Eigen::VectorXd
+        {
+            if (!x.allFinite())
+                return Eigen::VectorXd::Zero(x.size());
+            const double max_elem = x.cwiseAbs().maxCoeff();
+            if (max_rot > 0.0 && std::isfinite(max_elem) && max_elem > max_rot)
+                x *= max_rot / max_elem;
+            return x;
+        };
+
+        // Seed with steepest descent (-g) like PySCF's initial x0_guess.
+        Eigen::VectorXd x0 = g_est;
+        const double x0_norm = x0.norm();
+        if (std::isfinite(x0_norm) && x0_norm > 0.0)
+            x0 *= (-1.0 / x0_norm);
+        else
+            x0.setZero();
+
+        Eigen::VectorXd step_total = Eigen::VectorXd::Zero(g_est.size());
+        // Keep this small: this is one candidate among several in the macro cascade.
+        const int max_micro_updates = 3;
+        for (int micro = 0; micro < max_micro_updates; ++micro)
+        {
+            // Provide a mutable gradient to the generic AH solver.
+            const AugHessianGradFn g_live = [&g_est]() -> Eigen::VectorXd { return g_est; };
+            AugHessianResult ah = solve_augmented_hessian(h_op, g_live, precond, x0, opts);
+            if (micro == 0)
+                result.ah = ah;
+
+            Eigen::VectorXd dx = cap_packed_step(ah.x);
+            if (dx.size() == 0 || dx.cwiseAbs().maxCoeff() < 1e-12)
+                break;
+
+            step_total.noalias() += dx;
+            // Linearized gradient update: g <- g + H*dx (PySCF: g_orb += hdxi).
+            const Eigen::VectorXd Hdx = h_op(dx);
+            if (!Hdx.allFinite() || Hdx.size() != g_est.size())
+                break;
+            g_est.noalias() += Hdx;
+
+            // Next seed: use the last accepted increment, mirroring PySCF's x0_guess update.
+            x0 = dx;
+
+            const double g_norm = g_est.norm();
+            if (std::isfinite(g_norm) && std::isfinite(g0_norm) && g0_norm > 0.0 &&
+                g_norm < 0.2 * g0_norm)
+                break;
+        }
+
+        Eigen::MatrixXd kappa = unpack_rotation_vector(step_total, pairs, nbasis);
+        // Trust-region cap at boundary (same as diagonal augmented_hessian_step).
+        result.kappa = cap_step_norm(std::move(kappa), max_rot);
+        return result;
+    }
+
+} // namespace HartreeFock::Correlation::CASSCF

--- a/src/post_hf/casscf/aug-hessian-orbital.h
+++ b/src/post_hf/casscf/aug-hessian-orbital.h
@@ -1,0 +1,108 @@
+#ifndef HF_POSTHF_CASSCF_AUG_HESSIAN_ORBITAL_H
+#define HF_POSTHF_CASSCF_AUG_HESSIAN_ORBITAL_H
+
+#include "post_hf/casscf/aug-hessian.h"
+#include "post_hf/casscf/orbital.h"
+
+#include <Eigen/Core>
+
+#include <vector>
+
+namespace HartreeFock::Correlation::CASSCF
+{
+    // Adapter layer that packages the existing CASSCF orbital gradient and
+    // matrix-free Hessian action (delta_g_sa_action / hess_diag) into the
+    // generic AugHessianHopFn / AugHessianGradFn / AugHessianPrecondFn
+    // callbacks consumed by solve_augmented_hessian.
+    //
+    // Nothing here mutates global state or replaces the existing diagonal
+    // augmented_hessian_step. The intent is for the macro driver to call
+    // solve_orbital_augmented_hessian_step as one more candidate alongside
+    // sa-coupled / sa-grad-fallback / numeric-newton.
+
+    // Pack the upper triangle of an antisymmetric kappa matrix into the flat
+    // pair vector used by solve_augmented_hessian. The layout matches
+    // non_redundant_pairs(): one entry per (p, q) with p < q in different
+    // orbital blocks. Symmetry-forbidden pairs are zeroed in place so the
+    // packed vector contains only physically variable rotations.
+    Eigen::VectorXd pack_rotation_matrix(
+        const Eigen::MatrixXd       &kappa,
+        const std::vector<RotPair>  &pairs,
+        const std::vector<int>      &mo_irreps,
+        bool                         use_sym);
+
+    // Inverse of pack_rotation_matrix: scatter a flat pair vector into the
+    // antisymmetric (nbasis x nbasis) representation expected by
+    // delta_g_sa_action and apply_orbital_rotation.
+    Eigen::MatrixXd unpack_rotation_vector(
+        const Eigen::VectorXd       &x,
+        const std::vector<RotPair>  &pairs,
+        int                          nbasis);
+
+    // Build a Hessian-vector callback that wraps delta_g_sa_action. The
+    // returned closure captures every input by reference, so the caller is
+    // responsible for keeping F_I_mo / F_A_mo / context / pairs / mo_irreps
+    // alive for the entire CIAH solve.
+    AugHessianHopFn make_orbital_hessian_action(
+        const OrbitalHessianContext  *context,
+        const Eigen::MatrixXd        &F_I_mo,
+        const Eigen::MatrixXd        &F_A_mo,
+        int                           n_core,
+        int                           n_act,
+        int                           n_virt,
+        const std::vector<RotPair>   &pairs,
+        const std::vector<int>       &mo_irreps,
+        bool                          use_sym);
+
+    // Build a gradient callback that returns the packed (signed) g vector
+    // from a fixed orbital gradient matrix. The closure takes a copy of
+    // g_orb so the caller can free the source matrix without invalidating
+    // the AH solver.
+    AugHessianGradFn make_orbital_gradient(
+        const Eigen::MatrixXd        &g_orb,
+        const std::vector<RotPair>   &pairs,
+        const std::vector<int>       &mo_irreps,
+        bool                          use_sym);
+
+    // Build the diagonal Hessian preconditioner used inside CIAH Davidson.
+    // For each pair (p, q) the denominator is (h_pp_qq + level_shift) - e
+    // where e is the Ritz value passed in by the AH solver. denom_floor
+    // protects against tiny denominators in the same way the existing
+    // diagonal augmented_hessian_step does.
+    AugHessianPrecondFn make_orbital_preconditioner(
+        const Eigen::MatrixXd        &F_I_mo,
+        const Eigen::MatrixXd        &F_A_mo,
+        const std::vector<RotPair>   &pairs,
+        const std::vector<int>       &mo_irreps,
+        bool                          use_sym,
+        double                        level_shift,
+        double                        denom_floor = 1e-4);
+
+    // Top-level entry point. Builds the three callbacks, runs the CIAH
+    // Davidson, and returns the orbital step as an antisymmetric matrix
+    // capped at max_rot in element-wise infinity norm. Result.x carries the
+    // packed pair vector and the AH metadata so the macro driver can decide
+    // whether to accept the step.
+    struct OrbitalAugHessianStep
+    {
+        Eigen::MatrixXd  kappa;
+        AugHessianResult ah;
+    };
+
+    OrbitalAugHessianStep solve_orbital_augmented_hessian_step(
+        const Eigen::MatrixXd        &g_orb,
+        const Eigen::MatrixXd        &F_I_mo,
+        const Eigen::MatrixXd        &F_A_mo,
+        const OrbitalHessianContext  *context,
+        int                           n_core,
+        int                           n_act,
+        int                           n_virt,
+        double                        level_shift,
+        double                        max_rot,
+        const std::vector<int>       &mo_irreps,
+        bool                          use_sym,
+        const AugHessianOptions      &opts = AugHessianOptions{});
+
+} // namespace HartreeFock::Correlation::CASSCF
+
+#endif // HF_POSTHF_CASSCF_AUG_HESSIAN_ORBITAL_H

--- a/src/post_hf/casscf/aug-hessian.cpp
+++ b/src/post_hf/casscf/aug-hessian.cpp
@@ -1,0 +1,333 @@
+#include "post_hf/casscf/aug-hessian.h"
+
+#include <Eigen/Eigenvalues>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace HartreeFock::Correlation::CASSCF
+{
+    namespace
+    {
+        // Solve the bordered subspace eigenproblem
+        //     H_eff v = w * ovlp v
+        // with H_eff[0,0] = 0, H_eff[0,j] = g . x_j, H_eff[i,j] = x_i . (H x_j),
+        // ovlp[0,0] = 1, ovlp[i,j] = x_i . x_j. Both matrices are symmetrized
+        // before the eigensolve to absorb any drift from the matrix-free
+        // contractions. Returns the lowest eigenpair whose first component
+        // exceeds v0_min (or eigenpair 0 if none qualifies).
+        struct SubspaceMode
+        {
+            double          eigenvalue   = 0.0;
+            Eigen::VectorXd eigenvector;
+            double          v0           = 0.0;
+            bool            valid        = false;
+            int             chosen_index = -1;
+        };
+
+        SubspaceMode regular_step(
+            const Eigen::MatrixXd &heff,
+            const Eigen::MatrixXd &ovlp,
+            double                 v0_min,
+            double                 lindep)
+        {
+            SubspaceMode mode;
+            const Eigen::Index n = heff.rows();
+            if (n < 2 || ovlp.rows() != n)
+                return mode;
+
+            // Symmetrize and shift the overlap below lindep up to a small
+            // identity floor to keep the generalized eigensolve well posed.
+            Eigen::MatrixXd S = 0.5 * (ovlp + ovlp.transpose());
+            Eigen::MatrixXd H = 0.5 * (heff + heff.transpose());
+
+            Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> overlap_eig(S);
+            if (overlap_eig.info() != Eigen::Success)
+                return mode;
+
+            Eigen::VectorXd seigs = overlap_eig.eigenvalues();
+            Eigen::MatrixXd U     = overlap_eig.eigenvectors();
+            const double s_min    = seigs.minCoeff();
+            if (!(std::isfinite(s_min)) || s_min < lindep)
+                return mode;
+
+            // Whiten the bordered system into a standard symmetric eigenproblem:
+            //   X = U diag(1/sqrt(s)),   H_white = X^T H X.
+            Eigen::VectorXd inv_sqrt = seigs.array().rsqrt();
+            Eigen::MatrixXd X        = U * inv_sqrt.asDiagonal();
+            Eigen::MatrixXd H_white  = X.transpose() * H * X;
+            H_white                  = 0.5 * (H_white + H_white.transpose());
+
+            Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> eig(H_white);
+            if (eig.info() != Eigen::Success)
+                return mode;
+
+            const Eigen::VectorXd &w  = eig.eigenvalues();
+            const Eigen::MatrixXd  Vg = X * eig.eigenvectors();
+
+            // Pick the smallest eigenvalue with |v[0]| > v0_min. PySCF's
+            // ciah._regular_step (pyscf/soscf/ciah.py:295) defends against
+            // eigenvectors that would scale the orbital step by 1/v0 -> infty.
+            int chosen = -1;
+            for (Eigen::Index k = 0; k < Vg.cols(); ++k)
+            {
+                const double v0 = Vg(0, k);
+                if (std::abs(v0) > v0_min)
+                {
+                    chosen = static_cast<int>(k);
+                    break;
+                }
+            }
+            if (chosen < 0)
+                chosen = 0;
+
+            mode.eigenvalue   = w(chosen);
+            mode.eigenvector  = Vg.col(chosen);
+            mode.v0           = mode.eigenvector(0);
+            mode.valid        = true;
+            mode.chosen_index = chosen;
+            return mode;
+        }
+
+        // Modified Gram-Schmidt: orthogonalize v against each column of V
+        // already in the subspace, then normalize. Returns the norm of the
+        // residual; caller should reject the new vector if the norm is below
+        // the linear-dependence threshold.
+        double orthonormalize_against(
+            Eigen::VectorXd       &v,
+            const Eigen::MatrixXd &V,
+            double                 lindep)
+        {
+            for (Eigen::Index k = 0; k < V.cols(); ++k)
+            {
+                const double overlap = V.col(k).dot(v);
+                v.noalias() -= overlap * V.col(k);
+            }
+            const double norm = v.norm();
+            if (!(std::isfinite(norm)) || norm < lindep)
+                return 0.0;
+            v /= norm;
+            return norm;
+        }
+    } // namespace
+
+    AugHessianResult solve_augmented_hessian(
+        const AugHessianHopFn     &h_op,
+        const AugHessianGradFn    &g_op,
+        const AugHessianPrecondFn &precond,
+        const Eigen::VectorXd     &x0,
+        const AugHessianOptions   &opts)
+    {
+        AugHessianResult result;
+        result.x = Eigen::VectorXd::Zero(x0.size());
+
+        if (!h_op || !g_op || x0.size() == 0)
+            return result;
+
+        const Eigen::VectorXd g = g_op();
+        if (g.size() != x0.size())
+            return result;
+        const double g_norm = g.norm();
+        if (!(std::isfinite(g_norm)) || g_norm == 0.0)
+        {
+            result.converged = true;
+            return result;
+        }
+
+        const int    max_cycle    = std::max(1, opts.ah_max_cycle);
+        const int    max_subspace = std::max(1, std::min(opts.max_subspace, max_cycle));
+        const double lindep       = opts.ah_lindep;
+        const double v0_min       = opts.v0_min;
+
+        auto seed_initial_vector = [&]() -> Eigen::VectorXd {
+            // Seed with the supplied trial vector; if it is empty/degenerate
+            // fall back to the steepest-descent direction -g (the natural
+            // first Krylov vector of the bordered system).
+            Eigen::VectorXd seed = x0;
+            const double norm    = seed.norm();
+            if (!(std::isfinite(norm)) || norm < lindep)
+                seed = -g;
+            const double final_norm = seed.norm();
+            if (final_norm > 0.0 && std::isfinite(final_norm))
+                seed /= final_norm;
+            return seed;
+        };
+
+        Eigen::VectorXd seed = seed_initial_vector();
+        if (seed.size() != x0.size() || seed.norm() == 0.0)
+            return result;
+
+        Eigen::MatrixXd V (x0.size(), 1);
+        Eigen::MatrixXd HV(x0.size(), 1);
+        V.col(0)  = seed;
+        HV.col(0) = h_op(seed);
+        if (!HV.col(0).allFinite())
+            return result;
+
+        double prev_eigenvalue = std::numeric_limits<double>::infinity();
+        Eigen::VectorXd best_x = Eigen::VectorXd::Zero(x0.size());
+        double          best_residual = std::numeric_limits<double>::infinity();
+        double          best_eigenvalue = 0.0;
+        double          best_v0 = 0.0;
+
+        for (int iter = 1; iter <= max_cycle; ++iter)
+        {
+            const int m = static_cast<int>(V.cols());
+
+            // Bordered subspace matrices. Index 0 is the implicit "1"
+            // component of the augmented vector; indices 1..m correspond to
+            // the Krylov basis stored in V/HV.
+            Eigen::MatrixXd heff = Eigen::MatrixXd::Zero(m + 1, m + 1);
+            Eigen::MatrixXd ovlp = Eigen::MatrixXd::Identity(m + 1, m + 1);
+
+            for (int j = 0; j < m; ++j)
+            {
+                const double gxj = g.dot(V.col(j));
+                heff(0, j + 1)   = gxj;
+                heff(j + 1, 0)   = gxj;
+                for (int i = 0; i < m; ++i)
+                {
+                    heff(i + 1, j + 1) = V.col(i).dot(HV.col(j));
+                    ovlp(i + 1, j + 1) = V.col(i).dot(V.col(j));
+                }
+            }
+
+            SubspaceMode mode = regular_step(heff, ovlp, v0_min, lindep);
+            if (!mode.valid)
+                break;
+
+            // Reconstruct the trial step in the full space:
+            //   x_trial = sum_j (v_j / v0) * V[:, j]
+            // The 1/v0 normalization is what extracts the orbital step from
+            // the bordered eigenvector (ciah.py:_regular_step line 308).
+            Eigen::VectorXd coeffs(m);
+            const double safe_v0 = (std::abs(mode.v0) > 0.0) ? mode.v0
+                                                             : std::numeric_limits<double>::epsilon();
+            for (int j = 0; j < m; ++j)
+                coeffs(j) = mode.eigenvector(j + 1) / safe_v0;
+
+            Eigen::VectorXd x_trial   = V * coeffs;
+            Eigen::VectorXd Hx_trial  = HV * coeffs;
+
+            // Davidson residual for the bordered system:
+            //   r = H x + g - w x        (the leading 1 in the augmented
+            // vector contributes g; we already factored 1/v0 into x).
+            const double w           = mode.eigenvalue;
+            Eigen::VectorXd residual = Hx_trial + g - w * x_trial;
+            const double residual_norm = residual.norm();
+
+            // Cache the best finite iterate so we can fall back if the next
+            // micro-cycle stalls or breaks down.
+            if (std::isfinite(residual_norm) && residual_norm < best_residual)
+            {
+                best_residual    = residual_norm;
+                best_x           = x_trial;
+                best_eigenvalue  = w;
+                best_v0          = mode.v0;
+            }
+
+            result.iterations = iter;
+
+            // Convergence: bordered residual or eigenvalue stagnation.
+            const double eigenvalue_change = std::abs(w - prev_eigenvalue);
+            if (residual_norm < opts.ah_conv_tol || eigenvalue_change < opts.ah_conv_tol)
+            {
+                result.converged = true;
+                result.x         = x_trial;
+                result.eigenvalue = w;
+                result.v0         = mode.v0;
+                result.residual_norm = residual_norm;
+                result.orbital_only_fallback = false;
+                return result;
+            }
+            // PySCF early-exit: residual is small enough to feed back into
+            // the macro driver even if the eigenproblem is not fully
+            // converged yet (mc1step.py:ah_start_tol path).
+            if (iter >= opts.ah_start_cycle && residual_norm < opts.ah_start_tol)
+            {
+                result.converged = true;
+                result.x         = x_trial;
+                result.eigenvalue = w;
+                result.v0         = mode.v0;
+                result.residual_norm = residual_norm;
+                result.orbital_only_fallback = false;
+                return result;
+            }
+
+            prev_eigenvalue = w;
+
+            // Build the next Krylov vector from the preconditioned residual.
+            // Identity preconditioner is used when the caller supplied none,
+            // matching the safest fallback in ciah.davidson_cc.
+            Eigen::VectorXd next = precond
+                ? precond(residual, w - opts.ah_level_shift)
+                : residual;
+            if (!next.allFinite())
+                break;
+
+            const double next_norm = next.norm();
+            if (!(std::isfinite(next_norm)) || next_norm < lindep)
+                break;
+            next /= next_norm;
+
+            const double residual_after = orthonormalize_against(next, V, lindep);
+            if (residual_after == 0.0)
+                break;
+
+            // Restart at the subspace cap: keep the best iterate plus the
+            // newest correction so we do not lose progress already made.
+            if (m >= max_subspace)
+            {
+                Eigen::MatrixXd V_new (x0.size(), 0);
+                Eigen::MatrixXd HV_new(x0.size(), 0);
+
+                auto append_restart = [&](Eigen::VectorXd v) {
+                    const double v_norm = v.norm();
+                    if (!(std::isfinite(v_norm)) || v_norm < lindep)
+                        return;
+                    v /= v_norm;
+                    if (orthonormalize_against(v, V_new, lindep) == 0.0)
+                        return;
+                    V_new.conservativeResize(Eigen::NoChange, V_new.cols() + 1);
+                    HV_new.conservativeResize(Eigen::NoChange, HV_new.cols() + 1);
+                    V_new.col(V_new.cols() - 1)   = v;
+                    HV_new.col(HV_new.cols() - 1) = h_op(v);
+                };
+
+                append_restart(best_x);
+                append_restart(next);
+                if (V_new.cols() == 0)
+                    break;
+                V  = std::move(V_new);
+                HV = std::move(HV_new);
+                continue;
+            }
+
+            V.conservativeResize (Eigen::NoChange, m + 1);
+            HV.conservativeResize(Eigen::NoChange, m + 1);
+            V.col(m)  = next;
+            HV.col(m) = h_op(next);
+            if (!HV.col(m).allFinite())
+                break;
+        }
+
+        // Ran out of iterations (or broke down). Return the best iterate we
+        // saw; the caller can decide whether to accept it or fall back.
+        result.x             = best_x;
+        result.eigenvalue    = best_eigenvalue;
+        result.v0            = best_v0;
+        result.residual_norm = best_residual;
+
+        // Orbital-only fallback: if the chosen AH eigenvalue dropped below
+        // the floor, the bordered system is dominated by the gradient row
+        // and PySCF (ciah.py:301-306) drops the bordering and solves the
+        // pure orbital block. We signal this so the caller can decide
+        // whether to retry with a tighter step cap or switch solvers.
+        if (best_eigenvalue < opts.orbital_only_floor)
+            result.orbital_only_fallback = true;
+
+        return result;
+    }
+
+} // namespace HartreeFock::Correlation::CASSCF

--- a/src/post_hf/casscf/aug-hessian.h
+++ b/src/post_hf/casscf/aug-hessian.h
@@ -1,0 +1,89 @@
+#ifndef HF_POSTHF_CASSCF_AUG_HESSIAN_H
+#define HF_POSTHF_CASSCF_AUG_HESSIAN_H
+
+#include <Eigen/Core>
+
+#include <functional>
+
+namespace HartreeFock::Correlation::CASSCF
+{
+    // Generic Co-Iterative Augmented Hessian (CIAH) solver, modeled after
+    // pyscf/soscf/ciah.py:davidson_cc. The augmented system
+    //
+    //     [ 0   g^T ] [ 1 ]       [ 1 ]
+    //     [ g    H  ] [ x ]  = w  [ x ]
+    //
+    // is never assembled. Instead a Krylov subspace is built from the trial
+    // vector x and the Hessian-vector product H_op(x), and the lowest
+    // eigenpair of the bordered subspace matrix is extracted. The orbital
+    // step recovered from the eigenvector is x / v[0]; v[0] is the bordered
+    // first component (the implicit "1" in the augmented system).
+    //
+    // The callbacks give the caller full control over how the gradient and
+    // Hessian-vector product are computed without coupling this solver to
+    // the CASSCF data structures.
+    using AugHessianHopFn      = std::function<Eigen::VectorXd(const Eigen::VectorXd &)>;
+    using AugHessianGradFn     = std::function<Eigen::VectorXd()>;
+    using AugHessianPrecondFn  = std::function<Eigen::VectorXd(const Eigen::VectorXd &, double)>;
+
+    // Tunables follow the PySCF defaults documented in
+    // pyscf/mcscf/mc1step.py:707-733. The early-exit threshold ah_start_tol
+    // and minimum cycle count ah_start_cycle keep the inner micro-iteration
+    // cheap when the Krylov subspace is producing usable steps.
+    struct AugHessianOptions
+    {
+        double ah_conv_tol         = 1e-12;
+        double ah_start_tol        = 2.5;
+        int    ah_start_cycle      = 1;
+        int    ah_max_cycle        = 30;
+        double ah_lindep           = 1e-14;
+        double ah_level_shift      = 0.0;
+        // Mode-selection guard from ciah._regular_step (line 295). Eigenvectors
+        // with |v[0]| below this threshold imply the orbital step blows up and
+        // are skipped in favor of the next eigenvector.
+        double v0_min              = 0.1;
+        // Below this AH eigenvalue the bordered system is dropped and only the
+        // pure orbital block is solved (ciah lines 301-306).
+        double orbital_only_floor  = 1e-4;
+        // Maximum Krylov subspace size before restart. Bounded by ah_max_cycle.
+        int    max_subspace        = 30;
+    };
+
+    struct AugHessianResult
+    {
+        // Orbital step (or joint orb+CI step in the joint Newton extension)
+        // packed in the same layout the caller used to define h_op.
+        Eigen::VectorXd x;
+        // AH eigenvalue selected from the subspace.
+        double          eigenvalue     = 0.0;
+        // First component of the bordered eigenvector. The orbital scaling is
+        // 1/v0; small |v0| means the step would explode.
+        double          v0             = 0.0;
+        // Final residual norm of (H + g v0 - w v0) x.
+        double          residual_norm  = 0.0;
+        // Number of Davidson iterations actually run.
+        int             iterations     = 0;
+        // Whether the convergence test was satisfied (vs. early-exit / restart).
+        bool            converged      = false;
+        // True when the orbital-only fallback fired because the AH eigenvalue
+        // dropped below opts.orbital_only_floor.
+        bool            orbital_only_fallback = false;
+    };
+
+    // Solve the bordered AH eigenproblem with a CIAH-style Davidson inner
+    // loop. h_op must compute H*x for any trial vector x of size g.size().
+    // g_op is invoked once per outer iteration so the caller can re-evaluate
+    // the gradient if it depends on accumulated rotations (the keyframe path
+    // in mc1step.py:rotate_orb_cc). precond applies a preconditioner with
+    // the current Ritz value as the level-shift target; if it is null, an
+    // identity preconditioner is used.
+    AugHessianResult solve_augmented_hessian(
+        const AugHessianHopFn     &h_op,
+        const AugHessianGradFn    &g_op,
+        const AugHessianPrecondFn &precond,
+        const Eigen::VectorXd     &x0,
+        const AugHessianOptions   &opts);
+
+} // namespace HartreeFock::Correlation::CASSCF
+
+#endif // HF_POSTHF_CASSCF_AUG_HESSIAN_H

--- a/src/post_hf/casscf/casscf.cpp
+++ b/src/post_hf/casscf/casscf.cpp
@@ -3,6 +3,7 @@
 #include "io/logging.h"
 #include "base/tables.h"
 #include "post_hf/casscf.h"
+#include "post_hf/casscf/aug-hessian-orbital.h"
 #include "post_hf/casscf/casscf_driver_internal.h"
 #include "post_hf/casscf/casscf_utils.h"
 #include "post_hf/casscf/ci.h"
@@ -71,7 +72,9 @@ namespace
         const McscfState &current_state,
         const std::vector<RotPair> &opt_pairs,
         double tol_energy,
-        EvaluateFn &&evaluate)
+        EvaluateFn &&evaluate,
+        bool accept_uphill = false,
+        double uphill_max_eh = 5e-3)
     {
         CandidateSelection selection;
         selection.state = current_state;
@@ -142,6 +145,94 @@ namespace
                         current_state.roots, current_state.F_I_mo, opt_pairs, selection.step);
                 selection.predicted_delta = prediction.weighted_delta;
                 selection.max_root_predicted_delta_deviation = prediction.max_root_deviation;
+            }
+        }
+
+        // Pass 2: per-root-gradient-driven uphill acceptance (opt-in via
+        // mcscf_accept_uphill). Only fires when (a) the user opted in AND
+        // (b) Pass 1 above found no strict-monotone improvement. This keeps
+        // every existing case bit-identical at default settings — Pass 2 is
+        // skipped entirely when selection.accepted is already true.
+        //
+        // Pass 2 targets the "false SA stationary point" failure mode: the
+        // SA-weighted gradient g_SA = Σ w_I g_I has vanished by cancellation
+        // even though individual per-root gradients g_I remain large. The SA
+        // energy is at a local minimum of E_SA(κ), but each individual root's
+        // gradient still points into a nearby deeper basin. To escape, we
+        // accept a step that *increases* E_SA (bounded by uphill_max_eh) when
+        // it *reduces* the worst per-root orbital gradient. This is the signal
+        // PySCF's mc.newton() implicitly follows — its convergence is gated on
+        // the per-MO orbital gradient, so it keeps stepping past SA-stationary
+        // basins until per-root gradients also vanish.
+        if (accept_uphill && !selection.accepted)
+        {
+            double best_max_root_gnorm = current_state.max_root_gnorm;
+            for (const auto &candidate : candidates)
+            {
+                for (double scale : CASSCF_MACRO_STEP_SCALES)
+                {
+                    Eigen::MatrixXd trial_step = scale * candidate.step;
+                    if (trial_step.cwiseAbs().maxCoeff() < 1e-12)
+                        continue;
+
+                    const Eigen::MatrixXd rotated_coefficients =
+                        HartreeFock::Correlation::CASSCF::apply_orbital_rotation(
+                            coefficients, trial_step, overlap);
+                    auto trial_res = evaluate(rotated_coefficients, root_reference, false);
+                    if (!trial_res)
+                        continue;
+                    const auto &trial = *trial_res;
+
+                    const double actual_dE = trial.E_cas - current_state.E_cas;
+                    // Cap the worst uphill move we tolerate per macro step.
+                    if (actual_dE > uphill_max_eh)
+                        continue;
+                    // The trial must reduce the worst per-root orbital
+                    // gradient — otherwise it has not made progress toward a
+                    // true SA-stationary point where every root vanishes.
+                    //
+                    // Use a modest relative drop (0.05%) plus a tiny absolute
+                    // floor.  The old fixed 0.99 factor demanded a full 1%
+                    // reduction; at false SA-stationary points (|g_SA|≈0) the
+                    // available trust-region/probe steps often improve the
+                    // worst root by only ~0.3–0.7%, so every candidate was
+                    // rejected and the macro loop stalled.
+                    const double rel_floor =
+                        best_max_root_gnorm * (1.0 - 5.0e-4);
+                    const double abs_floor =
+                        best_max_root_gnorm -
+                        std::max(1.0e-8, 1.0e-6 * best_max_root_gnorm);
+                    const double max_root_threshold =
+                        std::max(rel_floor, abs_floor);
+                    if (!(trial.max_root_gnorm < max_root_threshold))
+                        continue;
+                    // No cap on the new SA gradient: at a false-stationary
+                    // point, |g_SA| ≈ 0 by construction; any meaningful
+                    // basin-escape probe will increase it (PySCF traces show
+                    // |g_SA| jumps from 1e-3 to 1e-1 across an escape step).
+                    // The actual_dE cap and the per-root reduction guard are
+                    // sufficient acceptance criteria.
+
+                    best_max_root_gnorm = trial.max_root_gnorm;
+                    const WeightedQuadraticModelPrediction prediction =
+                        build_weighted_root_quadratic_model_prediction(
+                            current_state.roots, current_state.F_I_mo, opt_pairs, trial_step);
+                    selection.accepted = true;
+                    selection.energy = trial.E_cas;
+                    selection.sa_gnorm = trial.gnorm;
+                    selection.merit = trial.E_cas + merit_weight * trial.gnorm * trial.gnorm;
+                    selection.state = trial;
+                    selection.coefficients = rotated_coefficients;
+                    selection.step = trial_step;
+                    selection.label =
+                        (std::abs(scale - 1.0) < 1e-12)
+                            ? candidate.label + "[uphill]"
+                            : std::format("{}@{:.5f}[uphill]", candidate.label, scale);
+                    selection.weighted_root_gnorm = trial.weighted_root_gnorm;
+                    selection.max_root_gnorm = trial.max_root_gnorm;
+                    selection.predicted_delta = prediction.weighted_delta;
+                    selection.max_root_predicted_delta_deviation = prediction.max_root_deviation;
+                }
             }
         }
 
@@ -341,6 +432,8 @@ namespace HartreeFock::Correlation::CASSCF
         const bool use_numeric_newton_debug = as.mcscf_debug_numeric_newton;
         const int numeric_newton_pair_limit = 64;
         const int ci_dense_threshold = 500;
+        const double max_rot = (as.mcscf_max_rot > 0.0) ? as.mcscf_max_rot : 0.20;
+        const double trust_radius_frob = 4.0 * max_rot;
 
         logging(LogLevel::Info, tag + " :",
                 std::format("Active space: ({:d}e, {:d}o)  n_core={:d}  n_virt={:d}  CI dim ≤ {:d}",
@@ -351,6 +444,9 @@ namespace HartreeFock::Correlation::CASSCF
         logging(LogLevel::Info, tag + " :",
                 std::format("CI response RHS: {}",
                             response_rhs_mode_name(configured_rhs_mode)));
+        logging(LogLevel::Info, tag + " :",
+                std::format("Orbital trust region: max_rot={:.3f}  Frobenius cap={:.3f}",
+                            max_rot, trust_radius_frob));
         if (configured_rhs_mode == ResponseRHSMode::CommutatorOnlyApproximate)
             logging(LogLevel::Warning, tag + " :",
                     "Using debug-only approximate commutator RHS instead of the default exact orbital-derivative response.");
@@ -561,26 +657,24 @@ namespace HartreeFock::Correlation::CASSCF
 
             Eigen::MatrixXd kappa = unpack_pairs(step);
             const double max_elem = kappa.cwiseAbs().maxCoeff();
-            if (max_elem > 0.20)
-                kappa *= 0.20 / max_elem;
+            if (max_elem > max_rot)
+                kappa *= max_rot / max_elem;
 
-            const double trust_radius = 0.80;
             const double frob = kappa.norm();
-            if (frob > trust_radius)
-                kappa *= trust_radius / frob;
+            if (frob > trust_radius_frob)
+                kappa *= trust_radius_frob / frob;
             return kappa;
         };
 
         auto cap_orbital_step = [&](Eigen::MatrixXd kappa)
         {
             const double max_elem = kappa.cwiseAbs().maxCoeff();
-            if (max_elem > 0.20)
-                kappa *= 0.20 / max_elem;
+            if (max_elem > max_rot)
+                kappa *= max_rot / max_elem;
 
-            const double trust_radius = 0.80;
             const double frob = kappa.norm();
-            if (frob > trust_radius)
-                kappa *= trust_radius / frob;
+            if (frob > trust_radius_frob)
+                kappa *= trust_radius_frob / frob;
             return kappa;
         };
 
@@ -655,7 +749,16 @@ namespace HartreeFock::Correlation::CASSCF
             const bool e_conv = macro > 1 && std::abs(st_current.E_cas - E_prev) < as.tol_mcscf_energy;
             const bool g_conv = sa_gradient_converged(st_current.gnorm, as.tol_mcscf_grad);
             const bool no_orb_rot = (st_current.gnorm == 0.0);
-            if ((e_conv && g_conv) || (g_conv && no_orb_rot))
+            // Under mcscf_accept_uphill, additionally require the per-root
+            // gradient to be small (within 100x of the SA tolerance) before
+            // declaring convergence. This keeps the optimizer iterating past
+            // SA-stationary points where individual roots are still large,
+            // letting the Pass-2 uphill branch attempt a basin escape.
+            const double max_root_gconv_tol = 100.0 * as.tol_mcscf_grad;
+            const bool per_root_g_conv =
+                !as.mcscf_accept_uphill ||
+                st_current.max_root_gnorm <= max_root_gconv_tol;
+            if (per_root_g_conv && ((e_conv && g_conv) || (g_conv && no_orb_rot)))
             {
                 if (macro == 1)
                 {
@@ -765,7 +868,7 @@ namespace HartreeFock::Correlation::CASSCF
                             n_act,
                             n_virt,
                             level_shift_local,
-                            0.20,
+                            max_rot,
                             all_mo_irr,
                             use_sym,
                             &root_hessian_ctx);
@@ -822,7 +925,7 @@ namespace HartreeFock::Correlation::CASSCF
                     n_act,
                     n_virt,
                     level_shift,
-                    0.20,
+                    max_rot,
                     all_mo_irr,
                     use_sym,
                     &sa_hessian_ctx,
@@ -842,7 +945,7 @@ namespace HartreeFock::Correlation::CASSCF
                 const RootResolvedOrbitalStepSet kappa_step_set = build_root_resolved_orbital_step_set(
                     st_current.roots, st_current.F_I_mo, nbasis,
                     n_core, n_act, n_virt,
-                    level_shift, 0.20, all_mo_irr, use_sym);
+                    level_shift, max_rot, all_mo_irr, use_sym);
                 const Eigen::MatrixXd &kappa = kappa_step_set.weighted;
                 kappa_total += kappa;
 
@@ -895,8 +998,8 @@ namespace HartreeFock::Correlation::CASSCF
                 }
             }
             const double max_k = kappa_total.cwiseAbs().maxCoeff();
-            if (max_k > 0.20)
-                kappa_total *= 0.20 / max_k;
+            if (max_k > max_rot)
+                kappa_total *= max_rot / max_k;
             const Eigen::MatrixXd &kappa_coupled = sa_coupled_result.orbital_step;
             const RootResolvedOrbitalStepSet kappa_grad_step_set =
                 build_root_resolved_gradient_fallback_step_set(st_current.roots);
@@ -915,7 +1018,33 @@ namespace HartreeFock::Correlation::CASSCF
                  (!coupled_step_reliable || stagnation_streak >= 2));
             const bool use_diagonal_fallback = stagnation_streak >= 2;
 
+            // CIAH augmented-Hessian step over the SA-averaged orbital
+            // gradient. Uses the same Hessian context the SA coupled solve
+            // already built, so the cost over the existing cascade is one
+            // extra Davidson loop driven by delta_g_sa_action. We always
+            // generate the candidate so the merit selector can compare it
+            // against sa-coupled; it only wins when the bordered eigenvalue
+            // is well-conditioned and the resulting kappa survives the cap.
+            const OrbitalAugHessianStep sa_aug_hess =
+                solve_orbital_augmented_hessian_step(
+                    st_current.g_orb,
+                    st_current.F_I_mo,
+                    st_current.F_A_mo,
+                    &sa_hessian_ctx,
+                    n_core,
+                    n_act,
+                    n_virt,
+                    level_shift,
+                    max_rot,
+                    all_mo_irr,
+                    use_sym);
+            const Eigen::MatrixXd &kappa_aug_hess = sa_aug_hess.kappa;
+
             append_candidate_step(step_candidates, kappa_coupled, "sa-coupled");
+            if (sa_aug_hess.kappa.allFinite() &&
+                sa_aug_hess.kappa.cwiseAbs().maxCoeff() > 1e-12 &&
+                !sa_aug_hess.ah.orbital_only_fallback)
+                append_candidate_step(step_candidates, kappa_aug_hess, "sa-aug-hessian");
             if (use_numeric_newton_fallback)
                 append_candidate_step(step_candidates, kappa_newton, "numeric-newton");
             if (use_diagonal_fallback)
@@ -952,7 +1081,7 @@ namespace HartreeFock::Correlation::CASSCF
                         break;
 
                     const double signed_probe =
-                        (probe_signal.weighted_signed(k) >= 0.0) ? -0.20 : 0.20;
+                        (probe_signal.weighted_signed(k) >= 0.0) ? -max_rot : max_rot;
                     append_candidate_step(
                         step_candidates,
                         build_single_pair_probe_step(k, signed_probe),
@@ -973,7 +1102,9 @@ namespace HartreeFock::Correlation::CASSCF
                     st_current,
                     opt_pairs,
                     as.tol_mcscf_energy,
-                    evaluate);
+                    evaluate,
+                    as.mcscf_accept_uphill,
+                    as.mcscf_uphill_max_eh);
 
             if (accepted_candidate.accepted)
             {
@@ -1076,7 +1207,12 @@ namespace HartreeFock::Correlation::CASSCF
             const bool e_conv_post = macro > 1 && std::abs(dE) < as.tol_mcscf_energy;
             const bool g_conv_post = sa_gradient_converged(reported_gnorm, as.tol_mcscf_grad);
             const bool no_orb_rot_post = (reported_gnorm == 0.0);
-            if ((e_conv_post && g_conv_post) || (g_conv_post && no_orb_rot_post))
+            const double max_root_gconv_tol_post = 100.0 * as.tol_mcscf_grad;
+            const bool per_root_g_conv_post =
+                !as.mcscf_accept_uphill ||
+                reported_max_root_gnorm <= max_root_gconv_tol_post;
+            if (per_root_g_conv_post &&
+                ((e_conv_post && g_conv_post) || (g_conv_post && no_orb_rot_post)))
             {
                 converged = true;
                 break;

--- a/src/post_hf/casscf/casscf_driver_internal.cpp
+++ b/src/post_hf/casscf/casscf_driver_internal.cpp
@@ -338,23 +338,24 @@ namespace HartreeFock::Correlation::CASSCF
         std::vector<CandidateStep> &candidates,
         const std::vector<Eigen::MatrixXd> &root_steps,
         const std::string &base_label,
-        bool cap_steps)
+        bool cap_steps,
+        double max_rot)
     {
         const HartreeFock::index_t root_count =
             static_cast<HartreeFock::index_t>(root_steps.size());
+        const double trust_radius_frob = 4.0 * max_rot;
         for (HartreeFock::index_t root = 0; root < root_count; ++root)
         {
             Eigen::MatrixXd step = root_steps[static_cast<std::size_t>(root)];
             if (cap_steps)
             {
                 const double max_elem = step.cwiseAbs().maxCoeff();
-                if (max_elem > 0.20)
-                    step *= 0.20 / max_elem;
+                if (max_elem > max_rot)
+                    step *= max_rot / max_elem;
 
-                const double trust_radius = 0.80;
                 const double frob = step.norm();
-                if (frob > trust_radius)
-                    step *= trust_radius / frob;
+                if (frob > trust_radius_frob)
+                    step *= trust_radius_frob / frob;
             }
             append_candidate_step(
                 candidates,

--- a/src/post_hf/casscf/casscf_driver_internal.h
+++ b/src/post_hf/casscf/casscf_driver_internal.h
@@ -210,7 +210,8 @@ namespace HartreeFock::Correlation::CASSCF
         std::vector<CandidateStep> &candidates,
         const std::vector<Eigen::MatrixXd> &root_steps,
         const std::string &base_label,
-        bool cap_steps);
+        bool cap_steps,
+        double max_rot = 0.20);
 } // namespace HartreeFock::Correlation::CASSCF
 
 #endif // HF_POSTHF_CASSCF_DRIVER_INTERNAL_H

--- a/tests/benchmarks/casscf/pyscf_reference/pyscf_reference_energies.md
+++ b/tests/benchmarks/casscf/pyscf_reference/pyscf_reference_energies.md
@@ -31,6 +31,13 @@ See `docs/CASSCF_STATUS.md` for full implementation status and remaining work.
 | water_cas44_sto3g_sa2 | CAS(4e,4o) | STO-3G | 2 | −74.7751377977 | −74.7751378317 | 3.4e-08 | **PASS** |
 | ethylene_cas44_sto3g_sa2 | CAS(4e,4o) | STO-3G | 2 | −77.0034974301 | −77.0034974774 | 4.7e-08 | **PASS** |
 
+### SAD-guess companions (P3 update, 2026-05-02)
+
+| Input | Active space | Basis | Roots | Guess | Planck SA / Eh | PySCF SAD-start / Eh | Delta / Eh | Note |
+|---|---|---|---|---|---|---|---|---|
+| water_cas44_sto3g_sa2_sad | CAS(4e,4o) | STO-3G | 2 | sad (original) | −74.7751377977 | −74.7877865139 | 1.26e-02 | Baseline monotone SAD landing (upper/local SA basin). Kept as regression control. |
+| water_cas44_sto3g_sa2_sad_uphill | CAS(4e,4o) | STO-3G | 2 | sad + `mcscf_accept_uphill` | −74.7877864784 | −74.7877865139 | 3.6e-08 | Uphill-enabled landing matches PySCF SAD-start basin. |
+
 ---
 
 ## Reference energy notes
@@ -38,12 +45,15 @@ See `docs/CASSCF_STATUS.md` for full implementation status and remaining work.
 ### Water CAS(4,4) SS
 PySCF references use the hcore-start converged values (both codes start from
 the same RHF after the d2d branch-preservation fix, commit 46aa199).
-The PySCF SAD-start minimum for water SA-2 (−74.7877865139 Eh, 13 mEh lower)
-has not been validated in Planck — see `docs/CASSCF_STATUS.md` item P4.
+The PySCF SAD-start minimum for water SA-2 (−74.7877865139 Eh) is now matched
+within 3.6e-08 Eh by Planck when `mcscf_accept_uphill .true.` is enabled in the
+SAD-guess companion input. See `docs/CASSCF_STATUS.md` item P3.
 
 ### Water SA-2
-Both codes converge from `guess hcore` to −74.7751378 Eh. The PySCF SAD-start
-minimum is lower and has not been compared.
+Both codes converge from `guess hcore` to −74.7751378 Eh. For `guess sad`,
+Planck reaches −74.7877864784 Eh when uphill acceptance is enabled
+(`mcscf_accept_uphill .true.`), matching the PySCF SAD-start basin to
+3.6e-08 Eh.
 
 ### Twisted ethylene SA-2
 Both codes converge from `guess hcore` to −77.0034974 Eh. Planck and PySCF

--- a/tests/benchmarks/casscf/pyscf_reference/water_cas44_sto3g_sa2_sad.hfinp
+++ b/tests/benchmarks/casscf/pyscf_reference/water_cas44_sto3g_sa2_sad.hfinp
@@ -1,0 +1,36 @@
+%begin_control
+    basis       sto-3g
+    calculation energy
+    verbosity   normal
+    basis_type  cartesian
+%end_control
+
+%begin_scf
+    scf_type    rhf
+    correlation casscf
+    use_diis    .true.
+    diis_dim    8
+    engine      rys
+    guess       sad
+    nactele     4
+    nactorb     4
+    nroots      2
+    mcscf_max_iter  100
+    mcscf_micro_per_macro  8
+    tol_mcscf_energy  1e-8
+    tol_mcscf_grad    1e-5
+%end_scf
+
+%begin_geom
+    coord_type  cartesian
+    coord_units angstrom
+    use_symm    .false.
+%end_geom
+
+%begin_coords
+3
+0   1
+O    0.000000    0.000000    0.117176
+H    0.000000    0.757005   -0.468704
+H    0.000000   -0.757005   -0.468704
+%end_coords

--- a/tests/benchmarks/casscf/pyscf_reference/water_cas44_sto3g_sa2_sad_uphill.hfinp
+++ b/tests/benchmarks/casscf/pyscf_reference/water_cas44_sto3g_sa2_sad_uphill.hfinp
@@ -1,0 +1,37 @@
+%begin_control
+    basis       sto-3g
+    calculation energy
+    verbosity   normal
+    basis_type  cartesian
+%end_control
+
+%begin_scf
+    scf_type    rhf
+    correlation casscf
+    use_diis    .true.
+    diis_dim    8
+    engine      rys
+    guess       sad
+    mcscf_accept_uphill .true.
+    nactele     4
+    nactorb     4
+    nroots      2
+    mcscf_max_iter  100
+    mcscf_micro_per_macro  8
+    tol_mcscf_energy  1e-8
+    tol_mcscf_grad    1e-5
+%end_scf
+
+%begin_geom
+    coord_type  cartesian
+    coord_units angstrom
+    use_symm    .false.
+%end_geom
+
+%begin_coords
+3
+0   1
+O    0.000000    0.000000    0.117176
+H    0.000000    0.757005   -0.468704
+H    0.000000   -0.757005   -0.468704
+%end_coords

--- a/tests/pyscf/diagnose_water_sa2_basin.py
+++ b/tests/pyscf/diagnose_water_sa2_basin.py
@@ -1,0 +1,146 @@
+"""
+Diagnostic for the water SA-CASSCF(4,4)/STO-3G two-basin problem (P3).
+
+Demonstrates that:
+1. PySCF reaches the same SA minimum (-74.7877865 Eh) regardless of init_guess.
+2. Both PySCF and Planck land at the same RHF stationary point.
+3. Both pick the same active space (HOMO-1, HOMO, LUMO, LUMO+1).
+4. PySCF's converged active orbitals contain a large (~80%) admixture of a
+   deeper occupied RHF orbital (RHF MO 2, σ_OH bonding) — i.e. PySCF performed
+   a large core-active rotation that Planck's trust-region-capped optimizer
+   does not take from the same starting orbitals.
+5. Per-root orbital gradients are large at PySCF's convergence too (|g_max| ~
+   3.7e-2), but cancel pairwise; this matches Planck's behaviour, so the
+   difference is in the basin reached, not in the SA convergence criterion.
+
+Re-run this whenever the Planck SA optimizer changes to check whether the
+deeper basin becomes reachable.
+
+Reference: docs/CASSCF_STATUS.md item P3.
+"""
+
+import numpy as np
+from pyscf import gto, scf, mcscf
+from pyscf.fci import direct_spin1
+from pyscf.mcscf.mc1step import gen_g_hop
+
+
+GEOM = """
+O   0.000000   0.000000   0.117176
+H   0.000000   0.757005  -0.468704
+H   0.000000  -0.757005  -0.468704
+"""
+
+PLANCK_SA_LOCAL = -74.7751377977
+PYSCF_SA_GLOBAL = -74.7877865139
+
+
+def build_mol():
+    mol = gto.Mole()
+    mol.atom = GEOM
+    mol.basis = "sto-3g"
+    mol.cart = True
+    mol.symmetry = False
+    mol.verbose = 0
+    mol.build()
+    return mol
+
+
+def run_pyscf(init_guess: str):
+    mol = build_mol()
+    mf = scf.RHF(mol)
+    mf.init_guess = init_guess
+    mf.conv_tol = 1e-12
+    mf.kernel()
+    mc = mcscf.CASSCF(mf, 4, 4)
+    mc = mc.state_average_([0.5, 0.5])
+    mc.conv_tol = 1e-9
+    mc.conv_tol_grad = 1e-6
+    mc.kernel()
+    return mol, mf, mc
+
+
+def report_basin_independence():
+    print("=" * 72)
+    print("(1) PySCF guess-independence")
+    print("=" * 72)
+    print(f"{'Guess':12s} {'RHF':>16s} {'CAS root 0':>16s} {'CAS root 1':>16s} {'SA':>16s}")
+    for guess in ["hcore", "1e", "minao", "atom", "huckel"]:
+        try:
+            _, mf, mc = run_pyscf(guess)
+            sa = sum(0.5 * e for e in mc.e_states)
+            print(f"{guess:12s} {mf.e_tot:>16.10f} {mc.e_states[0]:>16.10f} {mc.e_states[1]:>16.10f} {sa:>16.10f}")
+        except Exception as exc:
+            print(f"{guess:12s} FAILED: {exc}")
+
+
+def report_orbital_decomposition():
+    print()
+    print("=" * 72)
+    print("(2-4) PySCF converged active orbital decomposition")
+    print("=" * 72)
+    mol, mf, mc = run_pyscf("atom")
+    S = mol.intor("int1e_ovlp")
+    ncore, ncas = mc.ncore, mc.ncas
+    mo_act = mc.mo_coeff[:, ncore:ncore + ncas]
+    proj = mf.mo_coeff.T @ S @ mo_act
+    print(f"  Active space: ncore={ncore}, ncas={ncas}")
+    print(f"  Active MO indices in PySCF MO order: [{ncore}..{ncore + ncas - 1}]")
+    from pyscf.mcscf import addons
+    _, _, occ_nat = addons.cas_natorb(mc)
+    print(f"  Natural occupations: {occ_nat[ncore:ncore + ncas]}")
+    print()
+    print("  Decomposition of converged active CAS orbitals onto canonical RHF:")
+    for i in range(ncas):
+        print(f"    CAS active MO {i}:")
+        for j in range(mf.mo_coeff.shape[1]):
+            c = proj[j, i]
+            if abs(c) > 0.05:
+                print(f"      RHF MO {j} (E={mf.mo_energy[j]:+.4f}):  {c:+.4f}  ({c**2 * 100:5.1f}%)")
+    return mol, mf, mc
+
+
+def report_per_root_gradients(mol, mf, mc):
+    print()
+    print("=" * 72)
+    print("(5) Per-root vs SA orbital gradient at PySCF convergence")
+    print("=" * 72)
+    ncas = mc.ncas
+    nelec = mc.nelecas
+    weights = mc.weights
+    eris = mc.ao2mo(mc.mo_coeff)
+    per_state_dm1, per_state_dm2 = [], []
+    for civec in mc.ci:
+        dm1, dm2 = direct_spin1.make_rdm12(civec, ncas, nelec)
+        per_state_dm1.append(dm1)
+        per_state_dm2.append(dm2)
+    sa_dm1 = sum(w * d for w, d in zip(weights, per_state_dm1))
+    sa_dm2 = sum(w * d for w, d in zip(weights, per_state_dm2))
+    for i, (dm1, dm2) in enumerate(zip(per_state_dm1, per_state_dm2)):
+        g, _, _, _ = gen_g_hop(mc, mc.mo_coeff, 0, dm1, dm2, eris=eris)
+        print(f"  Per-root  (state {i}): |g_orb|_max = {np.max(np.abs(g)):.3e}    ||g_orb|| = {np.linalg.norm(g):.3e}")
+    g_sa, _, _, _ = gen_g_hop(mc, mc.mo_coeff, 0, sa_dm1, sa_dm2, eris=eris)
+    print(f"  SA-weighted        : |g_orb|_max = {np.max(np.abs(g_sa)):.3e}    ||g_orb|| = {np.linalg.norm(g_sa):.3e}")
+
+
+def report_basin_summary(mc):
+    print()
+    print("=" * 72)
+    print("Summary")
+    print("=" * 72)
+    sa = sum(0.5 * e for e in mc.e_states)
+    print(f"  PySCF SA energy (this run):    {sa:.10f} Eh")
+    print(f"  PySCF SA energy (P3 reference):{PYSCF_SA_GLOBAL:+.10f} Eh   delta {abs(sa - PYSCF_SA_GLOBAL):.2e}")
+    print(f"  Planck SA energy (P3 gated):   {PLANCK_SA_LOCAL:.10f} Eh")
+    print(f"  Basin gap (Planck - PySCF):    {(PLANCK_SA_LOCAL - PYSCF_SA_GLOBAL) * 1000:+.3f} mEh")
+
+
+def main():
+    report_basin_independence()
+    mol, mf, mc = report_orbital_decomposition()
+    report_per_root_gradients(mol, mf, mc)
+    report_basin_summary(mc)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/regression_cases.json
+++ b/tests/regression_cases.json
@@ -688,6 +688,65 @@
         {"type": "metric_eq", "metric": "point_group", "expected": "D2d"},
         {"type": "metric_close", "metric": "casscf_total_energy", "expected": -77.5145223873, "atol": 1e-9}
       ]
+    },
+    {
+      "id": "water_casscf_sa2_sto3g",
+      "input": "tests/benchmarks/casscf/pyscf_reference/water_cas44_sto3g_sa2.hfinp",
+      "tags": ["extended"],
+      "expected_exit_code": 0,
+      "contains": [
+        "CASSCF :                      Converged.",
+        "State-averaged over 2 roots :"
+      ],
+      "checks": [
+        {"type": "metric_close", "metric": "casscf_total_energy", "expected": -74.7751377977, "atol": 1e-9},
+        {"type": "metric_le",    "metric": "casscf_sa_gnorm",     "value":     1e-5}
+      ]
+    },
+    {
+      "id": "water_casscf_sa2_sto3g_sad_guess",
+      "input": "tests/benchmarks/casscf/pyscf_reference/water_cas44_sto3g_sa2_sad.hfinp",
+      "tags": ["extended"],
+      "expected_exit_code": 0,
+      "contains": [
+        "CASSCF :                      Converged.",
+        "State-averaged over 2 roots :"
+      ],
+      "checks": [
+        {"type": "metric_close", "metric": "casscf_total_energy", "expected": -74.7751377977, "atol": 1e-9},
+        {"type": "metric_le",    "metric": "casscf_sa_gnorm",     "value":     1e-5}
+      ]
+    },
+    {
+      "id": "water_casscf_sa2_sto3g_sad_guess_uphill",
+      "input": "tests/benchmarks/casscf/pyscf_reference/water_cas44_sto3g_sa2_sad_uphill.hfinp",
+      "tags": ["extended"],
+      "expected_exit_code": 0,
+      "contains": [
+        "CASSCF :                      Converged.",
+        "State-averaged over 2 roots :"
+      ],
+      "checks": [
+        {"type": "metric_close", "metric": "casscf_total_energy", "expected": -74.7877864784, "atol": 1e-9},
+        {"type": "metric_le",    "metric": "casscf_sa_gnorm",     "value":     1e-5}
+      ]
+    },
+    {
+      "id": "ethylene_casscf_sa2_sto3g",
+      "input": "tests/benchmarks/casscf/pyscf_reference/ethylene_cas44_sto3g_sa2.hfinp",
+      "tags": ["extended"],
+      "timeout_s": 300,
+      "expected_exit_code": 0,
+      "contains": [
+        "Point Group :                 D2d",
+        "CASSCF :                      Converged.",
+        "State-averaged over 2 roots :"
+      ],
+      "checks": [
+        {"type": "metric_eq",    "metric": "point_group",         "expected": "D2d"},
+        {"type": "metric_close", "metric": "casscf_total_energy", "expected": -77.0034974301, "atol": 1e-9},
+        {"type": "metric_le",    "metric": "casscf_sa_gnorm",     "value":     1e-5}
+      ]
     }
   ]
 }

--- a/vault/Implementation/CASSCF and SA-CASSCF.md
+++ b/vault/Implementation/CASSCF and SA-CASSCF.md
@@ -49,6 +49,15 @@ Iteration table prints:
 **Step scales tried**: `{1.0, 0.5, 0.25, 0.125, 0.0625, 0.03125, 0.015625}`
 **Merit function**: `E_cas + 0.1·‖g_orb‖²` (lowest wins)
 
+**Trust region**: every macro orbital step κ is capped element-wise at
+`mcscf_max_rot` (default `0.20`, settable in `[scf]`) and Frobenius-norm
+at `4 × mcscf_max_rot`. Per-pair single-direction probe steps under
+stagnation also use ±`mcscf_max_rot`. Empirically the cap is rarely
+binding (water SA-2 from sad/hcore takes `step_norm ≤ 0.11` even when
+`mcscf_max_rot = 10`); larger values do not change which basin the
+optimizer reaches, since the search direction comes from a local-Newton
+step that points into the local well regardless of step size.
+
 **Plateau escape**: if stagnation_streak ≥ 2 and both energy and step are flat, convergence is declared with a `[WRN]` line.
 
 ## Shared-κ SA Coupled Solve
@@ -80,9 +89,9 @@ Default mode: `ResponseRHSMode::ExactOrbitalDerivative` — exact CI-response RH
 - **Reversed Cayley sign** (`apply_orbital_rotation`): was applying `exp(-κ)` instead of `exp(+κ)`. Caused line search to test uphill directions and reject every candidate. Now fixed.
 - **`guess hcore` + `use_symm true` → wrong RHF**: d2d RHF branch preservation fix (commit 46aa199).
 
-## Open Work
+## Regression Coverage
 
-- SA stationarity assertion: `tests/regression_cases.json` has no `lte` check on `casscf_sa_gnorm` for any SA case — add `{ "metric": "casscf_sa_gnorm", "type": "lte", "value": 1e-5 }` to all SA entries
+- SA stationarity is gated by `metric_le` checks on `casscf_sa_gnorm` (≤ 1e-5) in `tests/regression_cases.json` for `water_casscf_sa2_sto3g` and `ethylene_casscf_sa2_sto3g`, alongside `casscf_total_energy` matches against the PySCF reference table.
 
 ## RASSCF
 

--- a/vault/Status/Open Work.md
+++ b/vault/Status/Open Work.md
@@ -9,19 +9,10 @@ tags: [status, open-work, bugs, todo]
 
 # Open Work
 
-Last updated: 2026-04-24
-
-## Missing Features
-
-### SA stationarity assertion in regression runner
-- `tests/run_regressions.py` parses `casscf_sa_gnorm` (`sa_g=...` in the log) but `tests/regression_cases.json` has no `lte` check on it for any SA case
-- Missing: assertion that the SA gradient norm is below `1e-5` at convergence
-- Fix: add `{ "metric": "casscf_sa_gnorm", "type": "lte", "value": 1e-5 }` to all SA entries in `tests/regression_cases.json`
+Last updated: 2026-05-01
 
 ## Potential Improvements
 
 - Range-separated and double-hybrid DFT (only global hybrids are currently supported; B3LYP and PBE0 are available as of commit f208777)
 - Analytic Hessian (currently semi-numerical only)
-- TDDFT / linear response
-- Löwdin population analysis (Mulliken is implemented)
 - ccgen `TensorOptimized` solver path (Phase 4) — scaffolding exists in `src/post_hf/cc/tensor_optimized.{cpp,h}` and `generated_kernel_registry`


### PR DESCRIPTION
Introduce an opt-in SA-CASSCF uphill acceptance path (`mcscf_accept_uphill` with `mcscf_uphill_max_eh`) so water CAS(4,4) SAD starts can cross the local SA barrier and reach the PySCF SAD-start basin. Add and gate both SAD fixtures (original monotone and uphill-enabled) to preserve historical behavior while locking in the PySCF-matching path.

- add augmented-Hessian orbital solver integration and CIAH-style micro-step accumulation
- expose and parse new SCF knobs (`mcscf_max_rot`, `mcscf_accept_uphill`, `mcscf_uphill_max_eh`)
- update candidate acceptance to allow bounded uphill basin-escape under opt-in mode
- keep logs clean by removing per-candidate uphill debug spam
- add SAD uphill benchmark input and dual regression cases
- refresh CASSCF status/teaching docs with rationale, learnings, and regression policy