### PR TITLE
Add screened-ERI DFT support and PySCF validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ tests/benchmarks/**/*.hfchk
 tests/benchmarks/**/*.uvvis.dat
 *.png
 *.log
+tests/*/__pycache__

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -430,6 +430,10 @@ if(BUILD_TESTING)
         ${CMAKE_SOURCE_DIR}/tests/dft_grid_invariants.cpp
     )
 
+    add_executable(planck-dft-functional-support
+        ${CMAKE_SOURCE_DIR}/tests/dft_functional_support.cpp
+    )
+
     add_executable(planck-multipole-integrals
         ${CMAKE_SOURCE_DIR}/tests/multipole_integrals.cpp
         ${INT_SRC}
@@ -467,6 +471,11 @@ if(BUILD_TESTING)
         ${eigen_SOURCE_DIR}
     )
 
+    target_include_directories(planck-dft-functional-support PRIVATE
+        ${SRC_DIR}
+        ${LIBXC_INSTALL_DIR}/include
+    )
+
     target_include_directories(planck-multipole-integrals PRIVATE
         ${SRC_DIR}
         ${eigen_SOURCE_DIR}
@@ -495,6 +504,12 @@ if(BUILD_TESTING)
     )
 
     set_target_properties(planck-dft-grid-invariants PROPERTIES
+        CXX_STANDARD 23
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF
+    )
+
+    set_target_properties(planck-dft-functional-support PROPERTIES
         CXX_STANDARD 23
         CXX_STANDARD_REQUIRED ON
         CXX_EXTENSIONS OFF
@@ -539,6 +554,11 @@ if(BUILD_TESTING)
     )
     add_dependencies(planck-symmetry-units libmsym)
 
+    target_link_libraries(planck-dft-functional-support
+        ${LIBXC_INSTALL_DIR}/lib/libxc.a
+    )
+    add_dependencies(planck-dft-functional-support libxc)
+
     add_test(
         NAME planck-casscf-internal
         COMMAND planck-casscf-internal
@@ -547,6 +567,11 @@ if(BUILD_TESTING)
     add_test(
         NAME planck-dft-grid-invariants
         COMMAND planck-dft-grid-invariants
+    )
+
+    add_test(
+        NAME planck-dft-functional-support
+        COMMAND planck-dft-functional-support
     )
 
     add_test(

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -942,6 +942,8 @@ The same post-SCF multipole analysis is available in `planck-dft`, because the d
 | `exchange pw91` + `correlation pw91` | PW91 | GGA |
 | `exchange b3lyp` | B3LYP | global hybrid GGA |
 | `exchange pbe0` | PBE0 | global hybrid GGA |
+| `exchange hse06` | HSE06 | range-separated hybrid GGA |
+| `exchange b2plyp` | B2PLYP | double-hybrid GGA |
 
 #### Grid quality
 
@@ -1068,7 +1070,10 @@ H     0.000000     0.000000     0.370000
 
 #### Custom libxc functional
 
-To use any libxc functional by its integer ID, replace the enum keywords with numeric IDs:
+`exchange` and `correlation` first try the built-in aliases above, then fall back
+to libxc names. That means inputs such as `exchange hse06`,
+`exchange hyb_gga_xc_cam_b3lyp`, or `exchange b2plyp` are accepted directly.
+You can also select any libxc functional by its integer ID:
 
 ```
 %begin_dft
@@ -1077,6 +1082,10 @@ To use any libxc functional by its integer ID, replace the enum keywords with nu
     grid           normal
 %end_dft
 ```
+
+Range-separated and double-hybrid functionals are currently implemented for
+single-point energies. Their gradient, optimization, frequency, and TDDFT
+workflows are still rejected with an explicit diagnostic.
 
 ### 16. All input keywords at a glance
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A quantum chemistry program implementing restricted, unrestricted, and restricte
 <div align="justify">
 
 - **RHF / ROHF / UHF** — closed-shell, restricted open-shell, and unrestricted Hartree-Fock; ROHF uses a Roothaan-type effective Fock construction with aufbau orbital reordering and DIIS convergence
-- **RKS / UKS (Kohn-Sham DFT)** — closed-shell and open-shell Kohn-Sham SCF via the `planck-dft` executable; LDA, GGA, and global hybrid exchange-correlation functionals through libxc; four grid quality presets (Coarse/Normal/Fine/UltraFine); arbitrary libxc functionals via integer ID
+- **RKS / UKS (Kohn-Sham DFT)** — closed-shell and open-shell Kohn-Sham SCF via the `planck-dft` executable; LDA, GGA, global hybrid, range-separated hybrid, and double-hybrid exchange-correlation functionals through libxc; four grid quality presets (Coarse/Normal/Fine/UltraFine); arbitrary libxc functionals by name or integer ID. Range-separated and double-hybrid functionals are currently implemented for single-point energies
 - **PCM solvation** — self-consistent conductor-like polarizable continuum model (C-PCM) for single-point RHF/UHF/RKS/UKS calculations with user-defined dielectric, named solvents, atom-centered cavities, and surface discretization controls
 - **TDDFT / linear response** — full Casida and optional TDA excited-state roots on top of converged KS orbitals, with RKS singlet/triplet support, UKS spin-conserving response, semilocal XC kernels, transition dipoles, oscillator strengths, wavelengths, and Gaussian-broadened UV-Vis spectra
 - **Two integral engines** — Obara-Saika for low angular momentum; Rys quadrature for high angular momentum; automatic engine selection per shell quartet (`engine auto`)
@@ -224,8 +224,8 @@ Kohn-Sham DFT settings. Only read by `planck-dft`; ignored by `hartree-fock`. Th
 | Keyword | Type | Values | Default | Description |
 |---|---|---|---|---|
 | `grid` / `grid_level` | enum | `coarse`, `normal`, `fine`, `ultrafine` | `normal` | Molecular integration grid quality. Higher quality uses more radial shells and angular points; see grid preset table below. |
-| `exchange` | enum | `slater`/`lda`, `b88`/`becke88`, `pw91`, `pbe`, `b3lyp`, `pbe0`/`pbeh` | `pbe` | Exchange or combined exchange-correlation functional. Combined XC entries such as `b3lyp` and `pbe0` ignore the separate `correlation` keyword. |
-| `correlation` | enum | `vwn`/`vwn5`, `lyp`, `p86`, `pw91`, `pbe` | `pbe` | Correlation functional |
+| `exchange` | enum/string | built-in aliases such as `slater`/`lda`, `b88`/`becke88`, `pw91`, `pbe`, `b3lyp`, `pbe0`/`pbeh`, `hse06`, `b2plyp`; or any libxc name | `pbe` | Exchange or combined exchange-correlation functional. Combined XC entries such as `b3lyp`, `pbe0`, `hse06`, and `b2plyp` ignore the separate `correlation` keyword. Unknown strings are resolved through libxc by name. |
+| `correlation` | enum/string | `vwn`/`vwn5`, `lyp`, `p86`, `pw91`, `pbe`; or any libxc name | `pbe` | Correlation functional |
 | `exchange_id` | int | any libxc integer ID | — | Use an arbitrary libxc exchange functional by its integer identifier. Overrides `exchange`. |
 | `correlation_id` | int | any libxc integer ID | — | Use an arbitrary libxc correlation functional by its integer identifier. Overrides `correlation`. |
 | `lr_nstates` / `tddft_nstates` / `nstates` / `nroots` | int | ≥ 1 | `5` | Number of TDDFT roots to solve for `calculation tddft` / `linearresponse`. |
@@ -235,6 +235,13 @@ Kohn-Sham DFT settings. Only read by `planck-dft`; ignored by `hartree-fock`. Th
 | `use_sao_blocking` | bool | `.true.`, `.false.` | `.true.` | Enable symmetry-adapted AO blocking for the Coulomb matrix assembly. |
 | `print_grid_summary` | bool | `.true.`, `.false.` | `.true.` | Print a per-atom grid point count summary before the KS iterations. |
 | `save_checkpoint` | bool | `.true.`, `.false.` | `.false.` | Write a `.dftchk` checkpoint file after successful convergence. |
+
+<p align="justify">
+Range-separated hybrids and double hybrids are currently supported for
+single-point energies. Analytic gradients, geometry optimization, frequencies,
+and TDDFT remain limited to the existing LDA/GGA/global-hybrid path and still
+error explicitly for the newer non-global cases.
+</p>
 
 ### Section: `%begin_pcm`
 
@@ -271,6 +278,17 @@ Optional continuum-solvation settings for a self-consistent conductor-like PCM s
 | PBE | `pbe` | `pbe` | GGA (default) |
 | B3LYP | `b3lyp` | ignored | Global hybrid GGA |
 | PBE0 | `pbe0` | ignored | Global hybrid GGA |
+| HSE06 | `hse06` | ignored | Range-separated hybrid GGA |
+| B2PLYP | `b2plyp` | ignored | Double-hybrid GGA |
+
+<p align="justify">
+For cross-code DFT comparisons, matching the SCF convergence threshold alone is
+not enough: different molecular quadrature grids can shift total energies by
+\(10^{-3}\) Eh on coarse settings. The PySCF equivalence tests in
+`tests/pyscf/` therefore force `fine` grids on both sides, where Planck and
+PySCF agree again at the \(10^{-6}\) to \(10^{-7}\) Eh level for B3LYP, HSE06,
+and B2PLYP on the current H\(_2\)/STO-3G fixtures.
+</p>
 
 ### Section: `%begin_geom`
 

--- a/docs/PLANCK_TEACHING_GUIDE.md
+++ b/docs/PLANCK_TEACHING_GUIDE.md
@@ -10,7 +10,7 @@ Planck is a compact electronic structure program built around Gaussian-basis
 self-consistent field theory. It implements:
 
 - Restricted and unrestricted Hartree-Fock (RHF/UHF) with DIIS acceleration
-- Kohn-Sham DFT (RKS/UKS) with LDA and GGA exchange-correlation functionals via libxc
+- Kohn-Sham DFT (RKS/UKS) with LDA, GGA, hybrid, range-separated-hybrid, and double-hybrid exchange-correlation functionals via libxc
 - Obara-Saika and Rys-quadrature two-electron integral engines
 - Conventional (stored ERI tensor) and direct (on-the-fly Fock build) SCF
 - Point-group detection, symmetry-adapted orbitals, and MO irrep labeling
@@ -3360,6 +3360,14 @@ F^{KS}_{\mu\nu} = h_{\mu\nu} + J_{\mu\nu} + V^{xc}_{\mu\nu}
 
 This is identical in structure to the HF Fock matrix, with the HF exchange matrix \(K\) replaced by the XC potential matrix \(V^{xc}\). Planck reuses the HF SCF loop for KS-DFT: the only structural difference is how the two-electron contribution to the Fock matrix is assembled (Coulomb only, no exchange, plus \(V^{xc}\) from numerical integration).
 
+For semilocal functionals this statement is literal. For hybrids, Planck adds
+the exact-exchange part back explicitly. Global hybrids use a scaled full-range
+exchange matrix. Range-separated hybrids and range-separated double hybrids use
+the screened-ERI path introduced in the integral engines: the KS build forms
+\(\alpha K^{\text{full}} + \beta K^{\text{SR}}(\omega)\), where \(\alpha\),
+\(\beta\), and \(\omega\) come from libxc's CAM metadata. Double hybrids then
+add a post-KS MP2-like correction scaled by the libxc PT2 coefficient.
+
 ### Exchange-Correlation Functional Families
 
 #### LDA (Local Density Approximation)
@@ -3393,6 +3401,44 @@ GGA functionals satisfy more exact constraints than LDA and generally give bette
 | B88 | PW91 (`gga_c_pw91`) | BPW91 |
 | PW91 (`gga_x_pw91`) | PW91 | PW91 |
 | PBE (`gga_x_pbe`) | PBE (`gga_c_pbe`) | PBE (default) |
+
+#### Hybrids, range separation, and double hybrids
+
+Global hybrids mix a fraction of Hartree-Fock exchange into the KS reference:
+
+\[
+E_{xc}^{hyb} = a_x E_x^{HF} + (1-a_x)E_x^{DFT} + E_c^{DFT}
+\]
+
+Range-separated hybrids split the Coulomb operator into long-range and
+short-range pieces,
+
+\[
+\frac{1}{r_{12}} = \frac{\operatorname{erf}(\omega r_{12})}{r_{12}}
+                 + \frac{\operatorname{erfc}(\omega r_{12})}{r_{12}},
+\]
+
+and then apply different exact-exchange fractions to the two pieces. In
+Planck's current libxc-driven notation the implemented KS exchange build is
+
+\[
+K^{xc}_{exact} = \alpha K^{full} + \beta K^{SR}(\omega).
+\]
+
+That form covers screened hybrids such as HSE06 (\(\alpha=0\),
+\(\beta=0.25\), \(\omega \approx 0.11\)) and range-separated double hybrids
+such as \(\omega\)B2PLYP.
+
+Double hybrids extend the hybrid idea once more:
+
+\[
+E^{DH} = E^{KS-hyb} + c_{PT2} E^{(2)}.
+\]
+
+In Planck the converged KS reference is followed by an RHF/UHF-based MP2-like
+correction from `src/post_hf/mp2.cpp`, scaled by the libxc PT2 coefficient.
+For B2PLYP, for example, libxc supplies \(a_x = 0.53\) and
+\(c_{PT2} = 0.27\).
 
 ### Numerical Integration: Molecular Grid
 
@@ -3439,6 +3485,15 @@ w_i(\mathbf r) = \frac{P_i(\mathbf r)}{\sum_k P_k(\mathbf r)} \cdot w_i^{radial-
 | `Normal` | 4 | 26 / 110 / 194 / 302 / 194 |
 | `Fine` | 5 | 26 / 194 / 302 / 434 / 302 |
 | `UltraFine` | 6 | 50 / 302 / 434 / 590 / 434 |
+
+The practical lesson from cross-code benchmarking is that the choice of grid
+matters as much as the SCF convergence threshold. Planck's molecular grids are
+ORCA-like Treutler-Ahlrichs + pruned Lebedev grids; PySCF's `grids.level`
+presets are different quadrature families. On the current H\(_2\)/STO-3G DFT
+fixtures, coarse-grid Planck-vs-PySCF comparisons differ by about
+\(10^{-3}\) Eh even for ordinary B3LYP, while `fine` and `ultrafine` grids
+reduce the gap back to \(10^{-6}\) to \(10^{-7}\) Eh. This is why the PySCF
+equivalence scripts in `tests/pyscf/` force `fine` grids for the DFT cases.
 
 ### AO Evaluation on the Grid
 
@@ -4734,13 +4789,15 @@ driver.cpp
 | Kohn-Sham DFT (RKS/UKS) | Complete |
 | LDA XC functionals (Slater, VWN5) | Complete |
 | GGA XC functionals (B88, PBE, PW91 exchange; LYP, P86, PBE, PW91 correlation) | Complete |
-| Arbitrary libxc functionals via integer ID | Complete within the currently supported LDA/GGA/global-hybrid subset; unsupported libxc families still error explicitly |
+| Arbitrary libxc functionals via integer ID or libxc name | Complete within the currently supported single-point KS subset; unsupported workflow/family combinations still error explicitly |
 | Molecular grid (Treutler-Ahlrichs + Lebedev + Becke) | Complete |
 | Analytic KS-DFT gradient (RKS/UKS, LDA/GGA/global hybrid) | Complete |
 | TD-DFT / linear response (RKS singlet/triplet, UKS spin-conserving, Casida/TDA, semilocal XC kernels) | Complete |
 | DFT geometry optimization / gradients | Complete |
 | Global hybrid XC functionals (B3LYP, PBE0, compatible libxc IDs) | Complete |
-| Range-separated and double-hybrid XC functionals | Not supported |
+| Range-separated hybrid XC functionals (for example HSE06) | Complete for single-point energies |
+| Double-hybrid XC functionals (for example B2PLYP) | Complete for single-point energies |
+| Range-separated double hybrids (for example \(\omega\)B2PLYP) | Complete for single-point energies |
 | Spherical harmonic basis | Not supported (Cartesian only) |
 | C-PCM solvation (RHF/UHF/RKS/UKS, single-point energy) | Complete |
 | PCM gradients / geometry optimization / frequencies | Not implemented |

--- a/docs/index.html
+++ b/docs/index.html
@@ -294,7 +294,7 @@
 <p>Planck is a compact electronic structure program built around Gaussian-basis self-consistent field theory. It implements:</p>
 <ul>
 <li>Restricted and unrestricted Hartree-Fock (RHF/UHF) with DIIS acceleration</li>
-<li>Kohn-Sham DFT (RKS/UKS) with LDA and GGA exchange-correlation functionals via libxc</li>
+<li>Kohn-Sham DFT (RKS/UKS) with LDA, GGA, hybrid, range-separated-hybrid, and double-hybrid exchange-correlation functionals via libxc</li>
 <li>Obara-Saika and Rys-quadrature two-electron integral engines</li>
 <li>Conventional (stored ERI tensor) and direct (on-the-fly Fock build) SCF</li>
 <li>Point-group detection, symmetry-adapted orbitals, and MO irrep labeling</li>
@@ -2057,6 +2057,7 @@ E[P] = T_s[P] + V_{ne}[P] + J[P] + E_{xc}[P] + V_{nn}
 F^{KS}_{\mu\nu} = h_{\mu\nu} + J_{\mu\nu} + V^{xc}_{\mu\nu}
 \]</span></p>
 <p>This is identical in structure to the HF Fock matrix, with the HF exchange matrix <span class="math-inline">\(K\)</span> replaced by the XC potential matrix <span class="math-inline">\(V^{xc}\)</span>. Planck reuses the HF SCF loop for KS-DFT: the only structural difference is how the two-electron contribution to the Fock matrix is assembled (Coulomb only, no exchange, plus <span class="math-inline">\(V^{xc}\)</span> from numerical integration).</p>
+<p>For semilocal functionals this statement is literal. For hybrids, Planck adds the exact-exchange part back explicitly. Global hybrids use a scaled full-range exchange matrix. Range-separated hybrids and range-separated double hybrids use the screened-ERI path introduced in the integral engines: the KS build forms <span class="math-inline">\(\alpha K^{\text{full}} + \beta K^{\text{SR}}(\omega)\)</span>, where <span class="math-inline">\(\alpha\)</span>, <span class="math-inline">\(\beta\)</span>, and <span class="math-inline">\(\omega\)</span> come from libxc&#x27;s CAM metadata. Double hybrids then add a post-KS MP2-like correction scaled by the libxc PT2 coefficient.</p>
 <h3 id="exchange-correlation-functional-families">Exchange-Correlation Functional Families</h3>
 <h4 id="lda-local-density-approximation">LDA (Local Density Approximation)</h4>
 <p>The XC energy depends only on the local electron density <span class="math-inline">\(\rho(\mathbf r)\)</span>:</p>
@@ -2088,6 +2089,26 @@ E_{xc}^{GGA}[\rho] = \int f(\rho(\mathbf r),\, |\nabla\rho(\mathbf r)|^2)\, d\ma
 <tr><td>PW91 (<code>gga_x_pw91</code>)</td><td>PW91</td><td>PW91</td></tr>
 <tr><td>PBE (<code>gga_x_pbe</code>)</td><td>PBE (<code>gga_c_pbe</code>)</td><td>PBE (default)</td></tr>
 </tbody></table></div>
+<h4 id="hybrids-range-separation-and-double-hybrids">Hybrids, range separation, and double hybrids</h4>
+<p>Global hybrids mix a fraction of Hartree-Fock exchange into the KS reference:</p>
+<p><span class="math-display">\[
+E_{xc}^{hyb} = a_x E_x^{HF} + (1-a_x)E_x^{DFT} + E_c^{DFT}
+\]</span></p>
+<p>Range-separated hybrids split the Coulomb operator into long-range and short-range pieces,</p>
+<p><span class="math-display">\[
+\frac{1}{r_{12}} = \frac{\operatorname{erf}(\omega r_{12})}{r_{12}}
+                 + \frac{\operatorname{erfc}(\omega r_{12})}{r_{12}},
+\]</span></p>
+<p>and then apply different exact-exchange fractions to the two pieces. In Planck&#x27;s current libxc-driven notation the implemented KS exchange build is</p>
+<p><span class="math-display">\[
+K^{xc}_{exact} = \alpha K^{full} + \beta K^{SR}(\omega).
+\]</span></p>
+<p>That form covers screened hybrids such as HSE06 (<span class="math-inline">\(\alpha=0\)</span>, <span class="math-inline">\(\beta=0.25\)</span>, <span class="math-inline">\(\omega \approx 0.11\)</span>) and range-separated double hybrids such as <span class="math-inline">\(\omega\)</span>B2PLYP.</p>
+<p>Double hybrids extend the hybrid idea once more:</p>
+<p><span class="math-display">\[
+E^{DH} = E^{KS-hyb} + c_{PT2} E^{(2)}.
+\]</span></p>
+<p>In Planck the converged KS reference is followed by an RHF/UHF-based MP2-like correction from <code>src/post_hf/mp2.cpp</code>, scaled by the libxc PT2 coefficient. For B2PLYP, for example, libxc supplies <span class="math-inline">\(a_x = 0.53\)</span> and <span class="math-inline">\(c_{PT2} = 0.27\)</span>.</p>
 <h3 id="numerical-integration-molecular-grid">Numerical Integration: Molecular Grid</h3>
 <p>Because <span class="math-inline">\(V^{xc}_{\mu\nu}\)</span> has no analytic closed form, it is evaluated numerically:</p>
 <p><span class="math-display">\[
@@ -2123,6 +2144,7 @@ w_i(\mathbf r) = \frac{P_i(\mathbf r)}{\sum_k P_k(\mathbf r)} \cdot w_i^{radial-
 <tr><td><code>Fine</code></td><td>5</td><td>26 / 194 / 302 / 434 / 302</td></tr>
 <tr><td><code>UltraFine</code></td><td>6</td><td>50 / 302 / 434 / 590 / 434</td></tr>
 </tbody></table></div>
+<p>The practical lesson from cross-code benchmarking is that the choice of grid matters as much as the SCF convergence threshold. Planck&#x27;s molecular grids are ORCA-like Treutler-Ahlrichs + pruned Lebedev grids; PySCF&#x27;s <code>grids.level</code> presets are different quadrature families. On the current H<span class="math-inline">\(_2\)</span>/STO-3G DFT fixtures, coarse-grid Planck-vs-PySCF comparisons differ by about <span class="math-inline">\(10^{-3}\)</span> Eh even for ordinary B3LYP, while <code>fine</code> and <code>ultrafine</code> grids reduce the gap back to <span class="math-inline">\(10^{-6}\)</span> to <span class="math-inline">\(10^{-7}\)</span> Eh. This is why the PySCF equivalence scripts in <code>tests/pyscf/</code> force <code>fine</code> grids for the DFT cases.</p>
 <h3 id="ao-evaluation-on-the-grid">AO Evaluation on the Grid</h3>
 <p><code>AOGridEvaluation</code> (declared in <code>src/dft/ao_grid.h</code>) stores the AO values and gradients at every grid point in a matrix of shape <code>(N_grid, N_AO)</code>. These are computed once before the KS iteration begins. For each grid point and each AO <span class="math-inline">\(\phi_\mu\)</span>, the value and Cartesian gradient components are evaluated from the contracted shell data in the <code>Basis</code> object.</p>
 <h3 id="density-and-xc-evaluation">Density and XC Evaluation</h3>
@@ -2949,13 +2971,15 @@ driver.cpp
 <tr><td>Kohn-Sham DFT (RKS/UKS)</td><td>Complete</td></tr>
 <tr><td>LDA XC functionals (Slater, VWN5)</td><td>Complete</td></tr>
 <tr><td>GGA XC functionals (B88, PBE, PW91 exchange; LYP, P86, PBE, PW91 correlation)</td><td>Complete</td></tr>
-<tr><td>Arbitrary libxc functionals via integer ID</td><td>Complete within the currently supported LDA/GGA/global-hybrid subset; unsupported libxc families still error explicitly</td></tr>
+<tr><td>Arbitrary libxc functionals via integer ID or libxc name</td><td>Complete within the currently supported single-point KS subset; unsupported workflow/family combinations still error explicitly</td></tr>
 <tr><td>Molecular grid (Treutler-Ahlrichs + Lebedev + Becke)</td><td>Complete</td></tr>
 <tr><td>Analytic KS-DFT gradient (RKS/UKS, LDA/GGA/global hybrid)</td><td>Complete</td></tr>
 <tr><td>TD-DFT / linear response (RKS singlet/triplet, UKS spin-conserving, Casida/TDA, semilocal XC kernels)</td><td>Complete</td></tr>
 <tr><td>DFT geometry optimization / gradients</td><td>Complete</td></tr>
 <tr><td>Global hybrid XC functionals (B3LYP, PBE0, compatible libxc IDs)</td><td>Complete</td></tr>
-<tr><td>Range-separated and double-hybrid XC functionals</td><td>Not supported</td></tr>
+<tr><td>Range-separated hybrid XC functionals (for example HSE06)</td><td>Complete for single-point energies</td></tr>
+<tr><td>Double-hybrid XC functionals (for example B2PLYP)</td><td>Complete for single-point energies</td></tr>
+<tr><td>Range-separated double hybrids (for example <span class="math-inline">\(\omega\)</span>B2PLYP)</td><td>Complete for single-point energies</td></tr>
 <tr><td>Spherical harmonic basis</td><td>Not supported (Cartesian only)</td></tr>
 <tr><td>C-PCM solvation (RHF/UHF/RKS/UKS, single-point energy)</td><td>Complete</td></tr>
 <tr><td>PCM gradients / geometry optimization / frequencies</td><td>Not implemented</td></tr>

--- a/src/base/types.h
+++ b/src/base/types.h
@@ -99,6 +99,13 @@ namespace HartreeFock
         Auto           // OS for L<4, Rys for L>=4 per quartet
     };
 
+    enum class ERIKernel
+    {
+        Coulomb,   // 1 / r12
+        LongRange, // erf(omega r12) / r12
+        ShortRange // erfc(omega r12) / r12
+    };
+
     enum class DFTGridQuality
     {
         Coarse,

--- a/src/dft/base/wrapper.h
+++ b/src/dft/base/wrapper.h
@@ -27,6 +27,13 @@ namespace DFT
             Polarized = XC_POLARIZED
         };
 
+        struct CAMCoefficients
+        {
+            double omega = 0.0;
+            double alpha = 0.0;
+            double beta = 0.0;
+        };
+
         class Functional
         {
         public:
@@ -133,6 +140,122 @@ namespace DFT
             bool is_global_hybrid() const noexcept
             {
                 return hybrid_type() == XC_HYB_HYBRID;
+            }
+
+            bool is_range_separated() const noexcept
+            {
+                const int type = hybrid_type();
+                if (type == XC_HYB_CAM || type == XC_HYB_CAMY || type == XC_HYB_CAMG)
+                    return true;
+
+                if (func_.hyb_type == nullptr)
+                    return false;
+
+                for (int term = 0; term < func_.hyb_number_terms; ++term)
+                {
+                    switch (func_.hyb_type[term])
+                    {
+                    case XC_HYB_ERF_SR:
+                    case XC_HYB_YUKAWA_SR:
+                    case XC_HYB_GAUSSIAN_SR:
+                        return true;
+                    default:
+                        break;
+                    }
+                }
+                return false;
+            }
+
+            bool has_pt2_term() const noexcept
+            {
+                if (func_.hyb_type == nullptr || func_.hyb_coeff == nullptr)
+                    return false;
+
+                for (int term = 0; term < func_.hyb_number_terms; ++term)
+                {
+                    if (func_.hyb_type[term] == XC_HYB_PT2)
+                        return true;
+                }
+                return false;
+            }
+
+            bool is_double_hybrid() const noexcept
+            {
+                return hybrid_type() == XC_HYB_DOUBLE_HYBRID || has_pt2_term();
+            }
+
+            CAMCoefficients cam_coefficients() const noexcept
+            {
+                CAMCoefficients coefficients;
+                if (func_.hyb_type == nullptr || func_.hyb_coeff == nullptr || func_.hyb_omega == nullptr)
+                    return coefficients;
+
+                for (int term = 0; term < func_.hyb_number_terms; ++term)
+                {
+                    switch (func_.hyb_type[term])
+                    {
+                    case XC_HYB_FOCK:
+                        coefficients.alpha += func_.hyb_coeff[term];
+                        break;
+                    case XC_HYB_ERF_SR:
+                    case XC_HYB_YUKAWA_SR:
+                    case XC_HYB_GAUSSIAN_SR:
+                        coefficients.beta += func_.hyb_coeff[term];
+                        if (std::abs(func_.hyb_omega[term]) > 0.0)
+                            coefficients.omega = func_.hyb_omega[term];
+                        break;
+                    default:
+                        break;
+                    }
+                }
+
+                return coefficients;
+            }
+
+            double perturbative_correlation_coefficient() const noexcept
+            {
+                if (func_.hyb_type == nullptr || func_.hyb_coeff == nullptr)
+                    return 0.0;
+
+                for (int term = 0; term < func_.hyb_number_terms; ++term)
+                {
+                    if (func_.hyb_type[term] == XC_HYB_PT2)
+                        return func_.hyb_coeff[term];
+                }
+                return 0.0;
+            }
+
+            double fock_exchange_coefficient() const noexcept
+            {
+                if (is_global_hybrid())
+                    return exact_exchange_coefficient();
+
+                if (func_.hyb_type == nullptr || func_.hyb_coeff == nullptr)
+                    return 0.0;
+
+                double coefficient = 0.0;
+                for (int term = 0; term < func_.hyb_number_terms; ++term)
+                {
+                    if (func_.hyb_type[term] == XC_HYB_FOCK)
+                        coefficient += func_.hyb_coeff[term];
+                }
+                return coefficient;
+            }
+
+            double short_range_exchange_coefficient() const noexcept
+            {
+                if (!is_range_separated())
+                    return 0.0;
+
+                return cam_coefficients().beta;
+            }
+
+            double range_separation_omega() const noexcept
+            {
+                if (!is_range_separated())
+                    return 0.0;
+
+                return cam_coefficients().omega;
             }
 
             bool is_combined_exchange_correlation() const noexcept
@@ -253,10 +376,47 @@ namespace DFT
                 return parsed;
             }
 
-            const int id = xc_functional_get_number(std::string(name).c_str());
-            if (id <= 0)
-                return std::unexpected("Unknown libxc functional: " + std::string(name));
-            return id;
+            std::string normalized(name);
+            std::transform(
+                normalized.begin(),
+                normalized.end(),
+                normalized.begin(),
+                [](unsigned char c)
+                {
+                    if (c == '-' || std::isspace(c))
+                        return '_';
+                    return static_cast<char>(std::tolower(c));
+                });
+
+            std::vector<std::string> candidates = {normalized};
+            const auto starts_with = [&normalized](std::string_view prefix)
+            {
+                return normalized.rfind(prefix, 0) == 0;
+            };
+
+            if (!starts_with("lda_") &&
+                !starts_with("gga_") &&
+                !starts_with("hyb_") &&
+                !starts_with("mgga_") &&
+                !starts_with("hyb_mgga_"))
+            {
+                candidates.push_back("hyb_gga_xc_" + normalized);
+                candidates.push_back("gga_xc_" + normalized);
+                candidates.push_back("hyb_gga_x_" + normalized);
+                candidates.push_back("gga_x_" + normalized);
+                candidates.push_back("gga_c_" + normalized);
+                candidates.push_back("hyb_mgga_xc_" + normalized);
+                candidates.push_back("mgga_xc_" + normalized);
+            }
+
+            for (const auto &candidate : candidates)
+            {
+                const int id = xc_functional_get_number(candidate.c_str());
+                if (id > 0)
+                    return id;
+            }
+
+            return std::unexpected("Unknown libxc functional: " + std::string(name));
         }
 
         inline std::expected<std::string, std::string> functional_name(int functional_id)

--- a/src/dft/driver.cpp
+++ b/src/dft/driver.cpp
@@ -25,6 +25,7 @@
 #include "opt/geomopt.h"
 #include "populations/multipole.h"
 #include "post_hf/integrals.h"
+#include "post_hf/mp2.h"
 #include "scf/scf.h"
 #include "symmetry/integral_symmetry.h"
 #include "symmetry/mo_symmetry.h"
@@ -760,12 +761,57 @@ namespace DFT::Driver
                     prepared.shell_pairs,
                     nbasis,
                     calculator._integral._engine,
+                    HartreeFock::ERIKernel::Coulomb,
+                    0.0,
                     calculator._integral._tol_eri,
                     calculator._use_integral_symmetry ? &calculator._integral_symmetry_ops : nullptr);
             }
             catch (const std::exception &e)
             {
                 return std::unexpected("Failed to build ERI tensor for KS Coulomb term: " + std::string(e.what()));
+            }
+
+            return {};
+        }
+
+        std::expected<void, std::string> ensure_short_range_eri_tensor(
+            HartreeFock::Calculator &calculator,
+            PreparedSystem &prepared,
+            double omega)
+        {
+            if (omega <= 0.0)
+                return {};
+
+            const std::size_t nbasis = calculator._shells.nbasis();
+            const std::size_t expected_size = nbasis * nbasis * nbasis * nbasis;
+            if (prepared.short_range_eri_omega == omega &&
+                prepared.short_range_eri.size() == expected_size)
+            {
+                return {};
+            }
+
+            try
+            {
+                HartreeFock::Logger::logging(
+                    HartreeFock::LogLevel::Info,
+                    "DFT 2e Integrals :",
+                    std::format("Building short-range ERI tensor for omega = {:.6f} ({:.1f} MB)",
+                                omega,
+                                expected_size * 8.0 / 1e6));
+                prepared.short_range_eri = _compute_2e(
+                    prepared.shell_pairs,
+                    nbasis,
+                    calculator._integral._engine,
+                    HartreeFock::ERIKernel::ShortRange,
+                    omega,
+                    calculator._integral._tol_eri,
+                    calculator._use_integral_symmetry ? &calculator._integral_symmetry_ops : nullptr);
+                prepared.short_range_eri_omega = omega;
+            }
+            catch (const std::exception &e)
+            {
+                return std::unexpected(
+                    "Failed to build short-range ERI tensor for KS exchange: " + std::string(e.what()));
             }
 
             return {};
@@ -1941,7 +1987,7 @@ namespace DFT::Driver
 
         std::expected<Result, std::string> run_ks_scf_scaffold(
             HartreeFock::Calculator &calculator,
-            const PreparedSystem &prepared,
+            PreparedSystem &prepared,
             const DFT::XC::Functional &x_functional,
             const DFT::XC::Functional &c_functional)
         {
@@ -2302,7 +2348,96 @@ namespace DFT::Driver
         {
             DFT::XC::Functional exchange;
             DFT::XC::Functional correlation;
+            double implemented_exact_exchange_coefficient = 0.0;
+            double perturbative_correlation_coefficient = 0.0;
+            bool has_range_separation = false;
+            bool has_double_hybrid_pt2 = false;
         };
+
+        std::string workflow_label(HartreeFock::CalculationType calculation)
+        {
+            switch (calculation)
+            {
+            case HartreeFock::CalculationType::SinglePoint:
+                return "single-point energies";
+            case HartreeFock::CalculationType::LinearResponse:
+                return "linear-response / TDDFT";
+            case HartreeFock::CalculationType::Gradient:
+                return "analytic gradients";
+            case HartreeFock::CalculationType::GeomOpt:
+                return "geometry optimization";
+            case HartreeFock::CalculationType::Frequency:
+                return "frequency analysis";
+            case HartreeFock::CalculationType::GeomOptFrequency:
+                return "geometry optimization + frequency analysis";
+            case HartreeFock::CalculationType::ImaginaryFollow:
+                return "imaginary-mode following";
+            }
+
+            return "this workflow";
+        }
+
+        std::expected<void, std::string> validate_workflow_support(
+            const HartreeFock::Calculator &calculator,
+            const InitializedFunctionals &functionals)
+        {
+            if (calculator._calculation == HartreeFock::CalculationType::SinglePoint)
+                return {};
+
+            if (!functionals.has_range_separation &&
+                !functionals.has_double_hybrid_pt2)
+            {
+                return {};
+            }
+
+            return std::unexpected(
+                std::format(
+                    "{} currently supports only single-point energies for range-separated and double-hybrid functionals",
+                    workflow_label(calculator._calculation)));
+        }
+
+        std::expected<void, std::string> apply_post_ks_double_hybrid_correction(
+            HartreeFock::Calculator &calculator,
+            const std::vector<HartreeFock::ShellPair> &shell_pairs,
+            const InitializedFunctionals &functionals,
+            Result &result)
+        {
+            if (std::abs(functionals.perturbative_correlation_coefficient) <= 1.0e-14)
+                return {};
+
+            std::expected<void, std::string> correction =
+                calculator._scf._scf == HartreeFock::SCFType::UHF
+                    ? HartreeFock::Correlation::run_ump2(calculator, shell_pairs)
+                    : HartreeFock::Correlation::run_rmp2(calculator, shell_pairs);
+            if (!correction)
+            {
+                return std::unexpected(
+                    "DFT double-hybrid perturbative correction failed: " + correction.error());
+            }
+
+            const double bare_pt2 = calculator._correlation_energy;
+            const double scaled_pt2 =
+                functionals.perturbative_correlation_coefficient * bare_pt2;
+
+            calculator._correlation_energy = scaled_pt2;
+            calculator._correlated_total_energy = calculator._total_energy + scaled_pt2;
+            calculator._have_correlated_total_energy = true;
+
+            result.total_energy += scaled_pt2;
+            result.xc_energy += scaled_pt2;
+
+            HartreeFock::Logger::logging(
+                HartreeFock::LogLevel::Info,
+                "DFT Double Hybrid :",
+                std::format(
+                    "{} PT2 coefficient = {:.6f}; bare MP2-like correction = {:.10f} Eh; scaled contribution = {:.10f} Eh",
+                    functionals.exchange.name(),
+                    functionals.perturbative_correlation_coefficient,
+                    bare_pt2,
+                    scaled_pt2));
+
+            return {};
+        }
 
         std::expected<InitializedFunctionals, std::string> initialize_functionals(
             HartreeFock::Calculator &calculator)
@@ -2333,12 +2468,11 @@ namespace DFT::Driver
             if (!correlation)
                 return std::unexpected("DFT correlation functional initialization failed: " + correlation.error());
 
-            if (exchange->is_hybrid() && !exchange->is_global_hybrid())
-            {
-                return std::unexpected(
-                    "DFT hybrid functional initialization failed: only global hybrids are supported; "
-                    "range-separated and double-hybrid functionals are not yet implemented");
-            }
+            const bool has_range_separation = exchange->is_range_separated();
+            const double implemented_exact_exchange_coefficient =
+                exchange->fock_exchange_coefficient();
+            const double perturbative_correlation_coefficient =
+                exchange->perturbative_correlation_coefficient();
 
             if (exchange->is_global_hybrid())
             {
@@ -2348,6 +2482,38 @@ namespace DFT::Driver
                     std::format("{} exact exchange coefficient = {:.6f}",
                                 exchange->name(),
                                 exchange->exact_exchange_coefficient()));
+            }
+            else if (exchange->is_range_separated())
+            {
+                const auto cam = exchange->cam_coefficients();
+                HartreeFock::Logger::logging(
+                    HartreeFock::LogLevel::Info,
+                    "DFT Hybrid XC :",
+                    std::format(
+                        "{} range-separated exchange uses alpha(full-range) = {:.6f}, beta(short-range) = {:.6f}, omega = {:.6f}",
+                        exchange->name(),
+                        cam.alpha,
+                        cam.beta,
+                        cam.omega));
+            }
+            else if (std::abs(implemented_exact_exchange_coefficient) > 1.0e-14)
+            {
+                HartreeFock::Logger::logging(
+                    HartreeFock::LogLevel::Info,
+                    "DFT Hybrid XC :",
+                    std::format("{} exact exchange coefficient = {:.6f}",
+                                exchange->name(),
+                                implemented_exact_exchange_coefficient));
+            }
+
+            if (std::abs(perturbative_correlation_coefficient) > 1.0e-14)
+            {
+                HartreeFock::Logger::logging(
+                    HartreeFock::LogLevel::Info,
+                    "DFT Double Hybrid :",
+                    std::format("{} PT2 correlation coefficient = {:.6f}",
+                                exchange->name(),
+                                perturbative_correlation_coefficient));
             }
 
             if (exchange->is_combined_exchange_correlation())
@@ -2361,7 +2527,11 @@ namespace DFT::Driver
 
             return InitializedFunctionals{
                 .exchange = std::move(*exchange),
-                .correlation = std::move(*correlation)};
+                .correlation = std::move(*correlation),
+                .implemented_exact_exchange_coefficient = implemented_exact_exchange_coefficient,
+                .perturbative_correlation_coefficient = perturbative_correlation_coefficient,
+                .has_range_separation = has_range_separation,
+                .has_double_hybrid_pt2 = std::abs(perturbative_correlation_coefficient) > 1.0e-14};
         }
 
         std::expected<Eigen::MatrixXd, std::string> compute_analytic_ks_gradient(
@@ -2504,11 +2674,25 @@ namespace DFT::Driver
             if (!prepared)
                 return std::unexpected(prepared.error());
 
-            return run_ks_scf_scaffold(
+            auto result = run_ks_scf_scaffold(
                 calculator,
                 *prepared,
                 functionals.exchange,
                 functionals.correlation);
+            if (!result)
+                return result;
+
+            if (auto correction = apply_post_ks_double_hybrid_correction(
+                    calculator,
+                    prepared->shell_pairs,
+                    functionals,
+                    *result);
+                !correction)
+            {
+                return std::unexpected(correction.error());
+            }
+
+            return result;
         }
 
         std::expected<Result, std::string> run_initial_single_point(
@@ -2532,6 +2716,16 @@ namespace DFT::Driver
                 functionals.correlation);
             if (!result)
                 return result;
+
+            if (auto correction = apply_post_ks_double_hybrid_correction(
+                    calculator,
+                    prepared->shell_pairs,
+                    functionals,
+                    *result);
+                !correction)
+            {
+                return std::unexpected(correction.error());
+            }
 
             if ((calculator._dft._save_checkpoint || options.save_checkpoint) && result->converged)
             {
@@ -3042,7 +3236,7 @@ namespace DFT::Driver
     std::expected<KSPotentialMatrices, std::string>
     assemble_current_ks_potential(
         HartreeFock::Calculator &calculator,
-        const PreparedSystem &prepared,
+        PreparedSystem &prepared,
         const XCGridEvaluation &xc_grid)
     {
         if (prepared.ao_grid.nbasis() != static_cast<Eigen::Index>(calculator._shells.nbasis()))
@@ -3078,40 +3272,78 @@ namespace DFT::Driver
             total_density,
             calculator._shells.nbasis());
 
-        const double exact_exchange_coefficient = xc_grid.exact_exchange_coefficient;
+        const double full_range_exchange_coefficient = xc_grid.full_range_exchange_coefficient;
+        const double short_range_exchange_coefficient = xc_grid.short_range_exchange_coefficient;
+        const double exact_exchange_coefficient =
+            full_range_exchange_coefficient + short_range_exchange_coefficient;
         Eigen::MatrixXd exact_exchange_alpha;
         Eigen::MatrixXd exact_exchange_beta;
         double exact_exchange_energy = 0.0;
+
+        if (std::abs(short_range_exchange_coefficient) > 1.0e-14)
+        {
+            if (auto screened_eri_ready =
+                    ensure_short_range_eri_tensor(calculator, prepared, xc_grid.range_separation_omega);
+                !screened_eri_ready)
+            {
+                return std::unexpected(screened_eri_ready.error());
+            }
+        }
 
         if (std::abs(exact_exchange_coefficient) > 1.0e-14)
         {
             if (calculator._scf._scf == HartreeFock::SCFType::UHF)
             {
-                const Eigen::MatrixXd exchange_alpha = build_exchange_from_eri(
-                    calculator._eri,
-                    alpha_density,
-                    calculator._shells.nbasis());
-                const Eigen::MatrixXd exchange_beta = build_exchange_from_eri(
-                    calculator._eri,
-                    beta_density,
-                    calculator._shells.nbasis());
-                exact_exchange_alpha = -exact_exchange_coefficient * exchange_alpha;
-                exact_exchange_beta = -exact_exchange_coefficient * exchange_beta;
+                Eigen::MatrixXd exchange_alpha = Eigen::MatrixXd::Zero(nbasis, nbasis);
+                Eigen::MatrixXd exchange_beta = Eigen::MatrixXd::Zero(nbasis, nbasis);
+
+                if (std::abs(full_range_exchange_coefficient) > 1.0e-14)
+                {
+                    exchange_alpha.noalias() +=
+                        full_range_exchange_coefficient *
+                        build_exchange_from_eri(calculator._eri, alpha_density, calculator._shells.nbasis());
+                    exchange_beta.noalias() +=
+                        full_range_exchange_coefficient *
+                        build_exchange_from_eri(calculator._eri, beta_density, calculator._shells.nbasis());
+                }
+
+                if (std::abs(short_range_exchange_coefficient) > 1.0e-14)
+                {
+                    exchange_alpha.noalias() +=
+                        short_range_exchange_coefficient *
+                        build_exchange_from_eri(prepared.short_range_eri, alpha_density, calculator._shells.nbasis());
+                    exchange_beta.noalias() +=
+                        short_range_exchange_coefficient *
+                        build_exchange_from_eri(prepared.short_range_eri, beta_density, calculator._shells.nbasis());
+                }
+
+                exact_exchange_alpha = -exchange_alpha;
+                exact_exchange_beta = -exchange_beta;
                 exact_exchange_energy =
-                    -0.5 * exact_exchange_coefficient *
+                    -0.5 *
                     (density_trace_product(alpha_density, exchange_alpha) +
                      density_trace_product(beta_density, exchange_beta));
             }
             else
             {
-                const Eigen::MatrixXd exchange = build_exchange_from_eri(
-                    calculator._eri,
-                    alpha_density,
-                    calculator._shells.nbasis());
-                exact_exchange_alpha = -0.5 * exact_exchange_coefficient * exchange;
+                Eigen::MatrixXd exchange = Eigen::MatrixXd::Zero(nbasis, nbasis);
+                if (std::abs(full_range_exchange_coefficient) > 1.0e-14)
+                {
+                    exchange.noalias() +=
+                        full_range_exchange_coefficient *
+                        build_exchange_from_eri(calculator._eri, alpha_density, calculator._shells.nbasis());
+                }
+                if (std::abs(short_range_exchange_coefficient) > 1.0e-14)
+                {
+                    exchange.noalias() +=
+                        short_range_exchange_coefficient *
+                        build_exchange_from_eri(prepared.short_range_eri, alpha_density, calculator._shells.nbasis());
+                }
+
+                exact_exchange_alpha = -0.5 * exchange;
                 exact_exchange_beta = exact_exchange_alpha;
                 exact_exchange_energy =
-                    -0.25 * exact_exchange_coefficient *
+                    -0.25 *
                     density_trace_product(alpha_density, exchange);
             }
         }
@@ -3216,6 +3448,9 @@ namespace DFT::Driver
         auto functionals = initialize_functionals(calculator);
         if (!functionals)
             return std::unexpected(functionals.error());
+
+        if (auto workflow_support = validate_workflow_support(calculator, *functionals); !workflow_support)
+            return std::unexpected(workflow_support.error());
 
         HartreeFock::Logger::logging(
             HartreeFock::LogLevel::Info,

--- a/src/dft/driver.h
+++ b/src/dft/driver.h
@@ -35,6 +35,8 @@ namespace DFT::Driver
         AOGridEvaluation ao_grid;
         GridPreset grid_preset;
         std::optional<HartreeFock::Solvation::PCMState> pcm;
+        mutable std::vector<double> short_range_eri;
+        mutable double short_range_eri_omega = -1.0;
     };
 
     struct Result
@@ -56,7 +58,7 @@ namespace DFT::Driver
     std::expected<KSPotentialMatrices, std::string>
     assemble_current_ks_potential(
         HartreeFock::Calculator &calculator,
-        const PreparedSystem &prepared,
+        PreparedSystem &prepared,
         const XCGridEvaluation &xc_grid);
 
     std::expected<PreparedSystem, std::string>

--- a/src/dft/xc_grid.cpp
+++ b/src/dft/xc_grid.cpp
@@ -150,12 +150,6 @@ namespace DFT
                     label + " meta-GGA functionals are not supported yet because tau/laplacian terms are not wired");
             }
 
-            if (functional.is_hybrid() && !functional.is_global_hybrid())
-            {
-                return std::unexpected(
-                    label + " range-separated and double-hybrid functionals are not supported yet");
-            }
-
             if (!functional.is_supported_semilocal())
             {
                 return std::unexpected(
@@ -404,8 +398,11 @@ namespace DFT
         evaluation.exchange_energy = evaluation.exchange.energy;
         evaluation.correlation_energy = evaluation.correlation.energy;
         evaluation.total_energy = evaluation.exchange_energy + evaluation.correlation_energy;
+        evaluation.full_range_exchange_coefficient = exchange_functional.fock_exchange_coefficient();
+        evaluation.short_range_exchange_coefficient = exchange_functional.short_range_exchange_coefficient();
+        evaluation.range_separation_omega = exchange_functional.range_separation_omega();
         evaluation.exact_exchange_coefficient =
-            exchange_functional.is_hybrid() ? exchange_functional.exact_exchange_coefficient() : 0.0;
+            evaluation.full_range_exchange_coefficient + evaluation.short_range_exchange_coefficient;
         auto integrated_electrons = density.integrated_electrons(molecular_grid);
         if (!integrated_electrons)
             return std::unexpected(integrated_electrons.error());

--- a/src/dft/xc_grid.h
+++ b/src/dft/xc_grid.h
@@ -76,6 +76,9 @@ namespace DFT
         double correlation_energy = 0.0;
         double total_energy = 0.0;
         double exact_exchange_coefficient = 0.0;
+        double full_range_exchange_coefficient = 0.0;
+        double short_range_exchange_coefficient = 0.0;
+        double range_separation_omega = 0.0;
         double integrated_electrons = 0.0;
     };
 

--- a/src/integrals/base.h
+++ b/src/integrals/base.h
@@ -40,17 +40,19 @@ inline std::vector<double> _compute_2e(
     const std::vector<HartreeFock::ShellPair> &shell_pairs,
     const std::size_t nbasis,
     const HartreeFock::IntegralMethod &engine,
+    HartreeFock::ERIKernel kernel = HartreeFock::ERIKernel::Coulomb,
+    double omega = 0.0,
     double tol_eri = 1e-10,
     const std::vector<HartreeFock::SignedAOSymOp> *sym_ops = nullptr)
 {
     switch (engine)
     {
     case HartreeFock::IntegralMethod::RysQuadrature:
-        return HartreeFock::RysQuad::_compute_2e(shell_pairs, nbasis, tol_eri, sym_ops);
+        return HartreeFock::RysQuad::_compute_2e(shell_pairs, nbasis, kernel, omega, tol_eri, sym_ops);
     case HartreeFock::IntegralMethod::Auto:
-        return HartreeFock::RysQuad::_compute_2e_auto(shell_pairs, nbasis, tol_eri, sym_ops);
+        return HartreeFock::RysQuad::_compute_2e_auto(shell_pairs, nbasis, kernel, omega, tol_eri, sym_ops);
     default:
-        return HartreeFock::ObaraSaika::_compute_2e(shell_pairs, nbasis, tol_eri, sym_ops);
+        return HartreeFock::ObaraSaika::_compute_2e(shell_pairs, nbasis, kernel, omega, tol_eri, sym_ops);
     }
 }
 
@@ -58,17 +60,19 @@ inline Eigen::MatrixXd _compute_2e_fock(const std::vector<HartreeFock::ShellPair
                                         const Eigen::MatrixXd &density,
                                         const std::size_t nbasis,
                                         const HartreeFock::IntegralMethod &engine,
+                                        HartreeFock::ERIKernel kernel = HartreeFock::ERIKernel::Coulomb,
+                                        double omega = 0.0,
                                         double tol_eri = 1e-10,
                                         const std::vector<HartreeFock::SignedAOSymOp> *sym_ops = nullptr)
 {
     switch (engine)
     {
     case HartreeFock::IntegralMethod::RysQuadrature:
-        return HartreeFock::RysQuad::_compute_2e_fock(shell_pairs, density, nbasis, tol_eri, sym_ops);
+        return HartreeFock::RysQuad::_compute_2e_fock(shell_pairs, density, nbasis, kernel, omega, tol_eri, sym_ops);
     case HartreeFock::IntegralMethod::Auto:
-        return HartreeFock::RysQuad::_compute_2e_fock_auto(shell_pairs, density, nbasis, tol_eri, sym_ops);
+        return HartreeFock::RysQuad::_compute_2e_fock_auto(shell_pairs, density, nbasis, kernel, omega, tol_eri, sym_ops);
     default:
-        return HartreeFock::ObaraSaika::_compute_2e_fock(shell_pairs, density, nbasis, tol_eri, sym_ops);
+        return HartreeFock::ObaraSaika::_compute_2e_fock(shell_pairs, density, nbasis, kernel, omega, tol_eri, sym_ops);
     }
 }
 
@@ -78,17 +82,19 @@ _compute_2e_fock_uhf(const std::vector<HartreeFock::ShellPair> &shell_pairs,
                      const Eigen::MatrixXd &Pb,
                      const std::size_t nbasis,
                      const HartreeFock::IntegralMethod &engine,
+                     HartreeFock::ERIKernel kernel = HartreeFock::ERIKernel::Coulomb,
+                     double omega = 0.0,
                      double tol_eri = 1e-10,
                      const std::vector<HartreeFock::SignedAOSymOp> *sym_ops = nullptr)
 {
     switch (engine)
     {
     case HartreeFock::IntegralMethod::RysQuadrature:
-        return HartreeFock::RysQuad::_compute_2e_fock_uhf(shell_pairs, Pa, Pb, nbasis, tol_eri, sym_ops);
+        return HartreeFock::RysQuad::_compute_2e_fock_uhf(shell_pairs, Pa, Pb, nbasis, kernel, omega, tol_eri, sym_ops);
     case HartreeFock::IntegralMethod::Auto:
-        return HartreeFock::RysQuad::_compute_2e_fock_uhf_auto(shell_pairs, Pa, Pb, nbasis, tol_eri, sym_ops);
+        return HartreeFock::RysQuad::_compute_2e_fock_uhf_auto(shell_pairs, Pa, Pb, nbasis, kernel, omega, tol_eri, sym_ops);
     default:
-        return HartreeFock::ObaraSaika::_compute_2e_fock_uhf(shell_pairs, Pa, Pb, nbasis, tol_eri, sym_ops);
+        return HartreeFock::ObaraSaika::_compute_2e_fock_uhf(shell_pairs, Pa, Pb, nbasis, kernel, omega, tol_eri, sym_ops);
     }
 }
 

--- a/src/integrals/os.cpp
+++ b/src/integrals/os.cpp
@@ -243,6 +243,36 @@ namespace
     };
 
     static thread_local EriScratch _eri_scratch;
+
+    struct ScreenedKernelData
+    {
+        double rho = 0.0;
+        double prefactor_scale = 1.0;
+        double boys_scale = 1.0;
+    };
+
+    static ScreenedKernelData screened_kernel_data(
+        double rho,
+        HartreeFock::ERIKernel kernel,
+        double omega) noexcept
+    {
+        if (kernel == HartreeFock::ERIKernel::Coulomb)
+            return ScreenedKernelData{.rho = rho, .prefactor_scale = 1.0, .boys_scale = 1.0};
+
+        if (omega <= 0.0)
+        {
+            return kernel == HartreeFock::ERIKernel::LongRange
+                       ? ScreenedKernelData{.rho = 0.0, .prefactor_scale = 0.0, .boys_scale = 0.0}
+                       : ScreenedKernelData{.rho = rho, .prefactor_scale = 1.0, .boys_scale = 1.0};
+        }
+
+        const double omega2 = omega * omega;
+        const double lambda = omega2 / (omega2 + rho);
+        return ScreenedKernelData{
+            .rho = lambda * rho,
+            .prefactor_scale = std::sqrt(lambda),
+            .boys_scale = lambda};
+    }
 } // namespace
 
 inline double HartreeFock::ObaraSaika::_os_1d(const double gamma, const double distPA, const double distPB, const int lA, const int lB)
@@ -620,18 +650,22 @@ static void _eri_vrr(
     const HartreeFock::PrimitivePair &ppCD,
     const int lABx, const int lABy, const int lABz,
     const int lCDx, const int lCDy, const int lCDz,
-    EriScratch &scratch)
+    EriScratch &scratch,
+    HartreeFock::ERIKernel kernel,
+    double omega)
 {
     const double zetaAB = ppAB.zeta;
     const double zetaCD = ppCD.zeta;
     const double delta = zetaAB + zetaCD;
     const double rho = zetaAB * zetaCD / delta;
+    const ScreenedKernelData screen = screened_kernel_data(rho, kernel, omega);
+    const double effective_rho = screen.rho;
 
     const double inv_2_zetaAB = 0.5 / zetaAB;
     const double inv_2_zetaCD = 0.5 / zetaCD;
     const double inv_2_delta = 0.5 / delta;
-    const double rho_over_zetaAB = rho / zetaAB;
-    const double rho_over_zetaCD = rho / zetaCD;
+    const double rho_over_zetaAB = effective_rho / zetaAB;
+    const double rho_over_zetaCD = effective_rho / zetaCD;
 
     const auto &P = ppAB.center;
     const auto &Q = ppCD.center;
@@ -650,11 +684,13 @@ static void _eri_vrr(
     const double QCx = ppCD.pA[0], QCy = ppCD.pA[1], QCz = ppCD.pA[2];
 
     const double PQx = P[0] - Q[0], PQy = P[1] - Q[1], PQz = P[2] - Q[2];
-    const double T = rho * (PQx * PQx + PQy * PQy + PQz * PQz);
+    const double T = screen.boys_scale * rho * (PQx * PQx + PQy * PQy + PQz * PQz);
 
     const int MMAX = lABx + lABy + lABz + lCDx + lCDy + lCDz;
 
-    const double prefac = ppAB.prefactor * ppCD.prefactor * 2.0 * std::sqrt(rho / std::numbers::pi);
+    const double prefac =
+        ppAB.prefactor * ppCD.prefactor * 2.0 * std::sqrt(rho / std::numbers::pi) *
+        screen.prefactor_scale;
 
     // ── Seed ─────────────────────────────────────────────────────────────────
     for (int m = 0; m <= MMAX; ++m)
@@ -887,7 +923,9 @@ static double _os_eri_primitive(
     const int lCx, const int lCy, const int lCz,
     const int lDx, const int lDy, const int lDz,
     const double ABx, const double ABy, const double ABz,
-    const double CDx, const double CDy, const double CDz)
+    const double CDx, const double CDy, const double CDz,
+    HartreeFock::ERIKernel kernel,
+    double omega)
 {
     const int lABx = lAx + lBx, lABy = lAy + lBy, lABz = lAz + lBz;
     const int lCDx = lCx + lDx, lCDy = lCy + lDy, lCDz = lCz + lDz;
@@ -897,7 +935,7 @@ static double _os_eri_primitive(
     scratch.resize_for_quartet(lABx, lABy, lABz, lCDx, lCDy, lCDz, mmax);
 
     // Build the quartet-sized VRR table in thread-local dynamic scratch.
-    _eri_vrr(ppAB, ppCD, lABx, lABy, lABz, lCDx, lCDy, lCDz, scratch);
+    _eri_vrr(ppAB, ppCD, lABx, lABy, lABz, lCDx, lCDy, lCDz, scratch, kernel, omega);
 
     // Extract m=0 slice into HRR buffer and zero unused entries
     for (int ax = 0; ax <= lABx; ++ax)
@@ -997,7 +1035,9 @@ static double _contracted_eri(
     const int lAx, const int lAy, const int lAz,
     const int lBx, const int lBy, const int lBz,
     const int lCx, const int lCy, const int lCz,
-    const int lDx, const int lDy, const int lDz)
+    const int lDx, const int lDy, const int lDz,
+    HartreeFock::ERIKernel kernel,
+    double omega)
 {
     const double ABx = spAB.R[0], ABy = spAB.R[1], ABz = spAB.R[2];
     const double CDx = spCD.R[0], CDy = spCD.R[1], CDz = spCD.R[2];
@@ -1005,7 +1045,26 @@ static double _contracted_eri(
     double eri = 0.0;
     for (const auto &ppAB : spAB.primitive_pairs)
         for (const auto &ppCD : spCD.primitive_pairs)
-            eri += ppAB.coeff_product * ppCD.coeff_product * _os_eri_primitive(ppAB, ppCD, lAx, lAy, lAz, lBx, lBy, lBz, lCx, lCy, lCz, lDx, lDy, lDz, ABx, ABy, ABz, CDx, CDy, CDz);
+        {
+            const double full =
+                _os_eri_primitive(ppAB, ppCD, lAx, lAy, lAz, lBx, lBy, lBz,
+                                  lCx, lCy, lCz, lDx, lDy, lDz,
+                                  ABx, ABy, ABz, CDx, CDy, CDz,
+                                  HartreeFock::ERIKernel::Coulomb, 0.0);
+
+            double value = full;
+            if (kernel != HartreeFock::ERIKernel::Coulomb)
+            {
+                const double long_range =
+                    _os_eri_primitive(ppAB, ppCD, lAx, lAy, lAz, lBx, lBy, lBz,
+                                      lCx, lCy, lCz, lDx, lDy, lDz,
+                                      ABx, ABy, ABz, CDx, CDy, CDz,
+                                      HartreeFock::ERIKernel::LongRange, omega);
+                value = (kernel == HartreeFock::ERIKernel::LongRange) ? long_range : (full - long_range);
+            }
+
+            eri += ppAB.coeff_product * ppCD.coeff_product * value;
+        }
     return eri;
 }
 
@@ -1015,11 +1074,14 @@ double HartreeFock::ObaraSaika::_contracted_eri_elem(
     int lAx, int lAy, int lAz,
     int lBx, int lBy, int lBz,
     int lCx, int lCy, int lCz,
-    int lDx, int lDy, int lDz)
+    int lDx, int lDy, int lDz,
+    HartreeFock::ERIKernel kernel,
+    double omega)
 {
     return _contracted_eri(spAB, spCD,
                            lAx, lAy, lAz, lBx, lBy, lBz,
-                           lCx, lCy, lCz, lDx, lDy, lDz);
+                           lCx, lCy, lCz, lDx, lDy, lDz,
+                           kernel, omega);
 }
 
 // ─── Gradient: derivative integral helpers ────────────────────────────────────
@@ -1319,7 +1381,10 @@ std::array<double, 12> HartreeFock::ObaraSaika::_compute_eri_deriv_elem(
         double eri = 0.0;
         for (const auto &ppAB : spAB.primitive_pairs)
             for (const auto &ppCD : spCD.primitive_pairs)
-                eri += (2.0 * ppAB.alpha) * ppAB.coeff_product * ppCD.coeff_product * _os_eri_primitive(ppAB, ppCD, ax, ay, az, bx, by, bz, cx, cy, cz, dx, dy, dz, ABx, ABy, ABz, CDx, CDy, CDz);
+                eri += (2.0 * ppAB.alpha) * ppAB.coeff_product * ppCD.coeff_product * _os_eri_primitive(
+                    ppAB, ppCD, ax, ay, az, bx, by, bz, cx, cy, cz, dx, dy, dz,
+                    ABx, ABy, ABz, CDx, CDy, CDz,
+                    HartreeFock::ERIKernel::Coulomb, 0.0);
         return eri;
     };
 
@@ -1329,7 +1394,10 @@ std::array<double, 12> HartreeFock::ObaraSaika::_compute_eri_deriv_elem(
         double eri = 0.0;
         for (const auto &ppAB : spAB.primitive_pairs)
             for (const auto &ppCD : spCD.primitive_pairs)
-                eri += ppAB.coeff_product * (2.0 * ppAB.beta) * ppCD.coeff_product * _os_eri_primitive(ppAB, ppCD, ax, ay, az, bx, by, bz, cx, cy, cz, dx, dy, dz, ABx, ABy, ABz, CDx, CDy, CDz);
+                eri += ppAB.coeff_product * (2.0 * ppAB.beta) * ppCD.coeff_product * _os_eri_primitive(
+                    ppAB, ppCD, ax, ay, az, bx, by, bz, cx, cy, cz, dx, dy, dz,
+                    ABx, ABy, ABz, CDx, CDy, CDz,
+                    HartreeFock::ERIKernel::Coulomb, 0.0);
         return eri;
     };
 
@@ -1339,7 +1407,10 @@ std::array<double, 12> HartreeFock::ObaraSaika::_compute_eri_deriv_elem(
         double eri = 0.0;
         for (const auto &ppAB : spAB.primitive_pairs)
             for (const auto &ppCD : spCD.primitive_pairs)
-                eri += ppAB.coeff_product * (2.0 * ppCD.alpha) * ppCD.coeff_product * _os_eri_primitive(ppAB, ppCD, ax, ay, az, bx, by, bz, cx, cy, cz, dx, dy, dz, ABx, ABy, ABz, CDx, CDy, CDz);
+                eri += ppAB.coeff_product * (2.0 * ppCD.alpha) * ppCD.coeff_product * _os_eri_primitive(
+                    ppAB, ppCD, ax, ay, az, bx, by, bz, cx, cy, cz, dx, dy, dz,
+                    ABx, ABy, ABz, CDx, CDy, CDz,
+                    HartreeFock::ERIKernel::Coulomb, 0.0);
         return eri;
     };
 
@@ -1349,7 +1420,10 @@ std::array<double, 12> HartreeFock::ObaraSaika::_compute_eri_deriv_elem(
         double eri = 0.0;
         for (const auto &ppAB : spAB.primitive_pairs)
             for (const auto &ppCD : spCD.primitive_pairs)
-                eri += ppAB.coeff_product * ppCD.coeff_product * (2.0 * ppCD.beta) * _os_eri_primitive(ppAB, ppCD, ax, ay, az, bx, by, bz, cx, cy, cz, dx, dy, dz, ABx, ABy, ABz, CDx, CDy, CDz);
+                eri += ppAB.coeff_product * ppCD.coeff_product * (2.0 * ppCD.beta) * _os_eri_primitive(
+                    ppAB, ppCD, ax, ay, az, bx, by, bz, cx, cy, cz, dx, dy, dz,
+                    ABx, ABy, ABz, CDx, CDy, CDz,
+                    HartreeFock::ERIKernel::Coulomb, 0.0);
         return eri;
     };
 
@@ -1358,7 +1432,8 @@ std::array<double, 12> HartreeFock::ObaraSaika::_compute_eri_deriv_elem(
     {
         return _contracted_eri(spAB, spCD,
                                ax, ay, az, bx, by, bz,
-                               cx, cy, cz, dx, dy, dz);
+                               cx, cy, cz, dx, dy, dz,
+                               HartreeFock::ERIKernel::Coulomb, 0.0);
     };
 
     for (int q = 0; q < 3; ++q)
@@ -1436,6 +1511,8 @@ Eigen::MatrixXd HartreeFock::ObaraSaika::_compute_2e_fock(
     const std::vector<HartreeFock::ShellPair> &shell_pairs,
     const Eigen::MatrixXd &density,
     const std::size_t nbasis,
+    const HartreeFock::ERIKernel kernel,
+    const double omega,
     const double tol_eri,
     const std::vector<HartreeFock::SignedAOSymOp> *sym_ops)
 {
@@ -1491,7 +1568,8 @@ Eigen::MatrixXd HartreeFock::ObaraSaika::_compute_2e_fock(
 
             const double val = _contracted_eri(spAB, spCD,
                                                lAx, lAy, lAz, lBx, lBy, lBz,
-                                               lCx, lCy, lCz, lDx, lDy, lDz);
+                                               lCx, lCy, lCz, lDx, lDy, lDz,
+                                               kernel, omega);
 
             if (!use_sym)
             {
@@ -1535,6 +1613,8 @@ HartreeFock::ObaraSaika::_compute_2e_fock_uhf(
     const Eigen::MatrixXd &Pa,
     const Eigen::MatrixXd &Pb,
     const std::size_t nbasis,
+    const HartreeFock::ERIKernel kernel,
+    const double omega,
     const double tol_eri,
     const std::vector<HartreeFock::SignedAOSymOp> *sym_ops)
 {
@@ -1586,7 +1666,8 @@ HartreeFock::ObaraSaika::_compute_2e_fock_uhf(
 
             const double val = _contracted_eri(spAB, spCD,
                                                lAx, lAy, lAz, lBx, lBy, lBz,
-                                               lCx, lCy, lCz, lDx, lDy, lDz);
+                                               lCx, lCy, lCz, lDx, lDy, lDz,
+                                               kernel, omega);
 
             if (!use_sym)
             {
@@ -1732,7 +1813,8 @@ static Eigen::MatrixXd _compute_schwarz_table(
 
         const double diag = _contracted_eri(sp, sp,
                                             lAx, lAy, lAz, lBx, lBy, lBz,
-                                            lAx, lAy, lAz, lBx, lBy, lBz);
+                                            lAx, lAy, lAz, lBx, lBy, lBz,
+                                            HartreeFock::ERIKernel::Coulomb, 0.0);
         const double q = std::sqrt(std::abs(diag));
         if (!use_sym)
         {
@@ -1755,6 +1837,8 @@ static Eigen::MatrixXd _compute_schwarz_table(
 std::vector<double> HartreeFock::ObaraSaika::_compute_2e(
     const std::vector<HartreeFock::ShellPair> &shell_pairs,
     const std::size_t nbasis,
+    const HartreeFock::ERIKernel kernel,
+    const double omega,
     const double tol_eri,
     const std::vector<HartreeFock::SignedAOSymOp> *sym_ops)
 {
@@ -1810,7 +1894,8 @@ std::vector<double> HartreeFock::ObaraSaika::_compute_2e(
 
             const double val = _contracted_eri(spAB, spCD,
                                                lAx, lAy, lAz, lBx, lBy, lBz,
-                                               lCx, lCy, lCz, lDx, lDy, lDz);
+                                               lCx, lCy, lCz, lDx, lDy, lDz,
+                                               kernel, omega);
 
             if (!use_sym)
             {

--- a/src/integrals/os.h
+++ b/src/integrals/os.h
@@ -40,6 +40,8 @@ namespace HartreeFock
         // quartets with Q(i,j)·Q(k,l) < tol_eri are skipped.
         std::vector<double> _compute_2e(const std::vector<HartreeFock::ShellPair> &shell_pairs,
                                         std::size_t nbasis,
+                                        HartreeFock::ERIKernel kernel = HartreeFock::ERIKernel::Coulomb,
+                                        double omega = 0.0,
                                         double tol_eri = 1e-10,
                                         const std::vector<HartreeFock::SignedAOSymOp> *sym_ops = nullptr);
 
@@ -50,7 +52,9 @@ namespace HartreeFock
             int lAx, int lAy, int lAz,
             int lBx, int lBy, int lBz,
             int lCx, int lCy, int lCz,
-            int lDx, int lDy, int lDz);
+            int lDx, int lDy, int lDz,
+            HartreeFock::ERIKernel kernel = HartreeFock::ERIKernel::Coulomb,
+            double omega = 0.0);
 
         Eigen::MatrixXd _compute_fock_rhf(const std::vector<double> &_eri,
                                           const Eigen::MatrixXd &density,
@@ -66,6 +70,8 @@ namespace HartreeFock
         Eigen::MatrixXd _compute_2e_fock(const std::vector<HartreeFock::ShellPair> &shell_pairs,
                                          const Eigen::MatrixXd &density,
                                          std::size_t nbasis,
+                                         HartreeFock::ERIKernel kernel = HartreeFock::ERIKernel::Coulomb,
+                                         double omega = 0.0,
                                          double tol_eri = 1e-10,
                                          const std::vector<HartreeFock::SignedAOSymOp> *sym_ops = nullptr);
 
@@ -76,6 +82,8 @@ namespace HartreeFock
                              const Eigen::MatrixXd &Pa,
                              const Eigen::MatrixXd &Pb,
                              std::size_t nbasis,
+                             HartreeFock::ERIKernel kernel = HartreeFock::ERIKernel::Coulomb,
+                             double omega = 0.0,
                              double tol_eri = 1e-10,
                              const std::vector<HartreeFock::SignedAOSymOp> *sym_ops = nullptr);
 

--- a/src/integrals/rys.cpp
+++ b/src/integrals/rys.cpp
@@ -52,6 +52,36 @@ namespace
         int sign = 1;
     };
 
+    struct ScreenedKernelData
+    {
+        double rho = 0.0;
+        double prefactor_scale = 1.0;
+        double boys_scale = 1.0;
+    };
+
+    static ScreenedKernelData screened_kernel_data(
+        double rho,
+        HartreeFock::ERIKernel kernel,
+        double omega) noexcept
+    {
+        if (kernel == HartreeFock::ERIKernel::Coulomb)
+            return ScreenedKernelData{.rho = rho, .prefactor_scale = 1.0, .boys_scale = 1.0};
+
+        if (omega <= 0.0)
+        {
+            return kernel == HartreeFock::ERIKernel::LongRange
+                       ? ScreenedKernelData{.rho = 0.0, .prefactor_scale = 0.0, .boys_scale = 0.0}
+                       : ScreenedKernelData{.rho = rho, .prefactor_scale = 1.0, .boys_scale = 1.0};
+        }
+
+        const double omega2 = omega * omega;
+        const double lambda = omega2 / (omega2 + rho);
+        return ScreenedKernelData{
+            .rho = lambda * rho,
+            .prefactor_scale = std::sqrt(lambda),
+            .boys_scale = lambda};
+    }
+
     static bool use_symmetry_ops(const SymOps *sym_ops)
     {
         return sym_ops != nullptr && sym_ops->size() > 1;
@@ -226,14 +256,16 @@ static double _auto_contracted_eri(
     int lAx, int lAy, int lAz,
     int lBx, int lBy, int lBz,
     int lCx, int lCy, int lCz,
-    int lDx, int lDy, int lDz) noexcept
+    int lDx, int lDy, int lDz,
+    HartreeFock::ERIKernel kernel,
+    double omega) noexcept
 {
     if (_auto_prefers_rys(spAB, spCD))
         return HartreeFock::RysQuad::_rys_contracted_eri(
-            spAB, spCD, lAx, lAy, lAz, lBx, lBy, lBz, lCx, lCy, lCz, lDx, lDy, lDz);
+            spAB, spCD, lAx, lAy, lAz, lBx, lBy, lBz, lCx, lCy, lCz, lDx, lDy, lDz, kernel, omega);
 
     return HartreeFock::ObaraSaika::_contracted_eri_elem(
-        spAB, spCD, lAx, lAy, lAz, lBx, lBy, lBz, lCx, lCy, lCz, lDx, lDy, lDz);
+        spAB, spCD, lAx, lAy, lAz, lBx, lBy, lBz, lCx, lCy, lCz, lDx, lDy, lDz, kernel, omega);
 }
 
 // ─── 1D Rys VRR ───────────────────────────────────────────────────────────────
@@ -373,7 +405,9 @@ double HartreeFock::RysQuad::_rys_eri_primitive(
     const int lCx, const int lCy, const int lCz,
     const int lDx, const int lDy, const int lDz,
     const double ABx, const double ABy, const double ABz,
-    const double CDx, const double CDy, const double CDz) noexcept
+    const double CDx, const double CDy, const double CDz,
+    HartreeFock::ERIKernel kernel,
+    double omega) noexcept
 {
     // Derived quantities
     const double zeta = ppAB.zeta;
@@ -381,8 +415,10 @@ double HartreeFock::RysQuad::_rys_eri_primitive(
     const double delta = zeta + eta;
     const double inv_delta = 1.0 / delta;
     const double rho = zeta * eta * inv_delta;
-    const double rho_over_zeta = rho * ppAB.inv_zeta;
-    const double rho_over_eta = rho * ppCD.inv_zeta;
+    const ScreenedKernelData screen = screened_kernel_data(rho, kernel, omega);
+    const double effective_rho = screen.rho;
+    const double rho_over_zeta = effective_rho * ppAB.inv_zeta;
+    const double rho_over_eta = effective_rho * ppCD.inv_zeta;
 
     // Gaussian product centers P and Q
     const double Px = ppAB.center[0], Py = ppAB.center[1], Pz = ppAB.center[2];
@@ -390,7 +426,7 @@ double HartreeFock::RysQuad::_rys_eri_primitive(
 
     // PQ displacement and Boys argument T = rho * |PQ|^2
     const double PQx = Px - Qx, PQy = Py - Qy, PQz = Pz - Qz;
-    const double T = rho * (PQx * PQx + PQy * PQy + PQz * PQz);
+    const double T = screen.boys_scale * rho * (PQx * PQx + PQy * PQy + PQz * PQz);
 
     // PA and QC vectors (stored in PrimitivePair.pA)
     const double PAx = ppAB.pA[0], PAy = ppAB.pA[1], PAz = ppAB.pA[2];
@@ -406,7 +442,9 @@ double HartreeFock::RysQuad::_rys_eri_primitive(
     const double WQx = Wx - Qx, WQy = Wy - Qy, WQz = Wz - Qz;
 
     // Overall prefactor: K_AB * K_CD * 2*sqrt(rho/pi)
-    const double prefac = ppAB.prefactor * ppCD.prefactor * 2.0 * std::sqrt(rho / std::numbers::pi);
+    const double prefac =
+        ppAB.prefactor * ppCD.prefactor * 2.0 * std::sqrt(rho / std::numbers::pi) *
+        screen.prefactor_scale;
 
     // Number of Rys roots
     const int lABx = lAx + lBx, lABy = lAy + lBy, lABz = lAz + lBz;
@@ -492,7 +530,9 @@ double HartreeFock::RysQuad::_rys_contracted_eri(
     const int lAx, const int lAy, const int lAz,
     const int lBx, const int lBy, const int lBz,
     const int lCx, const int lCy, const int lCz,
-    const int lDx, const int lDy, const int lDz) noexcept
+    const int lDx, const int lDy, const int lDz,
+    HartreeFock::ERIKernel kernel,
+    double omega) noexcept
 {
     const double ABx = spAB.R[0], ABy = spAB.R[1], ABz = spAB.R[2];
     const double CDx = spCD.R[0], CDy = spCD.R[1], CDz = spCD.R[2];
@@ -500,7 +540,26 @@ double HartreeFock::RysQuad::_rys_contracted_eri(
     double eri = 0.0;
     for (const auto &ppAB : spAB.primitive_pairs)
         for (const auto &ppCD : spCD.primitive_pairs)
-            eri += ppAB.coeff_product * ppCD.coeff_product * _rys_eri_primitive(ppAB, ppCD, lAx, lAy, lAz, lBx, lBy, lBz, lCx, lCy, lCz, lDx, lDy, lDz, ABx, ABy, ABz, CDx, CDy, CDz);
+        {
+            const double full =
+                _rys_eri_primitive(ppAB, ppCD, lAx, lAy, lAz, lBx, lBy, lBz,
+                                   lCx, lCy, lCz, lDx, lDy, lDz,
+                                   ABx, ABy, ABz, CDx, CDy, CDz,
+                                   HartreeFock::ERIKernel::Coulomb, 0.0);
+
+            double value = full;
+            if (kernel != HartreeFock::ERIKernel::Coulomb)
+            {
+                const double long_range =
+                    _rys_eri_primitive(ppAB, ppCD, lAx, lAy, lAz, lBx, lBy, lBz,
+                                       lCx, lCy, lCz, lDx, lDy, lDz,
+                                       ABx, ABy, ABz, CDx, CDy, CDz,
+                                       HartreeFock::ERIKernel::LongRange, omega);
+                value = (kernel == HartreeFock::ERIKernel::LongRange) ? long_range : (full - long_range);
+            }
+
+            eri += ppAB.coeff_product * ppCD.coeff_product * value;
+        }
     return eri;
 }
 
@@ -558,6 +617,8 @@ static Eigen::MatrixXd _rys_schwarz_table(
 std::vector<double> HartreeFock::RysQuad::_compute_2e(
     const std::vector<HartreeFock::ShellPair> &shell_pairs,
     const std::size_t nbasis,
+    const HartreeFock::ERIKernel kernel,
+    const double omega,
     const double tol_eri,
     const std::vector<HartreeFock::SignedAOSymOp> *sym_ops)
 {
@@ -605,7 +666,8 @@ std::vector<double> HartreeFock::RysQuad::_compute_2e(
             const double val = HartreeFock::RysQuad::_rys_contracted_eri(
                 spAB, spCD,
                 lAx, lAy, lAz, lBx, lBy, lBz,
-                lCx, lCy, lCz, lDx, lDy, lDz);
+                lCx, lCy, lCz, lDx, lDy, lDz,
+                kernel, omega);
 
             if (!use_sym)
             {
@@ -629,6 +691,8 @@ std::vector<double> HartreeFock::RysQuad::_compute_2e(
 std::vector<double> HartreeFock::RysQuad::_compute_2e_auto(
     const std::vector<HartreeFock::ShellPair> &shell_pairs,
     const std::size_t nbasis,
+    const HartreeFock::ERIKernel kernel,
+    const double omega,
     const double tol_eri,
     const std::vector<HartreeFock::SignedAOSymOp> *sym_ops)
 {
@@ -675,7 +739,8 @@ std::vector<double> HartreeFock::RysQuad::_compute_2e_auto(
             const int lDx = spCD.B._cartesian[0], lDy = spCD.B._cartesian[1], lDz = spCD.B._cartesian[2];
             const double val = _auto_contracted_eri(spAB, spCD,
                                                     lAx, lAy, lAz, lBx, lBy, lBz,
-                                                    lCx, lCy, lCz, lDx, lDy, lDz);
+                                                    lCx, lCy, lCz, lDx, lDy, lDz,
+                                                    kernel, omega);
 
             if (!use_sym)
             {
@@ -702,6 +767,8 @@ Eigen::MatrixXd HartreeFock::RysQuad::_compute_2e_fock(
     const std::vector<HartreeFock::ShellPair> &shell_pairs,
     const Eigen::MatrixXd &density,
     const std::size_t nbasis,
+    const HartreeFock::ERIKernel kernel,
+    const double omega,
     const double tol_eri,
     const std::vector<HartreeFock::SignedAOSymOp> *sym_ops)
 {
@@ -709,7 +776,7 @@ Eigen::MatrixXd HartreeFock::RysQuad::_compute_2e_fock(
     const std::size_t nb2 = nb * nb;
     const std::size_t nb3 = nb * nb * nb;
 
-    std::vector<double> eri = _compute_2e(shell_pairs, nbasis, tol_eri, sym_ops);
+    std::vector<double> eri = _compute_2e(shell_pairs, nbasis, kernel, omega, tol_eri, sym_ops);
 
     Eigen::MatrixXd G = Eigen::MatrixXd::Zero(nb, nb);
 
@@ -732,6 +799,8 @@ HartreeFock::RysQuad::_compute_2e_fock_uhf(
     const Eigen::MatrixXd &Pa,
     const Eigen::MatrixXd &Pb,
     const std::size_t nbasis,
+    const HartreeFock::ERIKernel kernel,
+    const double omega,
     const double tol_eri,
     const std::vector<HartreeFock::SignedAOSymOp> *sym_ops)
 {
@@ -740,7 +809,7 @@ HartreeFock::RysQuad::_compute_2e_fock_uhf(
     const std::size_t nb3 = nb * nb * nb;
 
     const Eigen::MatrixXd Pt = Pa + Pb;
-    std::vector<double> eri = _compute_2e(shell_pairs, nbasis, tol_eri, sym_ops);
+    std::vector<double> eri = _compute_2e(shell_pairs, nbasis, kernel, omega, tol_eri, sym_ops);
 
     Eigen::MatrixXd Ga = Eigen::MatrixXd::Zero(nb, nb);
     Eigen::MatrixXd Gb = Eigen::MatrixXd::Zero(nb, nb);
@@ -773,13 +842,15 @@ Eigen::MatrixXd HartreeFock::RysQuad::_compute_2e_fock_auto(
     const std::vector<HartreeFock::ShellPair> &shell_pairs,
     const Eigen::MatrixXd &density,
     const std::size_t nbasis,
+    const HartreeFock::ERIKernel kernel,
+    const double omega,
     const double tol_eri,
     const std::vector<HartreeFock::SignedAOSymOp> *sym_ops)
 {
     const std::size_t nb = nbasis;
     const std::size_t nb2 = nb * nb;
     const std::size_t nb3 = nb * nb * nb;
-    std::vector<double> eri = _compute_2e_auto(shell_pairs, nbasis, tol_eri, sym_ops);
+    std::vector<double> eri = _compute_2e_auto(shell_pairs, nbasis, kernel, omega, tol_eri, sym_ops);
     Eigen::MatrixXd G = Eigen::MatrixXd::Zero(nb, nb);
 
 #pragma omp parallel for schedule(static)
@@ -798,6 +869,8 @@ HartreeFock::RysQuad::_compute_2e_fock_uhf_auto(
     const Eigen::MatrixXd &Pa,
     const Eigen::MatrixXd &Pb,
     const std::size_t nbasis,
+    const HartreeFock::ERIKernel kernel,
+    const double omega,
     const double tol_eri,
     const std::vector<HartreeFock::SignedAOSymOp> *sym_ops)
 {
@@ -805,7 +878,7 @@ HartreeFock::RysQuad::_compute_2e_fock_uhf_auto(
     const std::size_t nb2 = nb * nb;
     const std::size_t nb3 = nb * nb * nb;
     const Eigen::MatrixXd Pt = Pa + Pb;
-    std::vector<double> eri = _compute_2e_auto(shell_pairs, nbasis, tol_eri, sym_ops);
+    std::vector<double> eri = _compute_2e_auto(shell_pairs, nbasis, kernel, omega, tol_eri, sym_ops);
     Eigen::MatrixXd Ga = Eigen::MatrixXd::Zero(nb, nb);
     Eigen::MatrixXd Gb = Eigen::MatrixXd::Zero(nb, nb);
 

--- a/src/integrals/rys.h
+++ b/src/integrals/rys.h
@@ -28,7 +28,9 @@ namespace HartreeFock
             int lCx, int lCy, int lCz,
             int lDx, int lDy, int lDz,
             double ABx, double ABy, double ABz,
-            double CDx, double CDy, double CDz) noexcept;
+            double CDx, double CDy, double CDz,
+            HartreeFock::ERIKernel kernel = HartreeFock::ERIKernel::Coulomb,
+            double omega = 0.0) noexcept;
 
         // ── Contracted shell quartet ───────────────────────────────────────────────
         //
@@ -39,7 +41,9 @@ namespace HartreeFock
             int lAx, int lAy, int lAz,
             int lBx, int lBy, int lBz,
             int lCx, int lCy, int lCz,
-            int lDx, int lDy, int lDz) noexcept;
+            int lDx, int lDy, int lDz,
+            HartreeFock::ERIKernel kernel = HartreeFock::ERIKernel::Coulomb,
+            double omega = 0.0) noexcept;
 
         // ── Public API — mirrors ObaraSaika:: signatures ───────────────────────────
 
@@ -47,6 +51,8 @@ namespace HartreeFock
         std::vector<double> _compute_2e(
             const std::vector<HartreeFock::ShellPair> &shell_pairs,
             std::size_t nbasis,
+            HartreeFock::ERIKernel kernel = HartreeFock::ERIKernel::Coulomb,
+            double omega = 0.0,
             double tol_eri = 1e-10,
             const std::vector<HartreeFock::SignedAOSymOp> *sym_ops = nullptr);
 
@@ -54,6 +60,8 @@ namespace HartreeFock
             const std::vector<HartreeFock::ShellPair> &shell_pairs,
             const Eigen::MatrixXd &density,
             std::size_t nbasis,
+            HartreeFock::ERIKernel kernel = HartreeFock::ERIKernel::Coulomb,
+            double omega = 0.0,
             double tol_eri = 1e-10,
             const std::vector<HartreeFock::SignedAOSymOp> *sym_ops = nullptr);
 
@@ -64,6 +72,8 @@ namespace HartreeFock
             const Eigen::MatrixXd &Pa,
             const Eigen::MatrixXd &Pb,
             std::size_t nbasis,
+            HartreeFock::ERIKernel kernel = HartreeFock::ERIKernel::Coulomb,
+            double omega = 0.0,
             double tol_eri = 1e-10,
             const std::vector<HartreeFock::SignedAOSymOp> *sym_ops = nullptr);
 
@@ -75,6 +85,8 @@ namespace HartreeFock
         std::vector<double> _compute_2e_auto(
             const std::vector<HartreeFock::ShellPair> &shell_pairs,
             std::size_t nbasis,
+            HartreeFock::ERIKernel kernel = HartreeFock::ERIKernel::Coulomb,
+            double omega = 0.0,
             double tol_eri = 1e-10,
             const std::vector<HartreeFock::SignedAOSymOp> *sym_ops = nullptr);
 
@@ -82,6 +94,8 @@ namespace HartreeFock
             const std::vector<HartreeFock::ShellPair> &shell_pairs,
             const Eigen::MatrixXd &density,
             std::size_t nbasis,
+            HartreeFock::ERIKernel kernel = HartreeFock::ERIKernel::Coulomb,
+            double omega = 0.0,
             double tol_eri = 1e-10,
             const std::vector<HartreeFock::SignedAOSymOp> *sym_ops = nullptr);
 
@@ -91,6 +105,8 @@ namespace HartreeFock
             const Eigen::MatrixXd &Pa,
             const Eigen::MatrixXd &Pb,
             std::size_t nbasis,
+            HartreeFock::ERIKernel kernel = HartreeFock::ERIKernel::Coulomb,
+            double omega = 0.0,
             double tol_eri = 1e-10,
             const std::vector<HartreeFock::SignedAOSymOp> *sym_ops = nullptr);
 

--- a/src/io/io.cpp
+++ b/src/io/io.cpp
@@ -10,6 +10,7 @@
 
 #include <Eigen/Geometry>
 
+#include "dft/base/wrapper.h"
 #include "io.h"
 #include "io/logging.h"
 #include "lookup/elements.h"
@@ -57,6 +58,22 @@ namespace HartreeFock::IO
             line.erase(pos);
         trim(line);
         return line;
+    }
+
+    static std::expected<int, std::string> resolve_libxc_name_or_id(
+        const std::string &value,
+        const std::string &label)
+    {
+        auto resolved = DFT::XC::functional_id(value);
+        if (!resolved)
+        {
+            return std::unexpected(
+                std::format("{} {} (and libxc resolution failed: {})",
+                            label,
+                            value,
+                            resolved.error()));
+        }
+        return resolved;
     }
 
     static std::expected<bool, std::string> toBool(const std::string &parsedString)
@@ -922,21 +939,39 @@ namespace HartreeFock::IO
                 {"exchange", [&dft](const std::string &value) -> std::expected<void, std::string>
                  {
                      auto parsed = map_string_enum<HartreeFock::XCExchangeFunctional>(value);
-                     if (!parsed)
-                         return std::unexpected(parsed.error());
-                     dft._exchange = *parsed;
-                     if (dft._exchange != HartreeFock::XCExchangeFunctional::Custom)
-                         dft._exchange_id = 0;
+                     if (parsed)
+                     {
+                         dft._exchange = *parsed;
+                         if (dft._exchange != HartreeFock::XCExchangeFunctional::Custom)
+                             dft._exchange_id = 0;
+                         return std::expected<void, std::string>{};
+                     }
+
+                     auto exchange_id = resolve_libxc_name_or_id(value, "Invalid XC exchange functional :");
+                     if (!exchange_id)
+                         return std::unexpected(exchange_id.error());
+
+                     dft._exchange = HartreeFock::XCExchangeFunctional::Custom;
+                     dft._exchange_id = *exchange_id;
                      return std::expected<void, std::string>{};
                  }},
                 {"correlation", [&dft](const std::string &value) -> std::expected<void, std::string>
                  {
                      auto parsed = map_string_enum<HartreeFock::XCCorrelationFunctional>(value);
-                     if (!parsed)
-                         return std::unexpected(parsed.error());
-                     dft._correlation = *parsed;
-                     if (dft._correlation != HartreeFock::XCCorrelationFunctional::Custom)
-                         dft._correlation_id = 0;
+                     if (parsed)
+                     {
+                         dft._correlation = *parsed;
+                         if (dft._correlation != HartreeFock::XCCorrelationFunctional::Custom)
+                             dft._correlation_id = 0;
+                         return std::expected<void, std::string>{};
+                     }
+
+                     auto correlation_id = resolve_libxc_name_or_id(value, "Invalid XC correlation functional :");
+                     if (!correlation_id)
+                         return std::unexpected(correlation_id.error());
+
+                     dft._correlation = HartreeFock::XCCorrelationFunctional::Custom;
+                     dft._correlation_id = *correlation_id;
                      return std::expected<void, std::string>{};
                  }},
                 {"exchange_id", [&dft](const std::string &value) -> std::expected<void, std::string>

--- a/src/post_hf/integrals.cpp
+++ b/src/post_hf/integrals.cpp
@@ -54,7 +54,8 @@ namespace HartreeFock::Correlation
         const std::size_t nb = calc._shells.nbasis();
         HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, tag,
                                      std::format("Building AO ERI tensor ({:.1f} MB)", nb * nb * nb * nb * 8.0 / 1e6));
-        eri_local = _compute_2e(shell_pairs, nb, calc._integral._engine, 1e-10,
+        eri_local = _compute_2e(shell_pairs, nb, calc._integral._engine,
+                                HartreeFock::ERIKernel::Coulomb, 0.0, 1e-10,
                                 calc._use_integral_symmetry ? &calc._integral_symmetry_ops : nullptr);
         return eri_local;
     }

--- a/src/post_hf/mp2_gradient.cpp
+++ b/src/post_hf/mp2_gradient.cpp
@@ -87,6 +87,8 @@ namespace
             density,
             calculator._shells.nbasis(),
             calculator._integral._engine,
+            HartreeFock::ERIKernel::Coulomb,
+            0.0,
             calculator._integral._tol_eri,
             calculator._use_integral_symmetry ? &calculator._integral_symmetry_ops : nullptr);
     }

--- a/src/scf/scf.cpp
+++ b/src/scf/scf.cpp
@@ -256,6 +256,7 @@ std::expected<void, std::string> HartreeFock::SCF::run_rhf(
         HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "2e Integrals :",
                                      std::format("Building ERI tensor ({:.1f} MB)", nbasis * nbasis * nbasis * nbasis * 8.0 / 1e6));
         eri = _compute_2e(shell_pairs, nbasis, calculator._integral._engine,
+                          HartreeFock::ERIKernel::Coulomb, 0.0,
                           calculator._integral._tol_eri,
                           calculator._use_integral_symmetry ? &calculator._integral_symmetry_ops : nullptr);
         calculator._eri = eri; // persist for post-HF use
@@ -279,7 +280,8 @@ std::expected<void, std::string> HartreeFock::SCF::run_rhf(
         // ── Build two-electron contribution G = J - 0.5*K ────────────────────
         Eigen::MatrixXd G = use_conventional
                                 ? HartreeFock::ObaraSaika::_compute_fock_rhf(eri, P, nbasis)
-                                : _compute_2e_fock(shell_pairs, P, nbasis, calculator._integral._engine, tol_eri,
+                                : _compute_2e_fock(shell_pairs, P, nbasis, calculator._integral._engine,
+                                                   HartreeFock::ERIKernel::Coulomb, 0.0, tol_eri,
                                                    calculator._use_integral_symmetry ? &calculator._integral_symmetry_ops : nullptr);
 
         Eigen::MatrixXd V_pcm = Eigen::MatrixXd::Zero(nbasis, nbasis);
@@ -551,6 +553,7 @@ std::expected<void, std::string> HartreeFock::SCF::run_uhf(
         HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "2e Integrals :",
                                      std::format("Building ERI tensor ({:.1f} MB)", nbasis * nbasis * nbasis * nbasis * 8.0 / 1e6));
         eri = _compute_2e(shell_pairs, nbasis, calculator._integral._engine,
+                          HartreeFock::ERIKernel::Coulomb, 0.0,
                           calculator._integral._tol_eri,
                           calculator._use_integral_symmetry ? &calculator._integral_symmetry_ops : nullptr);
         calculator._eri = eri; // persist for post-HF use
@@ -581,7 +584,8 @@ std::expected<void, std::string> HartreeFock::SCF::run_uhf(
         // ── Two-electron Fock contributions ───────────────────────────────────
         auto [Ga, Gb] = use_conventional
                             ? HartreeFock::ObaraSaika::_compute_fock_uhf(eri, Pa, Pb, nbasis)
-                            : _compute_2e_fock_uhf(shell_pairs, Pa, Pb, nbasis, calculator._integral._engine, tol_eri,
+                            : _compute_2e_fock_uhf(shell_pairs, Pa, Pb, nbasis, calculator._integral._engine,
+                                                   HartreeFock::ERIKernel::Coulomb, 0.0, tol_eri,
                                                    calculator._use_integral_symmetry ? &calculator._integral_symmetry_ops : nullptr);
 
         const Eigen::MatrixXd P_total = Pa + Pb;
@@ -1067,6 +1071,7 @@ std::expected<void, std::string> HartreeFock::SCF::run_rohf(
         HartreeFock::Logger::logging(HartreeFock::LogLevel::Info, "2e Integrals :",
                                      std::format("Building ERI tensor ({:.1f} MB)", nbasis * nbasis * nbasis * nbasis * 8.0 / 1e6));
         eri = _compute_2e(shell_pairs, nbasis, calculator._integral._engine,
+                          HartreeFock::ERIKernel::Coulomb, 0.0,
                           calculator._integral._tol_eri,
                           calculator._use_integral_symmetry ? &calculator._integral_symmetry_ops : nullptr);
         calculator._eri = eri;
@@ -1088,7 +1093,8 @@ std::expected<void, std::string> HartreeFock::SCF::run_rohf(
 
         auto [Ga, Gb] = use_conventional
                             ? HartreeFock::ObaraSaika::_compute_fock_uhf(eri, Pa, Pb, nbasis)
-                            : _compute_2e_fock_uhf(shell_pairs, Pa, Pb, nbasis, calculator._integral._engine, tol_eri,
+                            : _compute_2e_fock_uhf(shell_pairs, Pa, Pb, nbasis, calculator._integral._engine,
+                                                   HartreeFock::ERIKernel::Coulomb, 0.0, tol_eri,
                                                    calculator._use_integral_symmetry ? &calculator._integral_symmetry_ops : nullptr);
 
         const Eigen::MatrixXd Fa = H + Ga;

--- a/tests/README.md
+++ b/tests/README.md
@@ -15,9 +15,10 @@ This directory now separates lightweight regression inputs from heavier benchmar
 - `benchmarks/`
   - `casscf/archive/` for older exploratory CASSCF inputs and logs
   - `casscf/pyscf_reference/` for the PySCF-backed CASSCF reference corpus
+  - `dft/pyscf_reference/` for DFT cross-check and timing scripts against PySCF
   - `scf/engine_symmetry/` for engine/symmetry/SAD benchmark matrices
 - `pyscf/`
-  - External PySCF references for validating selected CASSCF energies
+  - External PySCF references for validating selected CASSCF, CC, and DFT energies
 - `run_regressions.py`
   - Manifest-driven binary runner for `hartree-fock` and `planck-dft`
 - `regression_cases.json`

--- a/tests/benchmarks/dft/pyscf_reference/benchmark.py
+++ b/tests/benchmarks/dft/pyscf_reference/benchmark.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+PYSCF_DIR = REPO_ROOT / "tests" / "pyscf"
+if str(PYSCF_DIR) not in sys.path:
+    sys.path.insert(0, str(PYSCF_DIR))
+
+from dft_case_utils import run_planck_dft, run_pyscf_reference  # noqa: E402
+
+CASE_INPUTS = {
+    "h2_dft_hse06_sto3g": REPO_ROOT / "tests/inputs/regression/dft/h2_dft_hse06.hfinp",
+    "h2_dft_b2plyp_sto3g": REPO_ROOT / "tests/inputs/regression/dft/h2_dft_b2plyp.hfinp",
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Benchmark Planck DFT against PySCF references")
+    parser.add_argument("--case", action="append", default=[])
+    args = parser.parse_args()
+
+    selected = args.case or list(CASE_INPUTS)
+    unknown = sorted(set(selected) - set(CASE_INPUTS))
+    if unknown:
+        print(f"Unknown case(s): {', '.join(unknown)}", file=sys.stderr)
+        return 1
+
+    header = (
+        f"{'Case':<24} {'PySCF / Eh':>16} {'Planck / Eh':>16} "
+        f"{'Delta / Eh':>12} {'PySCF s':>10} {'Planck s':>10} {'Planck/PySCF':>14}"
+    )
+    sep = "-" * len(header)
+    print(sep)
+    print(header)
+    print(sep)
+
+    for case_id in selected:
+        input_path = CASE_INPUTS[case_id]
+        pyscf_result = run_pyscf_reference(input_path)
+        planck_total, planck_time = run_planck_dft(input_path)
+        delta_total = abs(pyscf_result["total_energy"] - planck_total)
+        ratio = planck_time / pyscf_result["elapsed_s"] if pyscf_result["elapsed_s"] > 0.0 else float("nan")
+        print(
+            f"{case_id:<24} {pyscf_result['total_energy']:>16.10f} {planck_total:>16.10f} "
+            f"{delta_total:>12.2e} {pyscf_result['elapsed_s']:>10.3f} {planck_time:>10.3f} {ratio:>14.3f}"
+        )
+
+    print(sep)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmarks/dft/pyscf_reference/grid_sweep.py
+++ b/tests/benchmarks/dft/pyscf_reference/grid_sweep.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+PYSCF_DIR = REPO_ROOT / "tests" / "pyscf"
+if str(PYSCF_DIR) not in sys.path:
+    sys.path.insert(0, str(PYSCF_DIR))
+
+from dft_case_utils import (  # noqa: E402
+    run_planck_dft_with_grid,
+    run_pyscf_reference,
+)
+
+CASE_INPUTS = {
+    "h2_dft_b3lyp_sto3g": REPO_ROOT / "tests/inputs/regression/dft/h2_dft_b3lyp.hfinp",
+    "h2_dft_hse06_sto3g": REPO_ROOT / "tests/inputs/regression/dft/h2_dft_hse06.hfinp",
+    "h2_dft_b2plyp_sto3g": REPO_ROOT / "tests/inputs/regression/dft/h2_dft_b2plyp.hfinp",
+}
+
+GRID_ORDER = ("coarse", "normal", "fine", "ultrafine")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Sweep Planck and PySCF DFT grids side by side")
+    parser.add_argument("--case", action="append", default=[])
+    args = parser.parse_args()
+
+    selected = args.case or list(CASE_INPUTS)
+    unknown = sorted(set(selected) - set(CASE_INPUTS))
+    if unknown:
+        print(f"Unknown case(s): {', '.join(unknown)}", file=sys.stderr)
+        return 1
+
+    header = (
+        f"{'Case':<24} {'Grid':<10} {'PySCF / Eh':>16} {'Planck / Eh':>16} "
+        f"{'Delta / Eh':>12} {'PySCF s':>10} {'Planck s':>10}"
+    )
+    sep = "-" * len(header)
+    print(sep)
+    print(header)
+    print(sep)
+
+    for case_id in selected:
+        input_path = CASE_INPUTS[case_id]
+        previous_delta: float | None = None
+        for grid_name in GRID_ORDER:
+            pyscf_result = run_pyscf_reference(input_path, grid_name=grid_name)
+            planck_total, planck_time = run_planck_dft_with_grid(input_path, grid_name)
+            delta_total = abs(pyscf_result["total_energy"] - planck_total)
+            print(
+                f"{case_id:<24} {grid_name:<10} {pyscf_result['total_energy']:>16.10f} "
+                f"{planck_total:>16.10f} {delta_total:>12.2e} "
+                f"{pyscf_result['elapsed_s']:>10.3f} {planck_time:>10.3f}"
+            )
+            previous_delta = delta_total
+        print(sep)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/dft_functional_support.cpp
+++ b/tests/dft_functional_support.cpp
@@ -1,0 +1,128 @@
+#include <cmath>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include "dft/base/wrapper.h"
+
+namespace
+{
+    bool g_ok = true;
+
+    void require(bool condition, const std::string &message)
+    {
+        if (!condition)
+        {
+            std::cerr << message << '\n';
+            g_ok = false;
+        }
+    }
+
+    void require_near(double actual, double expected, double tol, const std::string &message)
+    {
+        if (std::abs(actual - expected) > tol)
+        {
+            std::ostringstream oss;
+            oss << message << ": expected " << expected << ", got " << actual
+                << " (tol " << tol << ")";
+            std::cerr << oss.str() << '\n';
+            g_ok = false;
+        }
+    }
+
+    DFT::XC::Functional require_functional(const std::string &name)
+    {
+        auto id = DFT::XC::functional_id(name);
+        if (!id)
+        {
+            std::cerr << "functional_id(" << name << ") failed: " << id.error() << '\n';
+            g_ok = false;
+            return DFT::XC::Functional::create(1, DFT::XC::Spin::Unpolarized).value();
+        }
+
+        auto functional = DFT::XC::Functional::create(*id, DFT::XC::Spin::Unpolarized);
+        if (!functional)
+        {
+            std::cerr << "Functional::create(" << name << ") failed: " << functional.error() << '\n';
+            g_ok = false;
+            return DFT::XC::Functional::create(1, DFT::XC::Spin::Unpolarized).value();
+        }
+
+        return std::move(*functional);
+    }
+
+    void test_hse06_metadata()
+    {
+        auto functional = require_functional("hse06");
+        const auto cam = functional.cam_coefficients();
+
+        require(functional.is_range_separated(), "HSE06 should be detected as range-separated");
+        require(!functional.is_double_hybrid(), "HSE06 should not be detected as a double hybrid");
+        require_near(cam.alpha, 0.0, 1e-12, "HSE06 long-range exact exchange coefficient mismatch");
+        require_near(cam.beta, 0.25, 1e-12, "HSE06 short-range exact exchange coefficient mismatch");
+        require_near(cam.omega, 0.11, 1e-12, "HSE06 omega mismatch");
+        require_near(
+            functional.fock_exchange_coefficient(),
+            0.0,
+            1e-12,
+            "HSE06 full-range exact exchange coefficient mismatch");
+        require_near(
+            functional.short_range_exchange_coefficient(),
+            0.25,
+            1e-12,
+            "HSE06 short-range exchange coefficient mismatch");
+    }
+
+    void test_b2plyp_metadata()
+    {
+        auto functional = require_functional("b2plyp");
+
+        require(!functional.is_range_separated(), "B2PLYP should not be detected as range-separated");
+        require(functional.is_double_hybrid(), "B2PLYP should be detected as a double hybrid");
+        require_near(
+            functional.fock_exchange_coefficient(),
+            0.53,
+            1e-12,
+            "B2PLYP Fock exchange coefficient mismatch");
+        require_near(
+            functional.perturbative_correlation_coefficient(),
+            0.27,
+            1e-12,
+            "B2PLYP PT2 correlation coefficient mismatch");
+    }
+
+    void test_wb2plyp_metadata()
+    {
+        auto functional = require_functional("wb2plyp");
+        const auto cam = functional.cam_coefficients();
+
+        require(functional.is_range_separated(), "wB2PLYP should be detected as range-separated");
+        require(functional.is_double_hybrid(), "wB2PLYP should be detected as a double hybrid");
+        require_near(cam.alpha, 1.0, 1e-12, "wB2PLYP long-range exact exchange coefficient mismatch");
+        require_near(cam.beta, -0.47, 1e-12, "wB2PLYP short-range exact exchange coefficient mismatch");
+        require_near(cam.omega, 0.30, 1e-12, "wB2PLYP omega mismatch");
+        require_near(
+            functional.perturbative_correlation_coefficient(),
+            0.27,
+            1e-12,
+            "wB2PLYP PT2 correlation coefficient mismatch");
+        require_near(
+            functional.fock_exchange_coefficient(),
+            1.0,
+            1e-12,
+            "wB2PLYP full-range exact exchange coefficient mismatch");
+        require_near(
+            functional.short_range_exchange_coefficient(),
+            -0.47,
+            1e-12,
+            "wB2PLYP short-range exact exchange coefficient mismatch");
+    }
+} // namespace
+
+int main()
+{
+    test_hse06_metadata();
+    test_b2plyp_metadata();
+    test_wb2plyp_metadata();
+    return g_ok ? 0 : 1;
+}

--- a/tests/inputs/regression/dft/h2_dft_b2plyp.hfinp
+++ b/tests/inputs/regression/dft/h2_dft_b2plyp.hfinp
@@ -1,0 +1,37 @@
+%begin_control
+    basis       sto-3g
+    calculation energy
+    verbosity   normal
+    basis_type  cartesian
+%end_control
+
+%begin_scf
+    scf_type    rhf
+    use_diis    .true.
+    diis_dim    6
+    engine      os
+    guess       hcore
+    max_cycles  50
+    tol_energy  1.0e-8
+    tol_density 1.0e-8
+%end_scf
+
+%begin_dft
+    grid                coarse
+    exchange            b2plyp
+    correlation         pbe
+    print_grid_summary  .true.
+%end_dft
+
+%begin_geom
+    coord_type  cartesian
+    coord_units angstrom
+    use_symm    .true.
+%end_geom
+
+%begin_coords
+2
+0   1
+H     0.000000     0.000000    -0.370000
+H     0.000000     0.000000     0.370000
+%end_coords

--- a/tests/inputs/regression/dft/h2_dft_hse06.hfinp
+++ b/tests/inputs/regression/dft/h2_dft_hse06.hfinp
@@ -1,0 +1,37 @@
+%begin_control
+    basis       sto-3g
+    calculation energy
+    verbosity   normal
+    basis_type  cartesian
+%end_control
+
+%begin_scf
+    scf_type    rhf
+    use_diis    .true.
+    diis_dim    6
+    engine      os
+    guess       hcore
+    max_cycles  50
+    tol_energy  1.0e-8
+    tol_density 1.0e-8
+%end_scf
+
+%begin_dft
+    grid                coarse
+    exchange            hse06
+    correlation         pbe
+    print_grid_summary  .true.
+%end_dft
+
+%begin_geom
+    coord_type  cartesian
+    coord_units angstrom
+    use_symm    .true.
+%end_geom
+
+%begin_coords
+2
+0   1
+H     0.000000     0.000000    -0.370000
+H     0.000000     0.000000     0.370000
+%end_coords

--- a/tests/pyscf/README.md
+++ b/tests/pyscf/README.md
@@ -1,7 +1,7 @@
 # PySCF Reference Calculations
 
-External reference suite for validating Planck CASSCF, SA-CASSCF, CCSD, and
-CCSDT energies against PySCF.
+External reference suite for validating Planck CASSCF, SA-CASSCF, CCSD,
+CCSDT, and selected DFT energies against PySCF.
 
 ## Requirements
 
@@ -58,6 +58,8 @@ tests/pyscf/.venv/bin/python tests/pyscf/run_all.py --list
 | `ethylene_casscf_ccpvdz.py` | C₂H₄ (planar) | cc-pVDZ | CAS(2e,2o) | SS-CASSCF |
 | `water_cas44_sto3g_sa2.py` | H₂O | STO-3G | CAS(4e,4o) | SA-CASSCF (2 roots) |
 | `ethylene_cas44_sto3g_sa2.py` | C₂H₄ (90° twisted) | STO-3G | CAS(4e,4o) | SA-CASSCF (2 roots) |
+| `h2_dft_hse06_sto3g.py` | H₂ | STO-3G | n/a | RKS HSE06 |
+| `h2_dft_b2plyp_sto3g.py` | H₂ | STO-3G | n/a | RKS B2PLYP + scaled MP2 |
 | `h2_rccsd_sto3g.py` | H₂ | STO-3G | n/a | RCCSD |
 | `lih_rccsdt_sto3g.py` | LiH | STO-3G | n/a | RCCSDT |
 | `b_uccsdt_sto3g.py` | B | STO-3G | n/a | UCCSD/UCCSDT |
@@ -65,7 +67,18 @@ tests/pyscf/.venv/bin/python tests/pyscf/run_all.py --list
 
 The case manifest lives in `tests/pyscf/cases.json`. All geometries match the
 Planck `.hfinp` inputs in `tests/benchmarks/casscf/pyscf_reference/` or
-`tests/inputs/regression/post_hf/`.
+`tests/inputs/regression/`.
+
+## DFT Notes
+
+- `h2_dft_hse06_sto3g.py` uses PySCF's native `hse06` libxc mapping.
+- PySCF 2.12.1 does not expose libxc's named `b2plyp` functional directly, so
+  `h2_dft_b2plyp_sto3g.py` builds the equivalent hybrid reference with the
+  custom XC string `0.53*HF + 0.47*B88, 0.73*LYP` and then adds the scaled
+  MP2 correction (`0.27 * E_MP2`) before comparing to Planck.
+- The DFT equivalence scripts force `fine` grids on both Planck and PySCF so
+  they can use microhartree-level tolerances without being dominated by coarse
+  quadrature differences.
 
 ## Tolerance
 

--- a/tests/pyscf/cases.json
+++ b/tests/pyscf/cases.json
@@ -43,6 +43,18 @@
       "allowed_statuses": ["PASS"]
     },
     {
+      "id": "h2_dft_b2plyp_sto3g",
+      "script": "tests/pyscf/h2_dft_b2plyp_sto3g.py",
+      "kind": "dft",
+      "allowed_statuses": ["PASS"]
+    },
+    {
+      "id": "h2_dft_hse06_sto3g",
+      "script": "tests/pyscf/h2_dft_hse06_sto3g.py",
+      "kind": "dft",
+      "allowed_statuses": ["PASS"]
+    },
+    {
       "id": "h2_rccsd_sto3g",
       "script": "tests/pyscf/h2_rccsd_sto3g.py",
       "kind": "cc",

--- a/tests/pyscf/dft_case_utils.py
+++ b/tests/pyscf/dft_case_utils.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+from pyscf import dft, mp
+
+from input_utils import build_molecule, grid_level, parse_input_file
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLANCK_DFT_EXE = REPO_ROOT / "build/planck-dft"
+DFT_TOTAL_PATTERN = re.compile(r"^\[INF\]\s+DFT Energy\s*:\s+([-+0-9Ee\.]+)\s+Eh", re.MULTILINE)
+
+
+def parse_last_float(pattern: re.Pattern[str], text: str, label: str) -> float:
+    matches = pattern.findall(text)
+    if not matches:
+        raise RuntimeError(f"Could not parse {label} from output")
+    return float(matches[-1])
+
+
+def manual_reference_spec(exchange_name: str) -> tuple[str, float]:
+    exchange = exchange_name.strip().lower()
+    if exchange == "b3lyp":
+        return "b3lyp", 0.0
+    if exchange == "hse06":
+        return "hse06", 0.0
+    if exchange == "b2plyp":
+        return "0.53*HF + 0.47*B88, 0.73*LYP", 0.27
+    raise ValueError(
+        f"PySCF reference mapping is not implemented for exchange functional {exchange_name!r}"
+    )
+
+
+def run_planck_dft(input_path: Path) -> tuple[float, float]:
+    if not PLANCK_DFT_EXE.exists():
+        raise RuntimeError(f"Planck DFT executable not found: {PLANCK_DFT_EXE}")
+
+    start = time.perf_counter()
+    proc = subprocess.run(
+        [str(PLANCK_DFT_EXE), str(input_path)],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    elapsed = time.perf_counter() - start
+    output = proc.stdout + proc.stderr
+    if proc.returncode != 0:
+        raise RuntimeError(
+            "Planck DFT run failed\n"
+            f"exit code: {proc.returncode}\n"
+            "---- output ----\n"
+            f"{output}"
+        )
+
+    return parse_last_float(DFT_TOTAL_PATTERN, output, "DFT total energy"), elapsed
+
+
+def with_grid_override(input_path: Path, grid_name: str) -> str:
+    lines = input_path.read_text(encoding="utf-8").splitlines()
+    out: list[str] = []
+    in_dft = False
+    replaced = False
+    for line in lines:
+        stripped = line.strip().lower()
+        if stripped.startswith("%begin_dft"):
+            in_dft = True
+            out.append(line)
+            continue
+        if stripped.startswith("%end_dft"):
+            if in_dft and not replaced:
+                out.append(f"    grid                {grid_name}")
+            in_dft = False
+            out.append(line)
+            continue
+        if in_dft and stripped.startswith("grid"):
+            out.append(f"    grid                {grid_name}")
+            replaced = True
+            continue
+        out.append(line)
+    return "\n".join(out) + "\n"
+
+
+def run_planck_dft_with_grid(input_path: Path, grid_name: str) -> tuple[float, float]:
+    contents = with_grid_override(input_path, grid_name)
+    with tempfile.NamedTemporaryFile("w", suffix=".hfinp", delete=False) as handle:
+        handle.write(contents)
+        temp_path = Path(handle.name)
+    try:
+        return run_planck_dft(temp_path)
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
+def run_pyscf_reference(input_path: Path, grid_name: str | None = None) -> dict[str, Any]:
+    spec = parse_input_file(input_path)
+    if grid_name is not None:
+        spec["dft"]["grid"] = grid_name
+    mol = build_molecule(spec)
+    dft_section = spec["dft"]
+    scf_section = spec["scf"]
+    xc_string, pt2_scale = manual_reference_spec(dft_section["exchange"])
+
+    if scf_section.get("scf_type", "rhf").lower() not in {"rhf", "rks"}:
+        raise ValueError(f"Only closed-shell RKS/RHF DFT references are supported for {input_path}")
+
+    mf = dft.RKS(mol)
+    mf.conv_tol = float(scf_section.get("tol_energy", "1e-10"))
+    mf.grids.level = grid_level(dft_section.get("grid", dft_section.get("grid_level", "normal")))
+    mf.xc = xc_string
+
+    start = time.perf_counter()
+    scf_energy = float(mf.kernel())
+    pt2_energy = 0.0
+    if abs(pt2_scale) > 0.0:
+        pt2_energy = float(mp.MP2(mf).kernel()[0])
+    total_energy = scf_energy + pt2_scale * pt2_energy
+    elapsed = time.perf_counter() - start
+
+    return {
+        "scf_energy": scf_energy,
+        "pt2_energy": pt2_energy,
+        "pt2_scale": pt2_scale,
+        "total_energy": total_energy,
+        "elapsed_s": elapsed,
+        "xc_string": xc_string,
+    }

--- a/tests/pyscf/generate_regression_references.py
+++ b/tests/pyscf/generate_regression_references.py
@@ -11,6 +11,8 @@ from typing import Any
 
 from pyscf import cc, dft, gto, mp, scf
 
+from input_utils import build_molecule, grid_level, parse_input_file
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_MANIFEST = REPO_ROOT / "tests" / "pyscf" / "regression_reference_cases.json"
 DEFAULT_OUTPUT = REPO_ROOT / "tests" / "pyscf" / "regression_references.json"
@@ -24,81 +26,6 @@ def load_manifest(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def parse_bool(value: str) -> bool:
-    return value.strip().lower() in {".true.", "true", "yes", "1"}
-
-
-def parse_input_file(path: Path) -> dict[str, Any]:
-    sections: dict[str, list[str]] = {}
-    current: str | None = None
-    for raw_line in path.read_text(encoding="utf-8").splitlines():
-        line = raw_line.split("#", 1)[0].rstrip()
-        stripped = line.strip()
-        if not stripped:
-            continue
-        lower = stripped.lower()
-        if lower.startswith("%begin_"):
-            current = lower[len("%begin_"):]
-            sections[current] = []
-            continue
-        if lower.startswith("%end_"):
-            current = None
-            continue
-        if current is not None:
-            sections[current].append(stripped)
-
-    parsed: dict[str, Any] = {}
-    for name in ("control", "scf", "geom", "dft"):
-        values: dict[str, str] = {}
-        for entry in sections.get(name, []):
-            parts = entry.split()
-            if parts:
-                values[parts[0].lower()] = " ".join(parts[1:])
-        parsed[name] = values
-
-    coords_lines = sections.get("coords", [])
-    if len(coords_lines) < 2:
-        raise ValueError(f"{path} is missing a valid coords section")
-    natoms = int(coords_lines[0].split()[0])
-    charge, multiplicity = (int(x) for x in coords_lines[1].split()[:2])
-    atoms: list[tuple[str, tuple[float, float, float]]] = []
-    for entry in coords_lines[2 : 2 + natoms]:
-        symbol, x, y, z = entry.split()[:4]
-        atoms.append((symbol, (float(x), float(y), float(z))))
-    parsed["coords"] = {
-        "natoms": natoms,
-        "charge": charge,
-        "multiplicity": multiplicity,
-        "atoms": atoms,
-    }
-    return parsed
-
-
-def build_molecule(spec: dict[str, Any]) -> gto.Mole:
-    control = spec["control"]
-    geom = spec["geom"]
-    coords = spec["coords"]
-    basis_name = control["basis"].lower()
-    basis_aliases = {
-        "cc-pvdz-unc": "cc-pvdz",
-    }
-
-    mol = gto.Mole()
-    mol.atom = "\n".join(
-        f"{symbol} {xyz[0]:.10f} {xyz[1]:.10f} {xyz[2]:.10f}"
-        for symbol, xyz in coords["atoms"]
-    )
-    mol.basis = basis_aliases.get(basis_name, control["basis"])
-    mol.charge = coords["charge"]
-    mol.spin = coords["multiplicity"] - 1
-    mol.cart = control.get("basis_type", "cartesian").lower() == "cartesian"
-    mol.symmetry = parse_bool(geom.get("use_symm", ".false."))
-    mol.unit = "Bohr" if geom.get("coord_units", "angstrom").lower() == "bohr" else "Angstrom"
-    mol.verbose = 0
-    mol.build()
-    return mol
-
-
 def functional_string(dft_section: dict[str, str]) -> str:
     exchange = dft_section.get("exchange", "").strip().lower()
     correlation = dft_section.get("correlation", "").strip().lower()
@@ -109,15 +36,6 @@ def functional_string(dft_section: dict[str, str]) -> str:
     if correlation == "vwn":
         correlation = "vwn5"
     return f"{exchange},{correlation}"
-
-
-def grid_level(name: str) -> int:
-    return {
-        "coarse": 0,
-        "normal": 1,
-        "fine": 3,
-        "ultrafine": 5,
-    }.get(name.lower(), 1)
 
 
 def run_input_case(case: dict[str, Any]) -> dict[str, float]:

--- a/tests/pyscf/h2_dft_b2plyp_sto3g.py
+++ b/tests/pyscf/h2_dft_b2plyp_sto3g.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""
+PySCF vs Planck cross-check: H2 B2PLYP/STO-3G
+Matches Planck input: tests/inputs/regression/dft/h2_dft_b2plyp.hfinp
+
+PySCF 2.12.1 does not expose libxc's named B2PLYP functional directly, so this
+reference is assembled as the libxc-equivalent hybrid SCF expression plus the
+scaled MP2 correction.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from dft_case_utils import REPO_ROOT, run_planck_dft_with_grid, run_pyscf_reference
+
+CASE = "h2_dft_b2plyp_sto3g"
+GRID = "fine"
+TOLERANCE = 1e-6
+INPUT_PATH = REPO_ROOT / "tests/inputs/regression/dft/h2_dft_b2plyp.hfinp"
+
+
+def main() -> int:
+    pyscf_result = run_pyscf_reference(INPUT_PATH, grid_name=GRID)
+    planck_total, planck_time = run_planck_dft_with_grid(INPUT_PATH, GRID)
+
+    delta_total = abs(pyscf_result["total_energy"] - planck_total)
+    status = "PASS" if delta_total < TOLERANCE else "FAIL"
+
+    print(f"CASE:           {CASE}")
+    print(f"GRID:           {GRID}")
+    print(f"PYSCF_XC:       {pyscf_result['xc_string']}")
+    print(f"PYSCF_SCFREF:   {pyscf_result['scf_energy']:.10f} Eh")
+    print(f"PYSCF_PT2:      {pyscf_result['pt2_energy']:.10f} Eh")
+    print(f"PYSCF_PT2_W:    {pyscf_result['pt2_scale']:.2f}")
+    print(f"PYSCF_TOTAL:    {pyscf_result['total_energy']:.10f} Eh")
+    print(f"PLANCK_TOTAL:   {planck_total:.10f} Eh")
+    print(f"DELTA_TOTAL:    {delta_total:.2e} Eh")
+    print(f"PYSCF_TIME:     {pyscf_result['elapsed_s']:.3f} s")
+    print(f"PLANCK_TIME:    {planck_time:.3f} s")
+    print(f"STATUS:         {status}")
+    return 0 if status == "PASS" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/pyscf/h2_dft_hse06_sto3g.py
+++ b/tests/pyscf/h2_dft_hse06_sto3g.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""
+PySCF vs Planck cross-check: H2 HSE06/STO-3G
+Matches Planck input: tests/inputs/regression/dft/h2_dft_hse06.hfinp
+"""
+
+from __future__ import annotations
+
+import sys
+
+from dft_case_utils import REPO_ROOT, run_planck_dft_with_grid, run_pyscf_reference
+
+CASE = "h2_dft_hse06_sto3g"
+GRID = "fine"
+TOLERANCE = 1e-6
+INPUT_PATH = REPO_ROOT / "tests/inputs/regression/dft/h2_dft_hse06.hfinp"
+
+
+def main() -> int:
+    pyscf_result = run_pyscf_reference(INPUT_PATH, grid_name=GRID)
+    planck_total, planck_time = run_planck_dft_with_grid(INPUT_PATH, GRID)
+
+    delta_total = abs(pyscf_result["total_energy"] - planck_total)
+    status = "PASS" if delta_total < TOLERANCE else "FAIL"
+
+    print(f"CASE:           {CASE}")
+    print(f"GRID:           {GRID}")
+    print(f"PYSCF_XC:       {pyscf_result['xc_string']}")
+    print(f"PYSCF_TOTAL:    {pyscf_result['total_energy']:.10f} Eh")
+    print(f"PLANCK_TOTAL:   {planck_total:.10f} Eh")
+    print(f"DELTA_TOTAL:    {delta_total:.2e} Eh")
+    print(f"PYSCF_TIME:     {pyscf_result['elapsed_s']:.3f} s")
+    print(f"PLANCK_TIME:    {planck_time:.3f} s")
+    print(f"STATUS:         {status}")
+    return 0 if status == "PASS" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/pyscf/input_utils.py
+++ b/tests/pyscf/input_utils.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from pyscf import gto
+
+
+def parse_bool(value: str) -> bool:
+    return value.strip().lower() in {".true.", "true", "yes", "1"}
+
+
+def parse_input_file(path: Path) -> dict[str, Any]:
+    sections: dict[str, list[str]] = {}
+    current: str | None = None
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.split("#", 1)[0].rstrip()
+        stripped = line.strip()
+        if not stripped:
+            continue
+        lower = stripped.lower()
+        if lower.startswith("%begin_"):
+            current = lower[len("%begin_") :]
+            sections[current] = []
+            continue
+        if lower.startswith("%end_"):
+            current = None
+            continue
+        if current is not None:
+            sections[current].append(stripped)
+
+    parsed: dict[str, Any] = {}
+    for name in ("control", "scf", "geom", "dft"):
+        values: dict[str, str] = {}
+        for entry in sections.get(name, []):
+            parts = entry.split()
+            if parts:
+                values[parts[0].lower()] = " ".join(parts[1:])
+        parsed[name] = values
+
+    coords_lines = sections.get("coords", [])
+    if len(coords_lines) < 2:
+        raise ValueError(f"{path} is missing a valid coords section")
+    natoms = int(coords_lines[0].split()[0])
+    charge, multiplicity = (int(x) for x in coords_lines[1].split()[:2])
+    atoms: list[tuple[str, tuple[float, float, float]]] = []
+    for entry in coords_lines[2 : 2 + natoms]:
+        symbol, x, y, z = entry.split()[:4]
+        atoms.append((symbol, (float(x), float(y), float(z))))
+    parsed["coords"] = {
+        "natoms": natoms,
+        "charge": charge,
+        "multiplicity": multiplicity,
+        "atoms": atoms,
+    }
+    return parsed
+
+
+def build_molecule(spec: dict[str, Any]) -> gto.Mole:
+    control = spec["control"]
+    geom = spec["geom"]
+    coords = spec["coords"]
+    basis_name = control["basis"].lower()
+    basis_aliases = {
+        "cc-pvdz-unc": "cc-pvdz",
+    }
+
+    mol = gto.Mole()
+    mol.atom = "\n".join(
+        f"{symbol} {xyz[0]:.10f} {xyz[1]:.10f} {xyz[2]:.10f}"
+        for symbol, xyz in coords["atoms"]
+    )
+    mol.basis = basis_aliases.get(basis_name, control["basis"])
+    mol.charge = coords["charge"]
+    mol.spin = coords["multiplicity"] - 1
+    mol.cart = control.get("basis_type", "cartesian").lower() == "cartesian"
+    mol.symmetry = parse_bool(geom.get("use_symm", ".false."))
+    mol.unit = "Bohr" if geom.get("coord_units", "angstrom").lower() == "bohr" else "Angstrom"
+    mol.verbose = 0
+    mol.build()
+    return mol
+
+
+def grid_level(name: str) -> int:
+    return {
+        "coarse": 0,
+        "normal": 1,
+        "fine": 3,
+        "ultrafine": 5,
+    }.get(name.lower(), 1)

--- a/tests/pyscf/run_all.py
+++ b/tests/pyscf/run_all.py
@@ -138,7 +138,7 @@ def main() -> int:
     parser.add_argument("--manifest", default=str(DEFAULT_MANIFEST))
     parser.add_argument("--python", default=str(DEFAULT_PYTHON))
     parser.add_argument("--case", action="append", default=[])
-    parser.add_argument("--kind", choices=["all", "casscf", "cc"], default="all")
+    parser.add_argument("--kind", choices=["all", "casscf", "cc", "dft"], default="all")
     parser.add_argument("--timeout", type=int, default=600)
     parser.add_argument("--list", action="store_true")
     args = parser.parse_args()

--- a/tests/regression_cases.json
+++ b/tests/regression_cases.json
@@ -599,6 +599,43 @@
       ]
     },
     {
+      "id": "h2_dft_hse06_sto3g",
+      "input": "tests/inputs/regression/dft/h2_dft_hse06.hfinp",
+      "executable": "planck-dft",
+      "tags": ["smoke", "core", "extended"],
+      "expected_exit_code": 0,
+      "contains": [
+        "Reference :                   RKS",
+        "DFT Correlation :             Using HSE06 as a combined XC functional; configured correlation is ignored",
+        "DFT 2e Integrals :            Building short-range ERI tensor for omega = 0.110000 (0.0 MB)",
+        "RKS Converged :",
+        "DFT Energy :"
+      ],
+      "checks": [
+        {"type": "metric_eq", "metric": "point_group", "expected": "Dinfh"},
+        {"type": "metric_close", "metric": "dft_total_energy", "expected": -1.1527116906, "atol": 1e-9}
+      ]
+    },
+    {
+      "id": "h2_dft_b2plyp_sto3g",
+      "input": "tests/inputs/regression/dft/h2_dft_b2plyp.hfinp",
+      "executable": "planck-dft",
+      "tags": ["smoke", "core", "extended"],
+      "expected_exit_code": 0,
+      "contains": [
+        "Reference :                   RKS",
+        "DFT Hybrid XC :               Double hybrid of Grimme exact exchange coefficient = 0.530000",
+        "DFT Double Hybrid :           Double hybrid of Grimme PT2 correlation coefficient = 0.270000",
+        "DFT Correlation :             Using Double hybrid of Grimme as a combined XC functional; configured correlation is ignored",
+        "RKS Converged :",
+        "DFT Energy :"
+      ],
+      "checks": [
+        {"type": "metric_eq", "metric": "point_group", "expected": "Dinfh"},
+        {"type": "metric_close", "metric": "dft_total_energy", "expected": -1.1479369543, "atol": 1e-9}
+      ]
+    },
+    {
       "id": "water_triplet_uks_pbe_sto3g",
       "input": "tests/inputs/regression/dft/water_triplet_uks_pbe_sto3g.hfinp",
       "executable": "planck-dft",


### PR DESCRIPTION
Implement screened two-electron integral kernels and use them in the KS DFT driver for range-separated exchange. Introduce an ERIKernel enum with Coulomb, long-range, and short-range variants, thread the kernel/omega parameters through the OS and Rys integral engines, and keep existing HF/post-HF call sites on explicit Coulomb defaults. Update the DFT libxc wrapper to expose CAM and PT2 metadata, allow exchange/correlation keywords to fall back to libxc names, and extend the KS driver to cache short-range AO ERI tensors, build exact exchange as alpha*K(full) + beta*K(SR, omega), and apply post-KS MP2-like corrections for double hybrids.

Add regression and validation coverage for the new functional families. Extend the functional support test, add HSE06 and B2PLYP regression inputs and expectations, and add PySCF-backed DFT equivalence scripts plus benchmark/grid-sweep tooling. The PySCF DFT checks now run on fine grids by default so cross-code agreement is tested at the microhartree level instead of being dominated by coarse-grid quadrature differences. Update README, QUICKSTART, and the teaching guide to document screened ERIs, range-separated and double-hybrid single-point support, and the new benchmarking story.