### PR TITLE
Optimize ERI scratch and XC assembly hot paths

### DIFF
--- a/src/dft/ks_matrix.cpp
+++ b/src/dft/ks_matrix.cpp
@@ -53,20 +53,25 @@ namespace DFT
                 density.grad_z(point)};
         }
 
-        Eigen::VectorXd gradient_projection(
+        void gradient_projection(
             const AOGridEvaluation &ao_grid,
             Eigen::Index point,
-            const Eigen::Vector3d &coefficient)
+            const Eigen::Vector3d &coefficient,
+            Eigen::Ref<Eigen::VectorXd> output)
         {
-            return (coefficient.x() * ao_grid.grad_x.row(point).transpose() + coefficient.y() * ao_grid.grad_y.row(point).transpose() + coefficient.z() * ao_grid.grad_z.row(point).transpose()).eval();
+            output.noalias() =
+                coefficient.x() * ao_grid.grad_x.row(point).transpose() +
+                coefficient.y() * ao_grid.grad_y.row(point).transpose() +
+                coefficient.z() * ao_grid.grad_z.row(point).transpose();
         }
 
+        template <typename PhiDerived, typename GradDerived>
         void accumulate_local_potential(
             Eigen::Ref<Eigen::MatrixXd> matrix,
             double weight,
             double vrho,
-            const Eigen::VectorXd &phi,
-            const Eigen::VectorXd &gradient_term)
+            const Eigen::MatrixBase<PhiDerived> &phi,
+            const Eigen::MatrixBase<GradDerived> &gradient_term)
         {
             if (weight == 0.0)
                 return;
@@ -103,6 +108,8 @@ namespace DFT
         {
             Eigen::MatrixXd alpha_local = Eigen::MatrixXd::Zero(nbasis, nbasis);
             Eigen::MatrixXd beta_local = Eigen::MatrixXd::Zero(nbasis, nbasis);
+            Eigen::VectorXd gradient_term_alpha = Eigen::VectorXd::Zero(nbasis);
+            Eigen::VectorXd gradient_term_beta = Eigen::VectorXd::Zero(nbasis);
 
 #ifdef USE_OPENMP
 #pragma omp for nowait schedule(static)
@@ -113,17 +120,17 @@ namespace DFT
                 if (weight == 0.0)
                     continue;
 
-                const Eigen::VectorXd phi = ao_grid.values.row(point).transpose();
+                const auto phi = ao_grid.values.row(point).transpose();
 
                 if (!polarized)
                 {
-                    Eigen::VectorXd gradient_term = Eigen::VectorXd::Zero(nbasis);
+                    gradient_term_alpha.setZero();
                     if (xc_grid.vsigma.cols() == 1)
                     {
                         const Eigen::Vector3d coefficient =
                             2.0 * xc_grid.vsigma(point, 0) *
                             density_gradient_at(xc_grid.density.total, point);
-                        gradient_term = gradient_projection(ao_grid, point, coefficient);
+                        gradient_projection(ao_grid, point, coefficient, gradient_term_alpha);
                     }
 
                     accumulate_local_potential(
@@ -131,12 +138,12 @@ namespace DFT
                         weight,
                         xc_grid.vrho(point, 0),
                         phi,
-                        gradient_term);
+                        gradient_term_alpha);
                     continue;
                 }
 
-                Eigen::VectorXd gradient_term_alpha = Eigen::VectorXd::Zero(nbasis);
-                Eigen::VectorXd gradient_term_beta = Eigen::VectorXd::Zero(nbasis);
+                gradient_term_alpha.setZero();
+                gradient_term_beta.setZero();
 
                 if (xc_grid.vsigma.cols() == 3)
                 {
@@ -148,8 +155,8 @@ namespace DFT
                     const Eigen::Vector3d coefficient_beta =
                         xc_grid.vsigma(point, 1) * grad_alpha + 2.0 * xc_grid.vsigma(point, 2) * grad_beta;
 
-                    gradient_term_alpha = gradient_projection(ao_grid, point, coefficient_alpha);
-                    gradient_term_beta = gradient_projection(ao_grid, point, coefficient_beta);
+                    gradient_projection(ao_grid, point, coefficient_alpha, gradient_term_alpha);
+                    gradient_projection(ao_grid, point, coefficient_beta, gradient_term_beta);
                 }
 
                 accumulate_local_potential(

--- a/src/integrals/os.cpp
+++ b/src/integrals/os.cpp
@@ -171,8 +171,16 @@ namespace
         int cy_dim = 0;
         int cz_dim = 0;
         int m_dim = 0;
+        std::size_t ax_stride = 0;
+        std::size_t ay_stride = 0;
+        std::size_t az_stride = 0;
+        std::size_t cx_stride = 0;
+        std::size_t cy_stride = 0;
+        std::size_t cz_stride = 0;
         std::vector<double> vrr;
         std::vector<double> hrr;
+        double *vrr_data = nullptr;
+        double *hrr_data = nullptr;
 
         void resize_for_quartet(
             int lABx, int lABy, int lABz,
@@ -186,25 +194,35 @@ namespace
             cy_dim = lCDy + 1;
             cz_dim = lCDz + 1;
             m_dim = mmax + 1;
+            cz_stride = 1;
+            cy_stride = static_cast<std::size_t>(cz_dim) * cz_stride;
+            cx_stride = static_cast<std::size_t>(cy_dim) * cy_stride;
+            az_stride = static_cast<std::size_t>(cx_dim) * cx_stride;
+            ay_stride = static_cast<std::size_t>(az_dim) * az_stride;
+            ax_stride = static_cast<std::size_t>(ay_dim) * ay_stride;
 
             const std::size_t spatial =
                 static_cast<std::size_t>(ax_dim) * ay_dim * az_dim *
                 cx_dim * cy_dim * cz_dim;
-            vrr.assign(spatial * static_cast<std::size_t>(m_dim), 0.0);
+            const std::size_t vrr_size = spatial * static_cast<std::size_t>(m_dim);
+            if (vrr.size() != vrr_size)
+                vrr.resize(vrr_size);
+            std::fill(vrr.begin(), vrr.end(), 0.0);
             hrr.resize(spatial);
+            vrr_data = vrr.data();
+            hrr_data = hrr.data();
         }
 
         std::size_t spatial_index(
             int ax, int ay, int az,
             int cx, int cy, int cz) const
         {
-            std::size_t idx = static_cast<std::size_t>(ax);
-            idx = idx * static_cast<std::size_t>(ay_dim) + static_cast<std::size_t>(ay);
-            idx = idx * static_cast<std::size_t>(az_dim) + static_cast<std::size_t>(az);
-            idx = idx * static_cast<std::size_t>(cx_dim) + static_cast<std::size_t>(cx);
-            idx = idx * static_cast<std::size_t>(cy_dim) + static_cast<std::size_t>(cy);
-            idx = idx * static_cast<std::size_t>(cz_dim) + static_cast<std::size_t>(cz);
-            return idx;
+            return static_cast<std::size_t>(ax) * ax_stride +
+                   static_cast<std::size_t>(ay) * ay_stride +
+                   static_cast<std::size_t>(az) * az_stride +
+                   static_cast<std::size_t>(cx) * cx_stride +
+                   static_cast<std::size_t>(cy) * cy_stride +
+                   static_cast<std::size_t>(cz) * cz_stride;
         }
 
         double &v(
@@ -212,9 +230,9 @@ namespace
             int cx, int cy, int cz,
             int m)
         {
-            return vrr[spatial_index(ax, ay, az, cx, cy, cz) *
-                           static_cast<std::size_t>(m_dim) +
-                       static_cast<std::size_t>(m)];
+            return vrr_data[spatial_index(ax, ay, az, cx, cy, cz) *
+                                static_cast<std::size_t>(m_dim) +
+                            static_cast<std::size_t>(m)];
         }
 
         const double &v(
@@ -222,23 +240,23 @@ namespace
             int cx, int cy, int cz,
             int m) const
         {
-            return vrr[spatial_index(ax, ay, az, cx, cy, cz) *
-                           static_cast<std::size_t>(m_dim) +
-                       static_cast<std::size_t>(m)];
+            return vrr_data[spatial_index(ax, ay, az, cx, cy, cz) *
+                                static_cast<std::size_t>(m_dim) +
+                            static_cast<std::size_t>(m)];
         }
 
         double &h(
             int ax, int ay, int az,
             int cx, int cy, int cz)
         {
-            return hrr[spatial_index(ax, ay, az, cx, cy, cz)];
+            return hrr_data[spatial_index(ax, ay, az, cx, cy, cz)];
         }
 
         const double &h(
             int ax, int ay, int az,
             int cx, int cy, int cz) const
         {
-            return hrr[spatial_index(ax, ay, az, cx, cy, cz)];
+            return hrr_data[spatial_index(ax, ay, az, cx, cy, cz)];
         }
     };
 

--- a/src/io/io.cpp
+++ b/src/io/io.cpp
@@ -10,10 +10,13 @@
 
 #include <Eigen/Geometry>
 
-#include "dft/base/wrapper.h"
 #include "io.h"
 #include "io/logging.h"
 #include "lookup/elements.h"
+
+#ifdef USING_Libxc
+#include "dft/base/wrapper.h"
+#endif
 
 namespace HartreeFock::IO
 {
@@ -64,6 +67,7 @@ namespace HartreeFock::IO
         const std::string &value,
         const std::string &label)
     {
+#ifdef USING_Libxc
         auto resolved = DFT::XC::functional_id(value);
         if (!resolved)
         {
@@ -74,6 +78,12 @@ namespace HartreeFock::IO
                             resolved.error()));
         }
         return resolved;
+#else
+        return std::unexpected(
+            std::format("{} {} (libxc support is unavailable in this executable)",
+                        label,
+                        value));
+#endif
     }
 
     static std::expected<bool, std::string> toBool(const std::string &parsedString)


### PR DESCRIPTION
Tighten two geometry-optimization hotspots without changing the existing module boundaries or introducing nested parallelism.

In the Obara-Saika ERI path, cache multidimensional strides and raw buffer pointers in EriScratch, reuse the existing VRR allocation when the quartet shape is unchanged, and keep the same recurrence structure and call graph.

In the DFT XC assembly path, reuse per-thread gradient work vectors inside assemble_xc_matrix instead of allocating fresh temporaries for each quadrature point. Keep the current OpenMP structure and reduction pattern intact.

Also guard the libxc parser include in io.cpp behind USING_Libxc so hartree-fock rebuilds cleanly without depending on xc.h at compile time.

Benchmark results on the profiled water geometry optimizations:

- hartree-fock, OMP_NUM_THREADS=1: 42.378 s -> 30.868 s
- hartree-fock, OMP_NUM_THREADS=8: 40.990 s -> 32.800 s
- planck-dft, OMP_NUM_THREADS=1: 62.415 s -> 53.796 s
- planck-dft, OMP_NUM_THREADS=8: 43.213 s -> 37.052 s

Final energies were unchanged for all benchmarked runs.