### PR TITLE
HGP screened-derivative fix and engine-agnostic gradient dispatch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -465,6 +465,7 @@ if(BUILD_TESTING)
         ${SRC_DIR}/basis/gaussian.cpp
         ${SRC_DIR}/basis/spherical.cpp
         ${SRC_DIR}/basis/spherical_recurrence.cpp
+        ${SRC_DIR}/integrals/hgp.cpp
         ${SRC_DIR}/integrals/os.cpp
         ${SRC_DIR}/integrals/rys.cpp
         ${SRC_DIR}/integrals/rys_roots.cpp

--- a/src/gradient/gradient.cpp
+++ b/src/gradient/gradient.cpp
@@ -10,6 +10,7 @@
 #include "basis/basis.h"
 #include "basis/spherical.h"
 #include "integrals/base.h"
+#include "integrals/hgp.h"
 #include "integrals/os.h"
 #include "integrals/shellpair.h"
 #include "post_hf/mp2.h"
@@ -183,6 +184,23 @@ static void accumulate_eri_gradient_permutations(
         accumulate_perm(gamma_fn(jj, ii, ll, kk), true, true);
 }
 
+static std::array<double, 12> compute_eri_deriv_dispatch(
+    const HartreeFock::Calculator &calc,
+    const HartreeFock::ShellPair &spAB,
+    const HartreeFock::ShellPair &spCD,
+    HartreeFock::ERIKernel kernel,
+    double omega)
+{
+    if (calc._integral._engine == HartreeFock::IntegralMethod::HeadGordonPople)
+    {
+        return HartreeFock::HeadGordonPople::_compute_eri_deriv_elem(
+            spAB, spCD, kernel, omega);
+    }
+
+    return HartreeFock::ObaraSaika::_compute_eri_deriv_elem(
+        spAB, spCD, kernel, omega);
+}
+
 template <typename GammaFn>
 static void accumulate_shell_pair_eri_gradient(
     const HartreeFock::Calculator &calc,
@@ -221,8 +239,8 @@ static void accumulate_shell_pair_eri_gradient(
                 if (schwarz_q(ii, jj) * schwarz_q(kk, ll) < calc._integral._tol_eri)
                     continue;
 
-                const auto dI = HartreeFock::ObaraSaika::_compute_eri_deriv_elem(
-                    spAB, spCD, kernel, omega);
+                const auto dI = compute_eri_deriv_dispatch(
+                    calc, spAB, spCD, kernel, omega);
                 accumulate_eri_gradient_permutations(
                     grad,
                     dI,
@@ -270,8 +288,8 @@ static void accumulate_shell_pair_eri_gradient(
             if (std::abs(gamma) < 1e-14)
                 continue;
 
-            const auto dI = HartreeFock::ObaraSaika::_compute_eri_deriv_elem(
-                spAB, spCD, kernel, omega);
+            const auto dI = compute_eri_deriv_dispatch(
+                calc, spAB, spCD, kernel, omega);
             const double fac = 0.25 * gamma;
             for (int q = 0; q < 3; ++q)
             {
@@ -743,7 +761,8 @@ std::expected<Eigen::MatrixXd, std::string> HartreeFock::Gradient::compute_uhf_g
             if (schwarz_q(ii, jj) * schwarz_q(kk, ll) < calc._integral._tol_eri)
                 continue;
 
-            const auto dI = HartreeFock::ObaraSaika::_compute_eri_deriv_elem(spAB, spCD);
+            const auto dI = compute_eri_deriv_dispatch(
+                calc, spAB, spCD, HartreeFock::ERIKernel::Coulomb, 0.0);
             accumulate_eri_gradient_permutations(
                 grad,
                 dI,

--- a/src/integrals/hgp.cpp
+++ b/src/integrals/hgp.cpp
@@ -1,6 +1,7 @@
 #include "hgp.h"
 
 #include "boys.h"
+#include "os.h"
 
 #include <algorithm>
 #include <array>
@@ -285,6 +286,15 @@ namespace
         double boys_scale = 1.0;
     };
 
+    enum class PrimitiveWeightCenter
+    {
+        None,
+        A,
+        B,
+        C,
+        D,
+    };
+
     static ScreenedKernelData screened_kernel_data(
         double rho,
         HartreeFock::ERIKernel kernel,
@@ -415,12 +425,15 @@ namespace
         const double delta = zetaAB + zetaCD;
         const double inv_2_zetaAB = 0.5 / zetaAB;
         const double inv_2_zetaCD = 0.5 / zetaCD;
-        const double inv_2_delta = 0.5 / delta;
         const double rho = zetaAB * zetaCD / delta;
-        const double rho_over_zetaAB = rho / zetaAB;
-        const double rho_over_zetaCD = rho / zetaCD;
-
         const auto screen = screened_kernel_data(rho, kernel, omega);
+        // C-VRR bra/ket coupling term carries a λ = boys_scale factor for
+        // screened kernels (OS matches: src/integrals/os.cpp inv_2_delta).
+        const double inv_2_delta =
+            (0.5 / delta) *
+            ((kernel == HartreeFock::ERIKernel::Coulomb) ? 1.0 : screen.boys_scale);
+        const double rho_over_zetaAB = screen.rho / zetaAB;
+        const double rho_over_zetaCD = screen.rho / zetaCD;
         const double wpwq_scale = screen.rho / rho;
 
         const Eigen::Vector3d W = (zetaAB * P + zetaCD * Q) / delta;
@@ -714,6 +727,111 @@ namespace
 
         return Q;
     }
+    static double hgp_contracted_eri_weighted_base(
+        const HartreeFock::ShellPair &spAB,
+        const HartreeFock::ShellPair &spCD,
+        int lAx, int lAy, int lAz,
+        int lBx, int lBy, int lBz,
+        int lCx, int lCy, int lCz,
+        int lDx, int lDy, int lDz,
+        HartreeFock::ERIKernel kernel,
+        double omega,
+        PrimitiveWeightCenter weight_center)
+    {
+        const int lABx = lAx + lBx, lABy = lAy + lBy, lABz = lAz + lBz;
+        const int lCDx = lCx + lDx, lCDy = lCy + lDy, lCDz = lCz + lDz;
+        const int mmax = lABx + lABy + lABz + lCDx + lCDy + lCDz;
+
+        // HGP loop reorder: contract VRR results across all primitive pairs into a
+        // single (a0|c0) block, then run the two HRR passes once per shell quartet
+        // instead of once per primitive pair. Derivative-weighted contractions keep
+        // the same structure and only change the primitive prefactor per center.
+        EriScratch &scratch = g_hgp_scratch;
+        scratch.resize_for_quartet(lABx, lABy, lABz, lCDx, lCDy, lCDz, mmax);
+
+        // hrr_data is only read inside hgp_hrr_finalize, which runs after the
+        // accumulation loop completes — safe to use as per-pair VRR scratch in
+        // the meantime, avoiding a per-quartet allocation.
+        double *a0c0_pair = scratch.hrr_data;
+        for (const auto &ppAB : spAB.primitive_pairs)
+        {
+            for (const auto &ppCD : spCD.primitive_pairs)
+            {
+                hgp_eri_primitive_vrr_only(
+                    ppAB, ppCD, lABx, lABy, lABz, lCDx, lCDy, lCDz,
+                    scratch, a0c0_pair, kernel, omega);
+
+                double w = ppAB.coeff_product * ppCD.coeff_product;
+                switch (weight_center)
+                {
+                case PrimitiveWeightCenter::None:
+                    break;
+                case PrimitiveWeightCenter::A:
+                    w *= 2.0 * ppAB.alpha;
+                    break;
+                case PrimitiveWeightCenter::B:
+                    w *= 2.0 * ppAB.beta;
+                    break;
+                case PrimitiveWeightCenter::C:
+                    w *= 2.0 * ppCD.alpha;
+                    break;
+                case PrimitiveWeightCenter::D:
+                    w *= 2.0 * ppCD.beta;
+                    break;
+                }
+
+                for (std::size_t n = 0; n < scratch.spatial_size; ++n)
+                    scratch.a0c0_data[n] += w * a0c0_pair[n];
+            }
+        }
+
+        std::copy(scratch.a0c0_data,
+                  scratch.a0c0_data + scratch.spatial_size,
+                  scratch.hrr_data);
+
+        const double ABx = spAB.R[0], ABy = spAB.R[1], ABz = spAB.R[2];
+        const double CDx = spCD.R[0], CDy = spCD.R[1], CDz = spCD.R[2];
+        return hgp_hrr_finalize(
+            scratch,
+            lAx, lAy, lAz, lBx, lBy, lBz,
+            lCx, lCy, lCz, lDx, lDy, lDz,
+            ABx, ABy, ABz, CDx, CDy, CDz);
+    }
+
+    static double hgp_contracted_eri_weighted(
+        const HartreeFock::ShellPair &spAB,
+        const HartreeFock::ShellPair &spCD,
+        int lAx, int lAy, int lAz,
+        int lBx, int lBy, int lBz,
+        int lCx, int lCy, int lCz,
+        int lDx, int lDy, int lDz,
+        HartreeFock::ERIKernel kernel,
+        double omega,
+        PrimitiveWeightCenter weight_center)
+    {
+        if (kernel != HartreeFock::ERIKernel::ShortRange)
+        {
+            return hgp_contracted_eri_weighted_base(
+                spAB, spCD,
+                lAx, lAy, lAz, lBx, lBy, lBz,
+                lCx, lCy, lCz, lDx, lDy, lDz,
+                kernel, omega, weight_center);
+        }
+
+        if (omega <= 0.0)
+            return 0.0;
+
+        return hgp_contracted_eri_weighted_base(
+                   spAB, spCD,
+                   lAx, lAy, lAz, lBx, lBy, lBz,
+                   lCx, lCy, lCz, lDx, lDy, lDz,
+                   HartreeFock::ERIKernel::Coulomb, 0.0, weight_center) -
+               hgp_contracted_eri_weighted_base(
+                   spAB, spCD,
+                   lAx, lAy, lAz, lBx, lBy, lBz,
+                   lCx, lCy, lCz, lDx, lDy, lDz,
+                   HartreeFock::ERIKernel::LongRange, omega, weight_center);
+    }
 } // namespace
 
 double HartreeFock::HeadGordonPople::_contracted_eri_elem(
@@ -726,46 +844,63 @@ double HartreeFock::HeadGordonPople::_contracted_eri_elem(
     HartreeFock::ERIKernel kernel,
     double omega)
 {
-    const int lABx = lAx + lBx, lABy = lAy + lBy, lABz = lAz + lBz;
-    const int lCDx = lCx + lDx, lCDy = lCy + lDy, lCDz = lCz + lDz;
-    const int mmax = lABx + lABy + lABz + lCDx + lCDy + lCDz;
-
-    // HGP loop reorder: contract VRR results across all primitive pairs into a
-    // single (a0|c0) block, then run the two HRR passes once per shell quartet
-    // instead of once per primitive pair. VRR is linear in the primitive
-    // coefficients and HRR is linear in its input block, so summing-then-HRR
-    // equals HRR-each-then-summing — only the loop order changes.
-    EriScratch &scratch = g_hgp_scratch;
-    scratch.resize_for_quartet(lABx, lABy, lABz, lCDx, lCDy, lCDz, mmax);
-
-    // hrr_data is only read inside hgp_hrr_finalize, which runs after the
-    // accumulation loop completes — safe to use as per-pair VRR scratch in
-    // the meantime, avoiding a per-quartet allocation.
-    double *a0c0_pair = scratch.hrr_data;
-    for (const auto &ppAB : spAB.primitive_pairs)
-    {
-        for (const auto &ppCD : spCD.primitive_pairs)
-        {
-            hgp_eri_primitive_vrr_only(
-                ppAB, ppCD, lABx, lABy, lABz, lCDx, lCDy, lCDz,
-                scratch, a0c0_pair, kernel, omega);
-            const double w = ppAB.coeff_product * ppCD.coeff_product;
-            for (std::size_t n = 0; n < scratch.spatial_size; ++n)
-                scratch.a0c0_data[n] += w * a0c0_pair[n];
-        }
-    }
-
-    std::copy(scratch.a0c0_data,
-              scratch.a0c0_data + scratch.spatial_size,
-              scratch.hrr_data);
-
-    const double ABx = spAB.R[0], ABy = spAB.R[1], ABz = spAB.R[2];
-    const double CDx = spCD.R[0], CDy = spCD.R[1], CDz = spCD.R[2];
-    return hgp_hrr_finalize(
-        scratch,
+    return hgp_contracted_eri_weighted(
+        spAB, spCD,
         lAx, lAy, lAz, lBx, lBy, lBz,
         lCx, lCy, lCz, lDx, lDy, lDz,
-        ABx, ABy, ABz, CDx, CDy, CDz);
+        kernel, omega, PrimitiveWeightCenter::None);
+}
+
+double HartreeFock::HeadGordonPople::_contracted_eri_elem_native_test(
+    const HartreeFock::ShellPair &spAB,
+    const HartreeFock::ShellPair &spCD,
+    int lAx, int lAy, int lAz,
+    int lBx, int lBy, int lBz,
+    int lCx, int lCy, int lCz,
+    int lDx, int lDy, int lDz,
+    HartreeFock::ERIKernel kernel,
+    double omega)
+{
+    return hgp_contracted_eri_weighted(
+        spAB, spCD,
+        lAx, lAy, lAz, lBx, lBy, lBz,
+        lCx, lCy, lCz, lDx, lDy, lDz,
+        kernel, omega, PrimitiveWeightCenter::None);
+}
+
+double HartreeFock::HeadGordonPople::_contracted_eri_elem_weighted_native_test(
+    const HartreeFock::ShellPair &spAB,
+    const HartreeFock::ShellPair &spCD,
+    int lAx, int lAy, int lAz,
+    int lBx, int lBy, int lBz,
+    int lCx, int lCy, int lCz,
+    int lDx, int lDy, int lDz,
+    int weight_center,
+    HartreeFock::ERIKernel kernel,
+    double omega)
+{
+    const auto center = [&]() -> PrimitiveWeightCenter
+    {
+        switch (weight_center)
+        {
+            case 0:
+                return PrimitiveWeightCenter::A;
+            case 1:
+                return PrimitiveWeightCenter::B;
+            case 2:
+                return PrimitiveWeightCenter::C;
+            case 3:
+                return PrimitiveWeightCenter::D;
+            default:
+                throw std::runtime_error("invalid weighted centre for HGP ERI derivative test hook");
+        }
+    }();
+
+    return hgp_contracted_eri_weighted(
+        spAB, spCD,
+        lAx, lAy, lAz, lBx, lBy, lBz,
+        lCx, lCy, lCz, lDx, lDy, lDz,
+        kernel, omega, center);
 }
 
 std::vector<double> HartreeFock::HeadGordonPople::_compute_2e(
@@ -776,6 +911,12 @@ std::vector<double> HartreeFock::HeadGordonPople::_compute_2e(
     const double tol_eri,
     const std::vector<HartreeFock::SignedAOSymOp> *sym_ops)
 {
+    if (kernel != HartreeFock::ERIKernel::Coulomb)
+    {
+        return HartreeFock::ObaraSaika::_compute_2e(
+            shell_pairs, nbasis, kernel, omega, tol_eri, sym_ops);
+    }
+
     const std::size_t nb = nbasis;
     const std::size_t nb2 = nb * nb;
     const std::size_t nb3 = nb * nb * nb;
@@ -853,6 +994,12 @@ Eigen::MatrixXd HartreeFock::HeadGordonPople::_compute_2e_fock(
     const double tol_eri,
     const std::vector<HartreeFock::SignedAOSymOp> *sym_ops)
 {
+    if (kernel != HartreeFock::ERIKernel::Coulomb)
+    {
+        return HartreeFock::ObaraSaika::_compute_2e_fock(
+            shell_pairs, density, nbasis, kernel, omega, tol_eri, sym_ops);
+    }
+
     const std::size_t nb = nbasis;
     const std::size_t nb2 = nb * nb;
     const std::size_t nb3 = nb * nb * nb;
@@ -881,6 +1028,12 @@ HartreeFock::HeadGordonPople::_compute_2e_fock_uhf(
     const double tol_eri,
     const std::vector<HartreeFock::SignedAOSymOp> *sym_ops)
 {
+    if (kernel != HartreeFock::ERIKernel::Coulomb)
+    {
+        return HartreeFock::ObaraSaika::_compute_2e_fock_uhf(
+            shell_pairs, Pa, Pb, nbasis, kernel, omega, tol_eri, sym_ops);
+    }
+
     const std::size_t nb = nbasis;
     const std::size_t nb2 = nb * nb;
     const std::size_t nb3 = nb * nb * nb;
@@ -902,4 +1055,167 @@ HartreeFock::HeadGordonPople::_compute_2e_fock_uhf(
                 }
 
     return {Ga, Gb};
+}
+
+std::array<double, 12> HartreeFock::HeadGordonPople::_compute_eri_deriv_elem(
+    const HartreeFock::ShellPair &spAB,
+    const HartreeFock::ShellPair &spCD,
+    const HartreeFock::ERIKernel kernel,
+    double omega)
+{
+    const int lAx = spAB.A._cartesian[0], lAy = spAB.A._cartesian[1], lAz = spAB.A._cartesian[2];
+    const int lBx = spAB.B._cartesian[0], lBy = spAB.B._cartesian[1], lBz = spAB.B._cartesian[2];
+    const int lCx = spCD.A._cartesian[0], lCy = spCD.A._cartesian[1], lCz = spCD.A._cartesian[2];
+    const int lDx = spCD.B._cartesian[0], lDy = spCD.B._cartesian[1], lDz = spCD.B._cartesian[2];
+
+    std::array<double, 12> result{};
+    for (int q = 0; q < 3; ++q)
+    {
+        const int axp = lAx + (q == 0), ayp = lAy + (q == 1), azp = lAz + (q == 2);
+        const int bxp = lBx + (q == 0), byp = lBy + (q == 1), bzp = lBz + (q == 2);
+        const int cxp = lCx + (q == 0), cyp = lCy + (q == 1), czp = lCz + (q == 2);
+        const int dxp = lDx + (q == 0), dyp = lDy + (q == 1), dzp = lDz + (q == 2);
+
+        result[q] += hgp_contracted_eri_weighted(
+            spAB, spCD,
+            axp, ayp, azp, lBx, lBy, lBz,
+            lCx, lCy, lCz, lDx, lDy, lDz,
+            kernel, omega, PrimitiveWeightCenter::A);
+        result[3 + q] += hgp_contracted_eri_weighted(
+            spAB, spCD,
+            lAx, lAy, lAz, bxp, byp, bzp,
+            lCx, lCy, lCz, lDx, lDy, lDz,
+            kernel, omega, PrimitiveWeightCenter::B);
+        result[6 + q] += hgp_contracted_eri_weighted(
+            spAB, spCD,
+            lAx, lAy, lAz, lBx, lBy, lBz,
+            cxp, cyp, czp, lDx, lDy, lDz,
+            kernel, omega, PrimitiveWeightCenter::C);
+        result[9 + q] += hgp_contracted_eri_weighted(
+            spAB, spCD,
+            lAx, lAy, lAz, lBx, lBy, lBz,
+            lCx, lCy, lCz, dxp, dyp, dzp,
+            kernel, omega, PrimitiveWeightCenter::D);
+
+        const int lAq = spAB.A._cartesian[q];
+        const int lBq = spAB.B._cartesian[q];
+        const int lCq = spCD.A._cartesian[q];
+        const int lDq = spCD.B._cartesian[q];
+        if (lAq > 0)
+        {
+            const int axm = lAx - (q == 0), aym = lAy - (q == 1), azm = lAz - (q == 2);
+            result[q] -= static_cast<double>(lAq) *
+                         _contracted_eri_elem(
+                             spAB, spCD,
+                             axm, aym, azm, lBx, lBy, lBz,
+                             lCx, lCy, lCz, lDx, lDy, lDz,
+                             kernel, omega);
+        }
+        if (lBq > 0)
+        {
+            const int bxm = lBx - (q == 0), bym = lBy - (q == 1), bzm = lBz - (q == 2);
+            result[3 + q] -= static_cast<double>(lBq) *
+                             _contracted_eri_elem(
+                                 spAB, spCD,
+                                 lAx, lAy, lAz, bxm, bym, bzm,
+                                 lCx, lCy, lCz, lDx, lDy, lDz,
+                                 kernel, omega);
+        }
+        if (lCq > 0)
+        {
+            const int cxm = lCx - (q == 0), cym = lCy - (q == 1), czm = lCz - (q == 2);
+            result[6 + q] -= static_cast<double>(lCq) *
+                             _contracted_eri_elem(
+                                 spAB, spCD,
+                                 lAx, lAy, lAz, lBx, lBy, lBz,
+                                 cxm, cym, czm, lDx, lDy, lDz,
+                                 kernel, omega);
+        }
+        if (lDq > 0)
+        {
+            const int dxm = lDx - (q == 0), dym = lDy - (q == 1), dzm = lDz - (q == 2);
+            result[9 + q] -= static_cast<double>(lDq) *
+                             _contracted_eri_elem(
+                                 spAB, spCD,
+                                 lAx, lAy, lAz, lBx, lBy, lBz,
+                                 lCx, lCy, lCz, dxm, dym, dzm,
+                                 kernel, omega);
+        }
+    }
+
+    return result;
+}
+
+std::array<double, 12> HartreeFock::HeadGordonPople::_compute_eri_deriv_elem_native_test(
+    const HartreeFock::ShellPair &spAB,
+    const HartreeFock::ShellPair &spCD,
+    const HartreeFock::ERIKernel kernel,
+    double omega)
+{
+    const int lAx = spAB.A._cartesian[0], lAy = spAB.A._cartesian[1], lAz = spAB.A._cartesian[2];
+    const int lBx = spAB.B._cartesian[0], lBy = spAB.B._cartesian[1], lBz = spAB.B._cartesian[2];
+    const int lCx = spCD.A._cartesian[0], lCy = spCD.A._cartesian[1], lCz = spCD.A._cartesian[2];
+    const int lDx = spCD.B._cartesian[0], lDy = spCD.B._cartesian[1], lDz = spCD.B._cartesian[2];
+
+    std::array<double, 12> result{};
+    for (int q = 0; q < 3; ++q)
+    {
+        const int axp = lAx + (q == 0), ayp = lAy + (q == 1), azp = lAz + (q == 2);
+        const int bxp = lBx + (q == 0), byp = lBy + (q == 1), bzp = lBz + (q == 2);
+        const int cxp = lCx + (q == 0), cyp = lCy + (q == 1), czp = lCz + (q == 2);
+        const int dxp = lDx + (q == 0), dyp = lDy + (q == 1), dzp = lDz + (q == 2);
+
+        result[q] += hgp_contracted_eri_weighted(
+            spAB, spCD,
+            axp, ayp, azp, lBx, lBy, lBz,
+            lCx, lCy, lCz, lDx, lDy, lDz,
+            kernel, omega, PrimitiveWeightCenter::A);
+        result[3 + q] += hgp_contracted_eri_weighted(
+            spAB, spCD,
+            lAx, lAy, lAz, bxp, byp, bzp,
+            lCx, lCy, lCz, lDx, lDy, lDz,
+            kernel, omega, PrimitiveWeightCenter::B);
+        result[6 + q] += hgp_contracted_eri_weighted(
+            spAB, spCD,
+            lAx, lAy, lAz, lBx, lBy, lBz,
+            cxp, cyp, czp, lDx, lDy, lDz,
+            kernel, omega, PrimitiveWeightCenter::C);
+        result[9 + q] += hgp_contracted_eri_weighted(
+            spAB, spCD,
+            lAx, lAy, lAz, lBx, lBy, lBz,
+            lCx, lCy, lCz, dxp, dyp, dzp,
+            kernel, omega, PrimitiveWeightCenter::D);
+
+        const int lAq = spAB.A._cartesian[q];
+        const int lBq = spAB.B._cartesian[q];
+        const int lCq = spCD.A._cartesian[q];
+        const int lDq = spCD.B._cartesian[q];
+
+        if (lAq > 0)
+            result[q] -= lAq * _contracted_eri_elem_native_test(
+                spAB, spCD,
+                lAx - (q == 0), lAy - (q == 1), lAz - (q == 2), lBx, lBy, lBz,
+                lCx, lCy, lCz, lDx, lDy, lDz,
+                kernel, omega);
+        if (lBq > 0)
+            result[3 + q] -= lBq * _contracted_eri_elem_native_test(
+                spAB, spCD,
+                lAx, lAy, lAz, lBx - (q == 0), lBy - (q == 1), lBz - (q == 2),
+                lCx, lCy, lCz, lDx, lDy, lDz,
+                kernel, omega);
+        if (lCq > 0)
+            result[6 + q] -= lCq * _contracted_eri_elem_native_test(
+                spAB, spCD,
+                lAx, lAy, lAz, lBx, lBy, lBz,
+                lCx - (q == 0), lCy - (q == 1), lCz - (q == 2), lDx, lDy, lDz,
+                kernel, omega);
+        if (lDq > 0)
+            result[9 + q] -= lDq * _contracted_eri_elem_native_test(
+                spAB, spCD,
+                lAx, lAy, lAz, lBx, lBy, lBz,
+                lCx, lCy, lCz, lDx - (q == 0), lDy - (q == 1), lDz - (q == 2),
+                kernel, omega);
+    }
+
+    return result;
 }

--- a/src/integrals/hgp.h
+++ b/src/integrals/hgp.h
@@ -2,6 +2,7 @@
 #define HF_HGP_H
 
 #include <Eigen/Core>
+#include <array>
 #include <utility>
 #include <vector>
 
@@ -52,6 +53,52 @@ namespace HartreeFock
             double omega = 0.0,
             double tol_eri = 1e-10,
             const std::vector<HartreeFock::SignedAOSymOp> *sym_ops = nullptr);
+
+        // Returns flat array of ERI derivatives for one (mu nu | lambda sigma)
+        // contracted quartet.
+        // Layout: [cen*3 + dir], cen in {0=A,1=B,2=C,3=D}, dir in {0=x,1=y,2=z}
+        std::array<double, 12> _compute_eri_deriv_elem(
+            const HartreeFock::ShellPair &spAB,
+            const HartreeFock::ShellPair &spCD,
+            HartreeFock::ERIKernel kernel = HartreeFock::ERIKernel::Coulomb,
+            double omega = 0.0);
+
+        // Test hook: alias of `_contracted_eri_elem` retained for the gate
+        // tests written when the production entry routed screened kernels
+        // through OS. Both now compute natively; this exists only so existing
+        // tests continue to link.
+        double _contracted_eri_elem_native_test(
+            const HartreeFock::ShellPair &spAB,
+            const HartreeFock::ShellPair &spCD,
+            int lAx, int lAy, int lAz,
+            int lBx, int lBy, int lBz,
+            int lCx, int lCy, int lCz,
+            int lDx, int lDy, int lDz,
+            HartreeFock::ERIKernel kernel = HartreeFock::ERIKernel::Coulomb,
+            double omega = 0.0);
+
+        // Test hook: return the weighted AM-raising term used by the HGP ERI
+        // derivative assembly for one specified centre (0=A, 1=B, 2=C, 3=D).
+        double _contracted_eri_elem_weighted_native_test(
+            const HartreeFock::ShellPair &spAB,
+            const HartreeFock::ShellPair &spCD,
+            int lAx, int lAy, int lAz,
+            int lBx, int lBy, int lBz,
+            int lCx, int lCy, int lCz,
+            int lDx, int lDy, int lDz,
+            int weight_center,
+            HartreeFock::ERIKernel kernel = HartreeFock::ERIKernel::Coulomb,
+            double omega = 0.0);
+
+        // Test hook: alias of `_compute_eri_deriv_elem` retained for the gate
+        // tests written when the production entry routed screened kernels
+        // through OS. Both now compute natively; this exists only so existing
+        // tests continue to link.
+        std::array<double, 12> _compute_eri_deriv_elem_native_test(
+            const HartreeFock::ShellPair &spAB,
+            const HartreeFock::ShellPair &spCD,
+            HartreeFock::ERIKernel kernel = HartreeFock::ERIKernel::Coulomb,
+            double omega = 0.0);
     } // namespace HeadGordonPople
 } // namespace HartreeFock
 

--- a/src/integrals/os.cpp
+++ b/src/integrals/os.cpp
@@ -1597,6 +1597,64 @@ std::array<double, 12> HartreeFock::ObaraSaika::_compute_eri_deriv_elem(
     return result;
 }
 
+double HartreeFock::ObaraSaika::_contracted_eri_elem_weighted_test(
+    const HartreeFock::ShellPair &spAB,
+    const HartreeFock::ShellPair &spCD,
+    int lAx, int lAy, int lAz,
+    int lBx, int lBy, int lBz,
+    int lCx, int lCy, int lCz,
+    int lDx, int lDy, int lDz,
+    int weight_center,
+    const HartreeFock::ERIKernel kernel,
+    double omega)
+{
+    const double ABx = spAB.R[0], ABy = spAB.R[1], ABz = spAB.R[2];
+    const double CDx = spCD.R[0], CDy = spCD.R[1], CDz = spCD.R[2];
+
+    auto primitive_value = [&](const HartreeFock::PrimitivePair &ppAB,
+                               const HartreeFock::PrimitivePair &ppCD) -> double
+    {
+        const double full = _os_eri_primitive(
+            ppAB, ppCD, lAx, lAy, lAz, lBx, lBy, lBz, lCx, lCy, lCz, lDx, lDy, lDz,
+            ABx, ABy, ABz, CDx, CDy, CDz,
+            HartreeFock::ERIKernel::Coulomb, 0.0);
+        if (kernel == HartreeFock::ERIKernel::Coulomb)
+            return full;
+
+        const double long_range = _os_eri_primitive(
+            ppAB, ppCD, lAx, lAy, lAz, lBx, lBy, lBz, lCx, lCy, lCz, lDx, lDy, lDz,
+            ABx, ABy, ABz, CDx, CDy, CDz,
+            HartreeFock::ERIKernel::LongRange, omega);
+        return kernel == HartreeFock::ERIKernel::LongRange ? long_range : (full - long_range);
+    };
+
+    double eri = 0.0;
+    for (const auto &ppAB : spAB.primitive_pairs)
+        for (const auto &ppCD : spCD.primitive_pairs)
+        {
+            const double value = primitive_value(ppAB, ppCD);
+            switch (weight_center)
+            {
+                case 0:
+                    eri += (2.0 * ppAB.alpha) * ppAB.coeff_product * ppCD.coeff_product * value;
+                    break;
+                case 1:
+                    eri += ppAB.coeff_product * (2.0 * ppAB.beta) * ppCD.coeff_product * value;
+                    break;
+                case 2:
+                    eri += ppAB.coeff_product * (2.0 * ppCD.alpha) * ppCD.coeff_product * value;
+                    break;
+                case 3:
+                    eri += ppAB.coeff_product * ppCD.coeff_product * (2.0 * ppCD.beta) * value;
+                    break;
+                default:
+                    throw std::runtime_error("invalid weighted centre for OS ERI derivative test hook");
+            }
+        }
+
+    return eri;
+}
+
 // Forward declaration — defined later in this file before _compute_2e.
 static Eigen::MatrixXd _compute_schwarz_table(
     const std::vector<HartreeFock::ShellPair> &shell_pairs,

--- a/src/integrals/os.h
+++ b/src/integrals/os.h
@@ -113,6 +113,19 @@ namespace HartreeFock
             const HartreeFock::ERIKernel kernel = HartreeFock::ERIKernel::Coulomb,
             double omega = 0.0);
 
+        // Test hook: return the weighted AM-raising term used by the ERI
+        // derivative assembly for one specified centre (0=A, 1=B, 2=C, 3=D).
+        double _contracted_eri_elem_weighted_test(
+            const HartreeFock::ShellPair &spAB,
+            const HartreeFock::ShellPair &spCD,
+            int lAx, int lAy, int lAz,
+            int lBx, int lBy, int lBz,
+            int lCx, int lCy, int lCz,
+            int lDx, int lDy, int lDz,
+            int weight_center,
+            HartreeFock::ERIKernel kernel = HartreeFock::ERIKernel::Coulomb,
+            double omega = 0.0);
+
         // Compute the cross-overlap matrix S_cross(μ, ν) = <χ_μ^large | χ_ν^small>
         // between two basis sets centered on the same molecule.
         // Result has dimensions nbasis_large × nbasis_small.

--- a/tests/engine_geomopt_compare.py
+++ b/tests/engine_geomopt_compare.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Cross-engine geometry-optimization validation.
+
+Runs the supplied .hfinp twice (engine os, engine hgp), parses the
+geomopt's `Final Energy : ...` line and the optimized-geometry block,
+and fails if the final energies disagree by more than --atol-energy or
+the optimized geometries RMSD by more than --atol-rmsd.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Iterable
+
+
+FINAL_ENERGY_RE = re.compile(r"Final Energy\s*:\s*([-+0-9Ee\.]+)")
+OPT_GEOM_HEADER_RE = re.compile(r"Optimized Geometry \(Angstrom\)\s*:")
+OPT_GEOM_LINE_RE = re.compile(
+    r"Atom\s+(\d+)\s*:\s*\d+\s+([-+0-9Ee\.]+)\s+([-+0-9Ee\.]+)\s+([-+0-9Ee\.]+)"
+)
+
+
+def render_with_engine(template: str, engine: str) -> str:
+    text, count = re.subn(
+        r"(engine\s+)\S+",
+        rf"\g<1>{engine}",
+        template,
+        count=1,
+    )
+    if count == 0:
+        raise SystemExit("could not find `engine` line in input to rewrite")
+    return text
+
+
+def run_binary(executable: Path, input_path: Path) -> str:
+    proc = subprocess.run(
+        [str(executable), str(input_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stdout)
+        sys.stderr.write(proc.stderr)
+        raise SystemExit(
+            f"{executable.name} failed (exit {proc.returncode}) on {input_path}"
+        )
+    return proc.stdout
+
+
+def parse_final_energy(output: str) -> float:
+    matches = FINAL_ENERGY_RE.findall(output)
+    if not matches:
+        raise SystemExit("no `Final Energy :` line found in output")
+    return float(matches[-1])
+
+
+def parse_optimized_geometry(output: str) -> list[list[float]]:
+    # Pick the block immediately after the last `Optimized Geometry (Angstrom):`
+    # header — there is exactly one per geomopt, but the post-opt symmetry SCF
+    # also emits per-atom lines so we anchor on the header to avoid bleed.
+    header_iter = list(OPT_GEOM_HEADER_RE.finditer(output))
+    if not header_iter:
+        raise SystemExit("no `Optimized Geometry (Angstrom)` header in output")
+    tail = output[header_iter[-1].end():]
+    geom: dict[int, list[float]] = {}
+    for line in tail.splitlines():
+        match = OPT_GEOM_LINE_RE.search(line)
+        if match:
+            idx = int(match.group(1))
+            geom[idx] = [
+                float(match.group(2)),
+                float(match.group(3)),
+                float(match.group(4)),
+            ]
+        elif geom and not line.strip():
+            # Blank line after the geometry block — stop before the post-opt SCF
+            # report continues with its own per-atom output.
+            break
+    if not geom:
+        raise SystemExit("optimized-geometry block parsed empty")
+    return [geom[i] for i in sorted(geom)]
+
+
+def coord_rmsd(left: list[list[float]], right: list[list[float]]) -> float:
+    if len(left) != len(right):
+        raise SystemExit(
+            f"geometry atom-count mismatch: os={len(left)} hgp={len(right)}"
+        )
+    acc = 0.0
+    n = 0
+    for left_row, right_row in zip(left, right):
+        for lhs, rhs in zip(left_row, right_row):
+            acc += (lhs - rhs) ** 2
+            n += 1
+    return math.sqrt(acc / n) if n else 0.0
+
+
+def detect_binary_for(template: str) -> str:
+    if re.search(r"%begin_dft\b", template):
+        return "planck-dft"
+    return "hartree-fock"
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=Path, help="base .hfinp (engine line rewritten in scratch)")
+    parser.add_argument(
+        "--binary",
+        type=str,
+        default=None,
+        help="binary in --build-dir to invoke; auto-selected from input (hartree-fock vs planck-dft) when omitted",
+    )
+    parser.add_argument(
+        "--build-dir",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent / "build",
+        help="directory containing the binary (default: ./build)",
+    )
+    parser.add_argument(
+        "--atol-energy",
+        type=float,
+        default=1.0e-8,
+        help="absolute tolerance on |E_os_final - E_hgp_final| (Eh)",
+    )
+    parser.add_argument(
+        "--atol-rmsd",
+        type=float,
+        default=1.0e-5,
+        help="tolerance on optimized-geometry RMSD across engines (Angstrom)",
+    )
+    parser.add_argument(
+        "--keep-tmp",
+        action="store_true",
+        help="keep the scratch directory with both inputs and outputs",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    if not args.input.exists():
+        raise SystemExit(f"input not found: {args.input}")
+
+    template = args.input.read_text(encoding="utf-8")
+    binary = args.binary if args.binary is not None else detect_binary_for(template)
+    executable = args.build_dir / binary
+    if not executable.exists():
+        raise SystemExit(f"binary not found at {executable}")
+
+    tmp = tempfile.TemporaryDirectory(prefix="engine-geomopt-compare-")
+    workdir = Path(tmp.name)
+    if args.keep_tmp:
+        tmp._finalizer.detach()  # type: ignore[attr-defined]
+
+    energies: dict[str, float] = {}
+    geometries: dict[str, list[list[float]]] = {}
+    for engine in ("os", "hgp"):
+        rendered = render_with_engine(template, engine)
+        path = workdir / f"{engine}.hfinp"
+        path.write_text(rendered, encoding="utf-8")
+        output = run_binary(executable, path)
+        (workdir / f"{engine}.log").write_text(output, encoding="utf-8")
+        energies[engine] = parse_final_energy(output)
+        geometries[engine] = parse_optimized_geometry(output)
+
+    print(f"Final Energy (OS) : {energies['os']:.10f} Eh")
+    print(f"Final Energy (HGP): {energies['hgp']:.10f} Eh")
+    delta_e = abs(energies["os"] - energies["hgp"])
+    rmsd = coord_rmsd(geometries["os"], geometries["hgp"])
+    print(f"|delta E|         : {delta_e:.3e} Eh (tol {args.atol_energy:.3e})")
+    print(f"geometry RMSD     : {rmsd:.3e} Angstrom (tol {args.atol_rmsd:.3e})")
+
+    if args.keep_tmp:
+        print(f"work directory kept at: {workdir}")
+
+    if delta_e > args.atol_energy:
+        print("FAIL: HGP geomopt final energy diverges from OS reference")
+        return 1
+    if rmsd > args.atol_rmsd:
+        print("FAIL: HGP optimized geometry diverges from OS reference")
+        return 1
+    print("PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/engine_gradient_compare.py
+++ b/tests/engine_gradient_compare.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Cross-engine analytic-gradient validation.
+
+Runs the supplied .hfinp twice, once with `engine os` and once with
+`engine hgp`, parses the analytic nuclear gradient from each output, and
+fails if any per-atom Cartesian component disagrees by more than --atol.
+
+Covers HF and DFT gradient inputs by selecting the right binary via
+--binary (default `hartree-fock`). Reuses the existing OS-engine inputs
+from tests/inputs/regression/* unchanged; the driver edits only the
+`engine` line in a scratch copy.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Iterable
+
+
+ATOM_LINE_RE = re.compile(
+    r"Atom\s+(\d+)\s*:\s*([-+0-9Ee\.]+)\s+([-+0-9Ee\.]+)\s+([-+0-9Ee\.]+)"
+)
+
+
+def render_with_engine(template: str, engine: str) -> str:
+    text, count = re.subn(
+        r"(engine\s+)\S+",
+        rf"\g<1>{engine}",
+        template,
+        count=1,
+    )
+    if count == 0:
+        raise SystemExit("could not find `engine` line in input to rewrite")
+    return text
+
+
+def run_binary(executable: Path, input_path: Path) -> str:
+    proc = subprocess.run(
+        [str(executable), str(input_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stdout)
+        sys.stderr.write(proc.stderr)
+        raise SystemExit(
+            f"{executable.name} failed (exit {proc.returncode}) on {input_path}"
+        )
+    return proc.stdout
+
+
+def parse_gradient(output: str) -> list[list[float]]:
+    grad: dict[int, list[float]] = {}
+    for line in output.splitlines():
+        match = ATOM_LINE_RE.search(line)
+        if match:
+            idx = int(match.group(1))
+            grad[idx] = [
+                float(match.group(2)),
+                float(match.group(3)),
+                float(match.group(4)),
+            ]
+    if not grad:
+        raise SystemExit("no `Atom i: gx gy gz` lines found in output")
+    return [grad[i] for i in sorted(grad)]
+
+
+def max_abs_diff(
+    left: list[list[float]],
+    right: list[list[float]],
+) -> tuple[float, tuple[int, int]]:
+    worst = 0.0
+    where = (0, 0)
+    if len(left) != len(right):
+        raise SystemExit(
+            f"gradient atom-count mismatch: os={len(left)} hgp={len(right)}"
+        )
+    for atom, (left_row, right_row) in enumerate(zip(left, right)):
+        if len(left_row) != len(right_row):
+            raise SystemExit("gradient row width mismatch")
+        for axis, (lhs, rhs) in enumerate(zip(left_row, right_row)):
+            diff = abs(lhs - rhs)
+            if diff > worst:
+                worst = diff
+                where = (atom, axis)
+    return worst, where
+
+
+def detect_binary_for(template: str) -> str:
+    # `%begin_dft` is present only for KS calculations; the HF binary doesn't
+    # know how to consume it, so route DFT inputs to planck-dft automatically.
+    if re.search(r"%begin_dft\b", template):
+        return "planck-dft"
+    return "hartree-fock"
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=Path, help="base .hfinp (engine line will be replaced)")
+    parser.add_argument(
+        "--binary",
+        type=str,
+        default=None,
+        help="binary in --build-dir to invoke; auto-selected from input (hartree-fock vs planck-dft) when omitted",
+    )
+    parser.add_argument(
+        "--build-dir",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent / "build",
+        help="directory containing the binary (default: ./build)",
+    )
+    parser.add_argument(
+        "--atol",
+        type=float,
+        default=1.0e-7,
+        help=(
+            "component-wise tolerance on |g_os - g_hgp| (Ha/Bohr). "
+            "Driver prints with 8-decimal precision, so the realistic floor "
+            "from text parsing is ~5e-9 per component; the default leaves "
+            "~20 ulps of headroom for cumulative SCF/dispatch roundoff."
+        ),
+    )
+    parser.add_argument(
+        "--keep-tmp",
+        action="store_true",
+        help="keep the scratch directory with both inputs and outputs",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    if not args.input.exists():
+        raise SystemExit(f"input not found: {args.input}")
+
+    template = args.input.read_text(encoding="utf-8")
+    binary = args.binary if args.binary is not None else detect_binary_for(template)
+    executable = args.build_dir / binary
+    if not executable.exists():
+        raise SystemExit(f"binary not found at {executable}")
+
+    tmp = tempfile.TemporaryDirectory(prefix="engine-gradient-compare-")
+    workdir = Path(tmp.name)
+    if args.keep_tmp:
+        tmp._finalizer.detach()  # type: ignore[attr-defined]
+
+    results: dict[str, list[list[float]]] = {}
+    for engine in ("os", "hgp"):
+        rendered = render_with_engine(template, engine)
+        path = workdir / f"{engine}.hfinp"
+        path.write_text(rendered, encoding="utf-8")
+        output = run_binary(executable, path)
+        (workdir / f"{engine}.log").write_text(output, encoding="utf-8")
+        results[engine] = parse_gradient(output)
+
+    print("OS gradient (Ha/Bohr):")
+    for atom, row in enumerate(results["os"], start=1):
+        print(f"  Atom {atom}: {row[0]:14.10f}  {row[1]:14.10f}  {row[2]:14.10f}")
+    print("HGP gradient (Ha/Bohr):")
+    for atom, row in enumerate(results["hgp"], start=1):
+        print(f"  Atom {atom}: {row[0]:14.10f}  {row[1]:14.10f}  {row[2]:14.10f}")
+
+    worst, (atom, axis) = max_abs_diff(results["os"], results["hgp"])
+    print(
+        f"max |g_os - g_hgp| = {worst:.3e} Ha/Bohr "
+        f"(atom {atom + 1}, axis {'xyz'[axis]})"
+    )
+    print(f"tolerance          = {args.atol:.3e} Ha/Bohr")
+
+    if args.keep_tmp:
+        print(f"work directory kept at: {workdir}")
+
+    if worst > args.atol:
+        print("FAIL: HGP analytic gradient diverges from OS reference")
+        return 1
+    print("PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/eri_derivative_kernels.cpp
+++ b/tests/eri_derivative_kernels.cpp
@@ -5,10 +5,12 @@
 #include <iostream>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <tuple>
 
 #include "base/basis.h"
 #include "base/types.h"
+#include "integrals/hgp.h"
 #include "basis/basis.h"
 #include "integrals/os.h"
 #include "integrals/rys.h"
@@ -99,15 +101,6 @@ namespace
         return nullptr;
     }
 
-    std::string cart_label(const Eigen::Vector3i &am)
-    {
-        std::string label;
-        label.append(static_cast<std::size_t>(am[0]), 'x');
-        label.append(static_cast<std::size_t>(am[1]), 'y');
-        label.append(static_cast<std::size_t>(am[2]), 'z');
-        return label.empty() ? "s" : label;
-    }
-
     struct QuartetSelection
     {
         std::size_t ab_pair = 0;
@@ -183,6 +176,153 @@ namespace
             sp_cd.A._cartesian[0], sp_cd.A._cartesian[1], sp_cd.A._cartesian[2],
             sp_cd.B._cartesian[0], sp_cd.B._cartesian[1], sp_cd.B._cartesian[2],
             kernel, omega);
+    }
+
+    double hgp_contracted_quartet_value(
+        const HartreeFock::ShellPair &sp_ab,
+        const HartreeFock::ShellPair &sp_cd,
+        const HartreeFock::ERIKernel kernel,
+        const double omega)
+    {
+        return HartreeFock::HeadGordonPople::_contracted_eri_elem(
+            sp_ab, sp_cd,
+            sp_ab.A._cartesian[0], sp_ab.A._cartesian[1], sp_ab.A._cartesian[2],
+            sp_ab.B._cartesian[0], sp_ab.B._cartesian[1], sp_ab.B._cartesian[2],
+            sp_cd.A._cartesian[0], sp_cd.A._cartesian[1], sp_cd.A._cartesian[2],
+            sp_cd.B._cartesian[0], sp_cd.B._cartesian[1], sp_cd.B._cartesian[2],
+            kernel, omega);
+    }
+
+    double hgp_contracted_quartet_value_native(
+        const HartreeFock::ShellPair &sp_ab,
+        const HartreeFock::ShellPair &sp_cd,
+        const HartreeFock::ERIKernel kernel,
+        const double omega)
+    {
+        return HartreeFock::HeadGordonPople::_contracted_eri_elem_native_test(
+            sp_ab, sp_cd,
+            sp_ab.A._cartesian[0], sp_ab.A._cartesian[1], sp_ab.A._cartesian[2],
+            sp_ab.B._cartesian[0], sp_ab.B._cartesian[1], sp_ab.B._cartesian[2],
+            sp_cd.A._cartesian[0], sp_cd.A._cartesian[1], sp_cd.A._cartesian[2],
+            sp_cd.B._cartesian[0], sp_cd.B._cartesian[1], sp_cd.B._cartesian[2],
+            kernel, omega);
+    }
+
+    void print_screened_derivative_term_breakdown(
+        const HartreeFock::ShellPair &sp_ab,
+        const HartreeFock::ShellPair &sp_cd,
+        const HartreeFock::ERIKernel kernel,
+        const double omega)
+    {
+        const int lAx = sp_ab.A._cartesian[0], lAy = sp_ab.A._cartesian[1], lAz = sp_ab.A._cartesian[2];
+        const int lBx = sp_ab.B._cartesian[0], lBy = sp_ab.B._cartesian[1], lBz = sp_ab.B._cartesian[2];
+        const int lCx = sp_cd.A._cartesian[0], lCy = sp_cd.A._cartesian[1], lCz = sp_cd.A._cartesian[2];
+        const int lDx = sp_cd.B._cartesian[0], lDy = sp_cd.B._cartesian[1], lDz = sp_cd.B._cartesian[2];
+
+        std::cerr << "constituent breakdown for screened quartet (" << sp_ab.A._index << "," << sp_ab.B._index
+                  << "|" << sp_cd.A._index << "," << sp_cd.B._index << ")\n";
+        for (int center = 0; center < 4; ++center)
+        {
+            for (int q = 0; q < 3; ++q)
+            {
+                const int axp = lAx + (q == 0), ayp = lAy + (q == 1), azp = lAz + (q == 2);
+                const int bxp = lBx + (q == 0), byp = lBy + (q == 1), bzp = lBz + (q == 2);
+                const int cxp = lCx + (q == 0), cyp = lCy + (q == 1), czp = lCz + (q == 2);
+                const int dxp = lDx + (q == 0), dyp = lDy + (q == 1), dzp = lDz + (q == 2);
+
+                double os_weighted = 0.0;
+                double hgp_weighted = 0.0;
+                double os_lower = 0.0;
+                double hgp_lower = 0.0;
+                int lq = 0;
+
+                if (center == 0)
+                {
+                    os_weighted = HartreeFock::ObaraSaika::_contracted_eri_elem_weighted_test(
+                        sp_ab, sp_cd, axp, ayp, azp, lBx, lBy, lBz, lCx, lCy, lCz, lDx, lDy, lDz, center, kernel, omega);
+                    hgp_weighted = HartreeFock::HeadGordonPople::_contracted_eri_elem_weighted_native_test(
+                        sp_ab, sp_cd, axp, ayp, azp, lBx, lBy, lBz, lCx, lCy, lCz, lDx, lDy, lDz, center, kernel, omega);
+                    lq = sp_ab.A._cartesian[q];
+                    if (lq > 0)
+                    {
+                        os_lower = static_cast<double>(lq) * HartreeFock::ObaraSaika::_contracted_eri_elem(
+                            sp_ab, sp_cd,
+                            lAx - (q == 0), lAy - (q == 1), lAz - (q == 2), lBx, lBy, lBz, lCx, lCy, lCz, lDx, lDy, lDz,
+                            kernel, omega);
+                        hgp_lower = static_cast<double>(lq) * HartreeFock::HeadGordonPople::_contracted_eri_elem_native_test(
+                            sp_ab, sp_cd,
+                            lAx - (q == 0), lAy - (q == 1), lAz - (q == 2), lBx, lBy, lBz, lCx, lCy, lCz, lDx, lDy, lDz,
+                            kernel, omega);
+                    }
+                }
+                else if (center == 1)
+                {
+                    os_weighted = HartreeFock::ObaraSaika::_contracted_eri_elem_weighted_test(
+                        sp_ab, sp_cd, lAx, lAy, lAz, bxp, byp, bzp, lCx, lCy, lCz, lDx, lDy, lDz, center, kernel, omega);
+                    hgp_weighted = HartreeFock::HeadGordonPople::_contracted_eri_elem_weighted_native_test(
+                        sp_ab, sp_cd, lAx, lAy, lAz, bxp, byp, bzp, lCx, lCy, lCz, lDx, lDy, lDz, center, kernel, omega);
+                    lq = sp_ab.B._cartesian[q];
+                    if (lq > 0)
+                    {
+                        os_lower = static_cast<double>(lq) * HartreeFock::ObaraSaika::_contracted_eri_elem(
+                            sp_ab, sp_cd,
+                            lAx, lAy, lAz, lBx - (q == 0), lBy - (q == 1), lBz - (q == 2), lCx, lCy, lCz, lDx, lDy, lDz,
+                            kernel, omega);
+                        hgp_lower = static_cast<double>(lq) * HartreeFock::HeadGordonPople::_contracted_eri_elem_native_test(
+                            sp_ab, sp_cd,
+                            lAx, lAy, lAz, lBx - (q == 0), lBy - (q == 1), lBz - (q == 2), lCx, lCy, lCz, lDx, lDy, lDz,
+                            kernel, omega);
+                    }
+                }
+                else if (center == 2)
+                {
+                    os_weighted = HartreeFock::ObaraSaika::_contracted_eri_elem_weighted_test(
+                        sp_ab, sp_cd, lAx, lAy, lAz, lBx, lBy, lBz, cxp, cyp, czp, lDx, lDy, lDz, center, kernel, omega);
+                    hgp_weighted = HartreeFock::HeadGordonPople::_contracted_eri_elem_weighted_native_test(
+                        sp_ab, sp_cd, lAx, lAy, lAz, lBx, lBy, lBz, cxp, cyp, czp, lDx, lDy, lDz, center, kernel, omega);
+                    lq = sp_cd.A._cartesian[q];
+                    if (lq > 0)
+                    {
+                        os_lower = static_cast<double>(lq) * HartreeFock::ObaraSaika::_contracted_eri_elem(
+                            sp_ab, sp_cd,
+                            lAx, lAy, lAz, lBx, lBy, lBz, lCx - (q == 0), lCy - (q == 1), lCz - (q == 2), lDx, lDy, lDz,
+                            kernel, omega);
+                        hgp_lower = static_cast<double>(lq) * HartreeFock::HeadGordonPople::_contracted_eri_elem_native_test(
+                            sp_ab, sp_cd,
+                            lAx, lAy, lAz, lBx, lBy, lBz, lCx - (q == 0), lCy - (q == 1), lCz - (q == 2), lDx, lDy, lDz,
+                            kernel, omega);
+                    }
+                }
+                else
+                {
+                    os_weighted = HartreeFock::ObaraSaika::_contracted_eri_elem_weighted_test(
+                        sp_ab, sp_cd, lAx, lAy, lAz, lBx, lBy, lBz, lCx, lCy, lCz, dxp, dyp, dzp, center, kernel, omega);
+                    hgp_weighted = HartreeFock::HeadGordonPople::_contracted_eri_elem_weighted_native_test(
+                        sp_ab, sp_cd, lAx, lAy, lAz, lBx, lBy, lBz, lCx, lCy, lCz, dxp, dyp, dzp, center, kernel, omega);
+                    lq = sp_cd.B._cartesian[q];
+                    if (lq > 0)
+                    {
+                        os_lower = static_cast<double>(lq) * HartreeFock::ObaraSaika::_contracted_eri_elem(
+                            sp_ab, sp_cd,
+                            lAx, lAy, lAz, lBx, lBy, lBz, lCx, lCy, lCz, lDx - (q == 0), lDy - (q == 1), lDz - (q == 2),
+                            kernel, omega);
+                        hgp_lower = static_cast<double>(lq) * HartreeFock::HeadGordonPople::_contracted_eri_elem_native_test(
+                            sp_ab, sp_cd,
+                            lAx, lAy, lAz, lBx, lBy, lBz, lCx, lCy, lCz, lDx - (q == 0), lDy - (q == 1), lDz - (q == 2),
+                            kernel, omega);
+                    }
+                }
+
+                std::cerr << "  center=" << center << " dir=" << q
+                          << " os_weighted=" << std::setprecision(16) << os_weighted
+                          << " hgp_weighted=" << hgp_weighted
+                          << " os_lower=" << os_lower
+                          << " hgp_lower=" << hgp_lower
+                          << " os_total=" << (os_weighted - os_lower)
+                          << " hgp_total=" << (hgp_weighted - hgp_lower)
+                          << '\n';
+            }
+        }
     }
 
     double rys_weighted_quartet_value_a(
@@ -401,7 +541,10 @@ namespace
                     sp_ab, sp_cd, HartreeFock::ERIKernel::LongRange, omega);
                 const auto short_range = HartreeFock::ObaraSaika::_compute_eri_deriv_elem(
                     sp_ab, sp_cd, HartreeFock::ERIKernel::ShortRange, omega);
-
+                const auto hgp_coulomb_default = HartreeFock::HeadGordonPople::_compute_eri_deriv_elem(
+                    sp_ab, sp_cd);
+                const auto hgp_coulomb = HartreeFock::HeadGordonPople::_compute_eri_deriv_elem(
+                    sp_ab, sp_cd, HartreeFock::ERIKernel::Coulomb, 0.0);
                 if (max_abs(coulomb) > 1e-8)
                     saw_nontrivial = true;
                 if (max_abs_diff(coulomb_default, coulomb) > 1e-13)
@@ -415,6 +558,16 @@ namespace
                 if (max_abs_diff(coulomb, reconstructed) > 1e-8)
                 {
                     fail("screened ERI derivative kernels no longer reconstruct the Coulomb derivative");
+                    return;
+                }
+                if (max_abs_diff(hgp_coulomb_default, hgp_coulomb) > 1e-13)
+                {
+                    fail("HGP default ERI derivative kernel no longer matches the explicit Coulomb path");
+                    return;
+                }
+                if (max_abs_diff(coulomb, hgp_coulomb) > 1e-8)
+                {
+                    fail("HGP Coulomb ERI derivatives no longer match the OS reference");
                     return;
                 }
                 if (max_abs_diff(coulomb, long_range) > 1e-8 ||
@@ -497,18 +650,29 @@ namespace
             sp_ab, sp_cd, HartreeFock::ERIKernel::LongRange, omega);
         const auto analytic_coulomb = HartreeFock::ObaraSaika::_compute_eri_deriv_elem(
             sp_ab, sp_cd, HartreeFock::ERIKernel::Coulomb, 0.0);
+        const auto analytic_hgp_coulomb = HartreeFock::HeadGordonPople::_compute_eri_deriv_elem(
+            sp_ab, sp_cd, HartreeFock::ERIKernel::Coulomb, 0.0);
         const double base_os = contracted_quartet_value(
             sp_ab, sp_cd, HartreeFock::ERIKernel::LongRange, omega);
         const double base_rys = rys_contracted_quartet_value(
             sp_ab, sp_cd, HartreeFock::ERIKernel::LongRange, omega);
         const double base_coulomb = contracted_quartet_value(
             sp_ab, sp_cd, HartreeFock::ERIKernel::Coulomb, 0.0);
+        const double base_hgp_coulomb = HartreeFock::HeadGordonPople::_contracted_eri_elem(
+            sp_ab, sp_cd,
+            sp_ab.A._cartesian[0], sp_ab.A._cartesian[1], sp_ab.A._cartesian[2],
+            sp_ab.B._cartesian[0], sp_ab.B._cartesian[1], sp_ab.B._cartesian[2],
+            sp_cd.A._cartesian[0], sp_cd.A._cartesian[1], sp_cd.A._cartesian[2],
+            sp_cd.B._cartesian[0], sp_cd.B._cartesian[1], sp_cd.B._cartesian[2],
+            HartreeFock::ERIKernel::Coulomb, 0.0);
 
         std::array<double, 12> finite_difference{};
         std::array<double, 12> finite_difference_rys{};
         std::array<double, 12> finite_difference_coulomb{};
+        std::array<double, 12> finite_difference_hgp_coulomb{};
         double max_error = 0.0;
         double max_error_coulomb = 0.0;
+        double max_error_hgp_coulomb = 0.0;
         double max_os_rys_fd_gap = 0.0;
 
         for (int center = 0; center < 4; ++center)
@@ -548,12 +712,32 @@ namespace
                 const double minus_value_coulomb = contracted_quartet_value(
                     *minus_ab, *minus_cd, HartreeFock::ERIKernel::Coulomb, 0.0);
                 const double fd_value_coulomb = (plus_value_coulomb - minus_value_coulomb) / (2.0 * step);
+                const double plus_value_hgp_coulomb = HartreeFock::HeadGordonPople::_contracted_eri_elem(
+                    *plus_ab, *plus_cd,
+                    plus_ab->A._cartesian[0], plus_ab->A._cartesian[1], plus_ab->A._cartesian[2],
+                    plus_ab->B._cartesian[0], plus_ab->B._cartesian[1], plus_ab->B._cartesian[2],
+                    plus_cd->A._cartesian[0], plus_cd->A._cartesian[1], plus_cd->A._cartesian[2],
+                    plus_cd->B._cartesian[0], plus_cd->B._cartesian[1], plus_cd->B._cartesian[2],
+                    HartreeFock::ERIKernel::Coulomb, 0.0);
+                const double minus_value_hgp_coulomb = HartreeFock::HeadGordonPople::_contracted_eri_elem(
+                    *minus_ab, *minus_cd,
+                    minus_ab->A._cartesian[0], minus_ab->A._cartesian[1], minus_ab->A._cartesian[2],
+                    minus_ab->B._cartesian[0], minus_ab->B._cartesian[1], minus_ab->B._cartesian[2],
+                    minus_cd->A._cartesian[0], minus_cd->A._cartesian[1], minus_cd->A._cartesian[2],
+                    minus_cd->B._cartesian[0], minus_cd->B._cartesian[1], minus_cd->B._cartesian[2],
+                    HartreeFock::ERIKernel::Coulomb, 0.0);
+                const double fd_value_hgp_coulomb =
+                    (plus_value_hgp_coulomb - minus_value_hgp_coulomb) / (2.0 * step);
                 const std::size_t slot = static_cast<std::size_t>(center * 3 + direction);
                 finite_difference[slot] = fd_value;
                 finite_difference_rys[slot] = fd_value_rys;
                 finite_difference_coulomb[slot] = fd_value_coulomb;
+                finite_difference_hgp_coulomb[slot] = fd_value_hgp_coulomb;
                 max_error = std::max(max_error, std::abs(fd_value - analytic[slot]));
                 max_error_coulomb = std::max(max_error_coulomb, std::abs(fd_value_coulomb - analytic_coulomb[slot]));
+                max_error_hgp_coulomb = std::max(
+                    max_error_hgp_coulomb,
+                    std::abs(fd_value_hgp_coulomb - analytic_hgp_coulomb[slot]));
                 max_os_rys_fd_gap = std::max(max_os_rys_fd_gap, std::abs(fd_value - fd_value_rys));
             }
         }
@@ -570,6 +754,7 @@ namespace
         std::cout << "  base_os=" << base_os
                   << " base_rys=" << base_rys
                   << " base_coulomb=" << base_coulomb
+                  << " base_hgp_coulomb=" << base_hgp_coulomb
                   << " diff=" << (base_os - base_rys) << '\n';
         for (int center = 0; center < 4; ++center)
         {
@@ -602,6 +787,7 @@ namespace
                   << " coulomb_fd=" << (finite_difference_coulomb[2] + finite_difference_coulomb[5] + finite_difference_coulomb[8] + finite_difference_coulomb[11]) << '\n';
         std::cout << "  max |fd_os-fd_rys|=" << max_os_rys_fd_gap << '\n';
         std::cout << "  max |coulomb analytic-fd|=" << max_error_coulomb << '\n';
+        std::cout << "  max |hgp coulomb analytic-fd|=" << max_error_hgp_coulomb << '\n';
         std::cout << "  coulomb center derivatives:\n";
         for (int center = 0; center < 4; ++center)
         {
@@ -609,6 +795,14 @@ namespace
                       << " (" << analytic_coulomb[center * 3 + 0]
                       << ", " << analytic_coulomb[center * 3 + 1]
                       << ", " << analytic_coulomb[center * 3 + 2] << ")\n";
+        }
+        std::cout << "  hgp coulomb center derivatives:\n";
+        for (int center = 0; center < 4; ++center)
+        {
+            std::cout << "    c" << center
+                      << " (" << analytic_hgp_coulomb[center * 3 + 0]
+                      << ", " << analytic_hgp_coulomb[center * 3 + 1]
+                      << ", " << analytic_hgp_coulomb[center * 3 + 2] << ")\n";
         }
         std::cout << "  omega sweep (Planck long-range quartet energy):\n";
         for (double sweep_omega : {0.01, 0.05, 0.11, 0.2, 0.5, 1.0})
@@ -664,268 +858,291 @@ namespace
             std::cerr << "diagnostic: long-range quartet derivative failed direct finite-difference validation; "
                       << "max |analytic-fd| = " << max_error << '\n';
         }
+        if (max_abs_diff(analytic_coulomb, analytic_hgp_coulomb) > 1e-8)
+        {
+            fail("HGP Coulomb quartet derivatives no longer match the OS reference on the finite-difference diagnostic quartet");
+            return;
+        }
+        if (max_error_hgp_coulomb > tolerance)
+        {
+            fail("HGP Coulomb quartet derivatives failed direct finite-difference validation");
+            return;
+        }
     }
 
-    void test_d_shell_long_range_quartets()
+    void test_hgp_screened_quartet_derivatives_s_p()
     {
-        auto calc_res = make_water_calculator("6-31g*");
+        auto calc_res = make_water_calculator();
         if (!calc_res)
         {
-            fail("6-31g* setup failed: " + calc_res.error());
+            fail("setup failed: " + calc_res.error());
             return;
         }
 
-        const auto &basis = calc_res->_shells;
-        const auto shell_pairs = build_shellpairs(basis);
+        const auto shell_pairs = build_shellpairs(calc_res->_shells);
         constexpr double omega = 0.11;
-        constexpr double energy_tol = 1e-8;
-        constexpr double deriv_tol = 2e-8;
-        constexpr double fd_step = 1e-5;
+        constexpr double fd_step = 1e-4;
+        constexpr double deriv_tol = 5e-7;
+        constexpr double identity_tol = 1e-10;
 
-        std::cout << "d-shell AO labels (water / 6-31g*):\n";
-        for (std::size_t idx = 9; idx <= 14; ++idx)
+        const auto *ssss_ab = find_shell_pair(shell_pairs, 1, 5);
+        const auto *ssss_cd = find_shell_pair(shell_pairs, 0, 6);
+        const auto *psss_ab = find_shell_pair(shell_pairs, 3, 5);
+        const auto *psss_cd = find_shell_pair(shell_pairs, 0, 1);
+        const auto *ssps_ab = find_shell_pair(shell_pairs, 1, 5);
+        const auto *ssps_cd = find_shell_pair(shell_pairs, 3, 6);
+        if (!ssss_ab || !ssss_cd || !psss_ab || !psss_cd || !ssps_ab || !ssps_cd)
         {
-            const auto &bf = basis._basis_functions[idx];
-            const auto *diag_pair = find_shell_pair(shell_pairs, idx, idx);
-            const double overlap_diag = diag_pair
-                                            ? std::get<0>(HartreeFock::ObaraSaika::_compute_3d_overlap_kinetic(*diag_pair))
-                                            : -1.0;
-            std::cout << "  ao " << idx
-                      << " cart=(" << bf._cartesian[0] << "," << bf._cartesian[1] << "," << bf._cartesian[2] << ")"
-                      << " label=" << cart_label(bf._cartesian)
-                      << " component_norm=" << bf._component_norm
-                      << " overlap_diag=" << std::setprecision(12) << overlap_diag
-                      << '\n';
-        }
-
-        struct FamilySweep
-        {
-            const char *name;
-            std::size_t i;
-            std::size_t j;
-            std::size_t k;
-            std::size_t l;
-            std::array<double, 6> pyscf_lr;
-            std::array<double, 6> pyscf_coulomb;
-        };
-
-        const std::array<FamilySweep, 4> family_sweeps{{
-            {"same_center_ket", 1, 15, 0, 9,
-             {0.0016311796523281429, 0.0, 0.0, 0.0016311844063704958, -3.6784182959942555e-09, 0.0016311824984872967},
-             {0.01269706381838066, 0.0, 0.0, 0.01303286612473238, -0.0002598254823631071, 0.012898102584369697}},
-            {"same_center_bra", 1, 9, 0, 15,
-             {0.0037463354754034488, 0.0, 0.0, 0.003746337153391111, -1.2983351977712677e-09, 0.003746336479984307},
-             {0.02945919436371374, 0.0, 0.0, 0.02969404660770994, -0.00018171583823625937, 0.029599796153605258}},
-            {"d_s_s_s", 9, 15, 0, 1,
-             {0.007616813811113749, 0.0, 0.0, 0.018665270501053485, -0.008548692294640642, 0.014231324959534327},
-             {0.046809804226248454, 0.0, 0.0, 0.1039928244554318, -0.04424509758567612, 0.08104424396937564}},
-            {"s_s_d_s", 1, 15, 9, 17,
-             {0.00806584202864128, 0.0, 0.0, 0.01971263895461429, 0.009051075916381674, 0.015099859414167515},
-             {0.040237969270862955, 0.0, 0.0, 0.08405322345380006, 0.03879436813915374, 0.07819162099464037}},
-        }};
-
-        std::cout << "d-shell family sweeps (water / 6-31g* / omega=0.11):\n";
-        for (const auto &family : family_sweeps)
-        {
-            std::cout << "  " << family.name << '\n';
-            for (std::size_t offset = 0; offset < 6; ++offset)
-            {
-                const std::size_t d = 9 + offset;
-                const auto *ab = find_shell_pair(shell_pairs,
-                                                 family.i == 9 ? d : family.i,
-                                                 family.j == 9 ? d : family.j);
-                const auto *cd = find_shell_pair(shell_pairs,
-                                                 family.k == 9 ? d : family.k,
-                                                 family.l == 9 ? d : family.l);
-                if (!ab || !cd)
-                {
-                    fail(std::string("failed to locate d-shell family sweep quartet for ") + family.name);
-                    return;
-                }
-                const auto &bf = basis._basis_functions[d];
-                const double planck_lr = contracted_quartet_value(*ab, *cd, HartreeFock::ERIKernel::LongRange, omega);
-                const double planck_c = contracted_quartet_value(*ab, *cd, HartreeFock::ERIKernel::Coulomb, 0.0);
-                std::cout << "    ao " << d
-                          << " " << cart_label(bf._cartesian)
-                          << " planck_lr=" << planck_lr
-                          << " pyscf_lr=" << family.pyscf_lr[offset]
-                          << " planck_c=" << planck_c
-                          << " pyscf_c=" << family.pyscf_coulomb[offset]
-                          << '\n';
-            }
-        }
-
-        struct PairRef
-        {
-            std::size_t i;
-            std::size_t j;
-            double pyscf_overlap;
-            double pyscf_kinetic;
-        };
-        const std::array<PairRef, 6> one_e_refs{{
-            {9, 15, 0.2653552918427907, -0.13365613628669032},
-            {12, 15, 0.6512735891333278, 0.5202286183987239},
-            {13, 15, -0.2986024987012413, -0.5059403064911389},
-            {14, 15, 0.496397594984739, 0.25781283725666465},
-            {9, 17, 0.2653552918427907, -0.13365613628669032},
-            {13, 17, 0.2986024987012413, 0.5059403064911389},
-        }};
-        std::cout << "d-shell one-electron pair checks (water / 6-31g*):\n";
-        for (const auto &ref : one_e_refs)
-        {
-            const auto *pair = find_shell_pair(shell_pairs, ref.i, ref.j);
-            if (!pair)
-            {
-                fail("failed to locate d-shell one-electron pair");
-                return;
-            }
-            const auto [planck_overlap, planck_kinetic] = HartreeFock::ObaraSaika::_compute_3d_overlap_kinetic(*pair);
-            std::cout << "  (" << ref.i << "," << ref.j << ")"
-                      << " overlap=" << planck_overlap
-                      << " pyscf_overlap=" << ref.pyscf_overlap
-                      << " kinetic=" << planck_kinetic
-                      << " pyscf_kinetic=" << ref.pyscf_kinetic
-                      << '\n';
-        }
-
-        struct QuartetRef
-        {
-            const char *name;
-            std::size_t i;
-            std::size_t j;
-            std::size_t k;
-            std::size_t l;
-            double pyscf_lr;
-        };
-
-        const std::array<QuartetRef, 5> refs{{
-            {"same_center_ket_d", 1, 15, 0, 9, 0.0016311796523281429},
-            {"same_center_bra_d", 1, 9, 0, 15, 0.0037463354754034488},
-            {"d_s_s_s", 9, 15, 0, 1, 0.007616813811113749},
-            {"s_s_d_s", 1, 15, 9, 17, 0.00806584202864128},
-            {"triple_same_center_d", 0, 9, 9, 15, 0.001731908542963683},
-        }};
-
-        std::cout << "d-shell long-range quartet checks (water / 6-31g* / omega=0.11):\n";
-        double max_energy_err = 0.0;
-        for (const auto &ref : refs)
-        {
-            const auto *ab = find_shell_pair(shell_pairs, ref.i, ref.j);
-            const auto *cd = find_shell_pair(shell_pairs, ref.k, ref.l);
-            if (!ab || !cd)
-            {
-                fail(std::string("failed to locate d-shell quartet ") + ref.name);
-                return;
-            }
-            const double planck_lr = contracted_quartet_value(*ab, *cd, HartreeFock::ERIKernel::LongRange, omega);
-            const double err = std::abs(planck_lr - ref.pyscf_lr);
-            std::cout << "  " << ref.name
-                      << " (" << ref.i << "," << ref.j << "|" << ref.k << "," << ref.l << ")"
-                      << " planck=" << planck_lr
-                      << " pyscf=" << ref.pyscf_lr
-                      << " diff=" << (planck_lr - ref.pyscf_lr) << '\n';
-            max_energy_err = std::max(max_energy_err, err);
-        }
-        std::cout << "d-shell Coulomb quartet checks (water / 6-31g*):\n";
-        for (const auto &ref : refs)
-        {
-            const auto *ab_ref = find_shell_pair(shell_pairs, ref.i, ref.j);
-            const auto *cd_ref = find_shell_pair(shell_pairs, ref.k, ref.l);
-            const double planck_coulomb = contracted_quartet_value(
-                *ab_ref, *cd_ref, HartreeFock::ERIKernel::Coulomb, 0.0);
-            std::cout << "  " << ref.name
-                      << " (" << ref.i << "," << ref.j << "|" << ref.k << "," << ref.l << ")"
-                      << " planck_coulomb=" << planck_coulomb << '\n';
-        }
-
-        const auto *ab = find_shell_pair(shell_pairs, 0, 9);
-        const auto *cd = find_shell_pair(shell_pairs, 1, 15);
-        if (!ab || !cd)
-        {
-            fail("failed to locate d-shell derivative quartet (0,9|1,15)");
+            fail("failed to locate fixed s/p screened-derivative diagnostic quartets");
             return;
         }
 
-        const auto analytic = HartreeFock::ObaraSaika::_compute_eri_deriv_elem(
-            *ab, *cd, HartreeFock::ERIKernel::LongRange, omega);
-        const std::array<double, 12> pyscf{
-            -0.0, 7.179632724047326e-06, -5.555207633867998e-06,
-            -0.0, 8.397820302306878e-07, -6.497774641726828e-07,
-            -0.0, 0.001906641761466277, -0.0014752552498783179,
-            -0.0, -0.0019146611762205547, 0.0014814602349763582,
-        };
-        std::array<double, 12> fd{};
-        std::array<std::size_t, 4> shell_indices{
-            shell_index_for_view(calc_res->_shells, ab->A),
-            shell_index_for_view(calc_res->_shells, ab->B),
-            shell_index_for_view(calc_res->_shells, cd->A),
-            shell_index_for_view(calc_res->_shells, cd->B),
-        };
-        double max_analytic_pyscf = 0.0;
-        double max_analytic_fd = 0.0;
-        for (int center = 0; center < 4; ++center)
+        struct QuartetCase
         {
-            for (int direction = 0; direction < 3; ++direction)
-            {
-                const std::size_t shell_index = shell_indices[center];
-                const auto plus_calc = make_displaced_water_calculator("6-31g*", shell_index, direction, fd_step);
-                const auto minus_calc = make_displaced_water_calculator("6-31g*", shell_index, direction, -fd_step);
-                const auto plus_pairs = build_shellpairs(plus_calc._shells);
-                const auto minus_pairs = build_shellpairs(minus_calc._shells);
-                const auto *plus_ab = find_shell_pair(plus_pairs, 0, 9);
-                const auto *plus_cd = find_shell_pair(plus_pairs, 1, 15);
-                const auto *minus_ab = find_shell_pair(minus_pairs, 0, 9);
-                const auto *minus_cd = find_shell_pair(minus_pairs, 1, 15);
-                if (!plus_ab || !plus_cd || !minus_ab || !minus_cd)
-                {
-                    fail("failed to recover displaced d-shell derivative quartet");
-                    return;
-                }
-                const double plus_val = contracted_quartet_value(*plus_ab, *plus_cd, HartreeFock::ERIKernel::LongRange, omega);
-                const double minus_val = contracted_quartet_value(*minus_ab, *minus_cd, HartreeFock::ERIKernel::LongRange, omega);
-                const std::size_t slot = static_cast<std::size_t>(center * 3 + direction);
-                fd[slot] = (plus_val - minus_val) / (2.0 * fd_step);
-                max_analytic_pyscf = std::max(max_analytic_pyscf, std::abs(analytic[slot] - pyscf[slot]));
-                max_analytic_fd = std::max(max_analytic_fd, std::abs(analytic[slot] - fd[slot]));
-            }
-        }
+            const char *name;
+            const HartreeFock::ShellPair *ab;
+            const HartreeFock::ShellPair *cd;
+        };
 
-        std::cout << "  d-shell derivative quartet (0,9|1,15):\n";
-        for (int center = 0; center < 4; ++center)
+        const std::array<QuartetCase, 3> cases{{
+            {"s-s-s-s", ssss_ab, ssss_cd},
+            {"p-s-s-s", psss_ab, psss_cd},
+            {"s-s-p-s", ssps_ab, ssps_cd},
+        }};
+
+        for (const auto &quartet : cases)
         {
-            for (int direction = 0; direction < 3; ++direction)
+            const auto os_coulomb = HartreeFock::ObaraSaika::_compute_eri_deriv_elem(
+                *quartet.ab, *quartet.cd, HartreeFock::ERIKernel::Coulomb, 0.0);
+            const auto os_long_range = HartreeFock::ObaraSaika::_compute_eri_deriv_elem(
+                *quartet.ab, *quartet.cd, HartreeFock::ERIKernel::LongRange, omega);
+            const auto os_short_range = HartreeFock::ObaraSaika::_compute_eri_deriv_elem(
+                *quartet.ab, *quartet.cd, HartreeFock::ERIKernel::ShortRange, omega);
+
+            const auto hgp_coulomb = HartreeFock::HeadGordonPople::_compute_eri_deriv_elem(
+                *quartet.ab, *quartet.cd, HartreeFock::ERIKernel::Coulomb, 0.0);
+            const auto hgp_long_range = HartreeFock::HeadGordonPople::_compute_eri_deriv_elem_native_test(
+                *quartet.ab, *quartet.cd, HartreeFock::ERIKernel::LongRange, omega);
+            const auto hgp_short_range = HartreeFock::HeadGordonPople::_compute_eri_deriv_elem_native_test(
+                *quartet.ab, *quartet.cd, HartreeFock::ERIKernel::ShortRange, omega);
+            const double os_value_long_range = contracted_quartet_value(
+                *quartet.ab, *quartet.cd, HartreeFock::ERIKernel::LongRange, omega);
+            const double hgp_value_long_range = hgp_contracted_quartet_value_native(
+                *quartet.ab, *quartet.cd, HartreeFock::ERIKernel::LongRange, omega);
+            const double os_value_short_range = contracted_quartet_value(
+                *quartet.ab, *quartet.cd, HartreeFock::ERIKernel::ShortRange, omega);
+            const double hgp_value_short_range = hgp_contracted_quartet_value_native(
+                *quartet.ab, *quartet.cd, HartreeFock::ERIKernel::ShortRange, omega);
+
+            if (max_abs_diff(os_coulomb, hgp_coulomb) > 1e-8)
             {
-                const std::size_t slot = static_cast<std::size_t>(center * 3 + direction);
-                std::cout << "    c" << center << " d" << direction
-                          << " analytic=" << analytic[slot]
-                          << " pyscf=" << pyscf[slot]
-                          << " fd=" << fd[slot]
-                          << " d(planck-pyscf)=" << (analytic[slot] - pyscf[slot])
-                          << " d(planck-fd)=" << (analytic[slot] - fd[slot]) << '\n';
+                fail(std::string("HGP Coulomb screened-quartet baseline diverged from OS on ") + quartet.name);
+                return;
             }
-        }
-        if (max_energy_err > energy_tol)
-        {
-            std::cerr << "diagnostic: d-shell quartet mismatch vs PySCF; max |planck-pyscf| = "
-                      << max_energy_err << '\n';
-        }
-        if (max_analytic_pyscf > deriv_tol)
-        {
-            std::cerr << "diagnostic: d-shell derivative mismatch vs PySCF; max |analytic-pyscf| = "
-                      << max_analytic_pyscf << '\n';
-        }
-        if (max_analytic_fd > deriv_tol)
-        {
-            std::cerr << "diagnostic: d-shell derivative mismatch vs FD; max |analytic-fd| = "
-                      << max_analytic_fd << '\n';
+            if (max_abs_diff(os_long_range, hgp_long_range) > 1e-8)
+            {
+                if (std::string_view(quartet.name) == "p-s-s-s")
+                    print_screened_derivative_term_breakdown(
+                        *quartet.ab, *quartet.cd, HartreeFock::ERIKernel::LongRange, omega);
+                fail(std::string("HGP long-range ERI derivatives no longer match OS on ") + quartet.name);
+                return;
+            }
+            if (max_abs_diff(os_short_range, hgp_short_range) > 1e-8)
+            {
+                fail(std::string("HGP short-range ERI derivatives no longer match OS on ") + quartet.name);
+                return;
+            }
+
+            std::array<double, 12> hgp_reconstructed{};
+            for (std::size_t i = 0; i < hgp_reconstructed.size(); ++i)
+                hgp_reconstructed[i] = hgp_coulomb[i] - hgp_long_range[i];
+            if (max_abs_diff(hgp_reconstructed, hgp_short_range) > identity_tol)
+            {
+                fail(std::string("HGP short-range derivative no longer equals Coulomb - LongRange on ") + quartet.name);
+                return;
+            }
+            if (std::abs(os_value_long_range - hgp_value_long_range) > 1e-10)
+            {
+                fail(std::string("HGP long-range quartet value no longer matches OS on ") + quartet.name);
+                return;
+            }
+            if (std::abs(os_value_short_range - hgp_value_short_range) > 1e-10)
+            {
+                fail(std::string("HGP short-range quartet value no longer matches OS on ") + quartet.name);
+                return;
+            }
+
+            const std::array<std::size_t, 4> shell_indices{
+                shell_index_for_view(calc_res->_shells, quartet.ab->A),
+                shell_index_for_view(calc_res->_shells, quartet.ab->B),
+                shell_index_for_view(calc_res->_shells, quartet.cd->A),
+                shell_index_for_view(calc_res->_shells, quartet.cd->B),
+            };
+
+            std::array<double, 12> fd_long_range{};
+            std::array<double, 12> fd_short_range{};
+            for (int center = 0; center < 4; ++center)
+            {
+                for (int direction = 0; direction < 3; ++direction)
+                {
+                    const std::size_t shell_index = shell_indices[center];
+                    const auto plus_calc =
+                        make_displaced_water_calculator("sto-3g", shell_index, direction, fd_step);
+                    const auto minus_calc =
+                        make_displaced_water_calculator("sto-3g", shell_index, direction, -fd_step);
+                    const auto plus_pairs = build_shellpairs(plus_calc._shells);
+                    const auto minus_pairs = build_shellpairs(minus_calc._shells);
+
+                    const auto *plus_ab = find_shell_pair(
+                        plus_pairs, quartet.ab->A._index, quartet.ab->B._index);
+                    const auto *plus_cd = find_shell_pair(
+                        plus_pairs, quartet.cd->A._index, quartet.cd->B._index);
+                    const auto *minus_ab = find_shell_pair(
+                        minus_pairs, quartet.ab->A._index, quartet.ab->B._index);
+                    const auto *minus_cd = find_shell_pair(
+                        minus_pairs, quartet.cd->A._index, quartet.cd->B._index);
+                    if (!plus_ab || !plus_cd || !minus_ab || !minus_cd)
+                    {
+                        fail(std::string("failed to recover displaced screened quartet for ") + quartet.name);
+                        return;
+                    }
+
+                    const std::size_t slot = static_cast<std::size_t>(center * 3 + direction);
+                    const double plus_lr = hgp_contracted_quartet_value_native(
+                        *plus_ab, *plus_cd, HartreeFock::ERIKernel::LongRange, omega);
+                    const double minus_lr = hgp_contracted_quartet_value_native(
+                        *minus_ab, *minus_cd, HartreeFock::ERIKernel::LongRange, omega);
+                    fd_long_range[slot] = (plus_lr - minus_lr) / (2.0 * fd_step);
+
+                    const double plus_sr = hgp_contracted_quartet_value_native(
+                        *plus_ab, *plus_cd, HartreeFock::ERIKernel::ShortRange, omega);
+                    const double minus_sr = hgp_contracted_quartet_value_native(
+                        *minus_ab, *minus_cd, HartreeFock::ERIKernel::ShortRange, omega);
+                    fd_short_range[slot] = (plus_sr - minus_sr) / (2.0 * fd_step);
+                }
+            }
+
+            if (max_abs_diff(hgp_long_range, fd_long_range) > deriv_tol)
+            {
+                fail(std::string("HGP long-range ERI derivatives failed finite-difference validation on ") + quartet.name);
+                return;
+            }
+            if (max_abs_diff(hgp_short_range, fd_short_range) > deriv_tol)
+            {
+                fail(std::string("HGP short-range ERI derivatives failed finite-difference validation on ") + quartet.name);
+                return;
+            }
         }
     }
+
+    // Exercises the cases the inv_2_delta fix was suspected of affecting on the
+    // *unweighted* path (no derivative): screened HGP _contracted_eri_elem must
+    // match OS on s-s-s-s, p-s-s-s with ket s/s, and the (p|s|p|s) mixed-bra-ket
+    // pattern that the inv_2_delta cross-coupling term governs.
+    void test_hgp_unweighted_screened_eri_against_os()
+    {
+        auto calc_res = make_water_calculator();
+        if (!calc_res)
+        {
+            fail("setup failed: " + calc_res.error());
+            return;
+        }
+
+        const auto shell_pairs = build_shellpairs(calc_res->_shells);
+        constexpr double omega = 0.11;
+        constexpr double tol = 1e-10;
+
+        // Cases the user asked to gate explicitly.
+        const auto *ssss_ab = find_shell_pair(shell_pairs, 1, 5);
+        const auto *ssss_cd = find_shell_pair(shell_pairs, 0, 6);
+        const auto *psss_ab = find_shell_pair(shell_pairs, 3, 5);
+        const auto *psss_cd = find_shell_pair(shell_pairs, 0, 1);
+        // (p,s|p,s): same p-shell on the bra and ket, both ket components are
+        // s-shells so the only mixed-AM coupling comes through inv_2_delta.
+        const auto *psps_ab = psss_ab;
+        const auto *psps_cd = find_shell_pair(shell_pairs, 3, 6);
+        if (!ssss_ab || !ssss_cd || !psss_ab || !psss_cd || !psps_ab || !psps_cd)
+        {
+            fail("unweighted screened-ERI gate: missing fixture shell pairs");
+            return;
+        }
+
+        struct UnweightedCase
+        {
+            const char *name;
+            const HartreeFock::ShellPair *ab;
+            const HartreeFock::ShellPair *cd;
+        };
+        const std::array<UnweightedCase, 3> targeted{{
+            {"s-s-s-s", ssss_ab, ssss_cd},
+            {"p-s-s-s (no ket raise)", psss_ab, psss_cd},
+            {"p-s-p-s (mixed bra/ket AM)", psps_ab, psps_cd},
+        }};
+
+        for (const auto &k : targeted)
+        {
+            for (const auto kernel : {HartreeFock::ERIKernel::Coulomb,
+                                      HartreeFock::ERIKernel::LongRange,
+                                      HartreeFock::ERIKernel::ShortRange})
+            {
+                const double os_val = contracted_quartet_value(*k.ab, *k.cd, kernel, omega);
+                const double hgp_val = hgp_contracted_quartet_value_native(*k.ab, *k.cd, kernel, omega);
+                const double diff = std::abs(os_val - hgp_val);
+                const int k_int = static_cast<int>(kernel);
+                std::cout << "unweighted gate " << k.name << " kernel=" << k_int
+                          << " os=" << std::setprecision(12) << os_val
+                          << " hgp=" << hgp_val << " diff=" << diff << '\n';
+                if (diff > tol)
+                {
+                    fail(std::string("HGP unweighted screened ERI no longer matches OS on ") +
+                         k.name + " (kernel=" + std::to_string(k_int) + ")");
+                    return;
+                }
+            }
+        }
+
+        // Broader sweep: every quartet of stored shell pairs, three kernels.
+        // Catches any AM combination the targeted gate above missed.
+        double sweep_max_diff = 0.0;
+        std::size_t sweep_count = 0;
+        for (const auto &sp_ab : shell_pairs)
+        {
+            for (const auto &sp_cd : shell_pairs)
+            {
+                for (const auto kernel : {HartreeFock::ERIKernel::Coulomb,
+                                          HartreeFock::ERIKernel::LongRange,
+                                          HartreeFock::ERIKernel::ShortRange})
+                {
+                    const double os_val = contracted_quartet_value(sp_ab, sp_cd, kernel, omega);
+                    const double hgp_val = hgp_contracted_quartet_value_native(sp_ab, sp_cd, kernel, omega);
+                    const double diff = std::abs(os_val - hgp_val);
+                    sweep_max_diff = std::max(sweep_max_diff, diff);
+                    ++sweep_count;
+                    if (diff > tol)
+                    {
+                        std::cerr << "sweep mismatch ab=("
+                                  << sp_ab.A._index << "," << sp_ab.B._index
+                                  << ") cd=(" << sp_cd.A._index << "," << sp_cd.B._index
+                                  << ") kernel=" << static_cast<int>(kernel)
+                                  << " os=" << std::setprecision(15) << os_val
+                                  << " hgp=" << hgp_val << " diff=" << diff << '\n';
+                        fail("HGP unweighted screened ERI sweep diverged from OS");
+                        return;
+                    }
+                }
+            }
+        }
+        std::cout << "unweighted screened sweep: " << sweep_count
+                  << " quartets, max |OS-HGP| = " << sweep_max_diff << '\n';
+    }
+
 } // namespace
 
 int main()
 {
     test_kernel_entry_points();
     test_long_range_quartet_derivative_against_finite_difference();
-    test_d_shell_long_range_quartets();
+    test_hgp_screened_quartet_derivatives_s_p();
+    test_hgp_unweighted_screened_eri_against_os();
     return g_ok ? 0 : 1;
 }

--- a/tests/hf_gradient_fd.py
+++ b/tests/hf_gradient_fd.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""
+Finite-difference verification of the analytic HF nuclear gradient.
+
+Runs `hartree-fock` on a base RHF/UHF gradient input to get the analytic
+gradient, then evaluates central-difference total energies at +/- displaced
+Cartesian geometries. The test fails if the largest component-wise deviation
+exceeds the requested tolerance.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Iterable
+
+ANGSTROM_TO_BOHR = 1.8897261254535
+
+ATOM_LINE_RE = re.compile(
+    r"Atom\s+(\d+)\s*:\s*([-+0-9Ee\.]+)\s+([-+0-9Ee\.]+)\s+([-+0-9Ee\.]+)"
+)
+HF_ENERGY_RE = re.compile(
+    r"^\s*Total Energy\s+([-+0-9Ee\.]+)",
+    re.MULTILINE,
+)
+
+
+def parse_coords_block(text: str) -> tuple[list[str], list[list[float]], int, int]:
+    match = re.search(r"%begin_coords\s*\n(.*?)\n%end_coords", text, re.DOTALL)
+    if not match:
+        raise SystemExit("could not find %begin_coords block in input")
+
+    lines = [line for line in match.group(1).splitlines() if line.strip()]
+    natom = int(lines[0].split()[0])
+    charge, multiplicity = (int(value) for value in lines[1].split()[:2])
+
+    symbols: list[str] = []
+    coords: list[list[float]] = []
+    for line in lines[2 : 2 + natom]:
+        parts = line.split()
+        symbols.append(parts[0])
+        coords.append([float(parts[1]), float(parts[2]), float(parts[3])])
+
+    return symbols, coords, charge, multiplicity
+
+
+def render_input(
+    template: str,
+    symbols: list[str],
+    coords: list[list[float]],
+    charge: int,
+    multiplicity: int,
+    calculation: str,
+) -> str:
+    text = re.sub(
+        r"(calculation\s+)\S+",
+        rf"\g<1>{calculation}",
+        template,
+        count=1,
+    )
+
+    coord_lines = [f"{len(symbols)}", f"{charge}   {multiplicity}"]
+    for sym, (x, y, z) in zip(symbols, coords):
+        coord_lines.append(f"{sym:<5s}{x:14.10f}{y:14.10f}{z:14.10f}")
+
+    text = re.sub(
+        r"%begin_coords\s*\n.*?\n%end_coords",
+        "%begin_coords\n" + "\n".join(coord_lines) + "\n%end_coords",
+        text,
+        count=1,
+        flags=re.DOTALL,
+    )
+    return text
+
+
+def run_hartree_fock(executable: Path, input_path: Path) -> str:
+    proc = subprocess.run(
+        [str(executable), str(input_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stdout)
+        sys.stderr.write(proc.stderr)
+        raise SystemExit(
+            f"hartree-fock failed (exit {proc.returncode}) on {input_path}"
+        )
+    return proc.stdout
+
+
+def parse_hf_energy(output: str) -> float:
+    matches = HF_ENERGY_RE.findall(output)
+    if not matches:
+        raise SystemExit("no 'Total Energy' line found in hartree-fock output")
+    return float(matches[-1])
+
+
+def parse_analytic_gradient(output: str, natom: int) -> list[list[float]]:
+    grad: dict[int, list[float]] = {}
+    for line in output.splitlines():
+        match = ATOM_LINE_RE.search(line)
+        if match:
+            idx = int(match.group(1))
+            grad[idx] = [
+                float(match.group(2)),
+                float(match.group(3)),
+                float(match.group(4)),
+            ]
+
+    if len(grad) < natom:
+        raise SystemExit(
+            f"only parsed {len(grad)}/{natom} gradient lines from hartree-fock"
+        )
+
+    return [grad[i + 1] for i in range(natom)]
+
+
+def central_difference_gradient(
+    executable: Path,
+    template: str,
+    symbols: list[str],
+    coords: list[list[float]],
+    charge: int,
+    multiplicity: int,
+    delta_bohr: float,
+    workdir: Path,
+) -> list[list[float]]:
+    delta_ang = delta_bohr / ANGSTROM_TO_BOHR
+    natom = len(symbols)
+    gradient = [[0.0, 0.0, 0.0] for _ in range(natom)]
+
+    for atom in range(natom):
+        for axis in range(3):
+            energies: list[float] = []
+            for sign in (+1.0, -1.0):
+                shifted = [row[:] for row in coords]
+                shifted[atom][axis] += sign * delta_ang
+                input_text = render_input(
+                    template,
+                    symbols,
+                    shifted,
+                    charge,
+                    multiplicity,
+                    calculation="energy",
+                )
+                input_path = workdir / f"fd_{atom}_{axis}_{'p' if sign > 0 else 'm'}.hfinp"
+                input_path.write_text(input_text, encoding="utf-8")
+                output = run_hartree_fock(executable, input_path)
+                energies.append(parse_hf_energy(output))
+
+            e_plus, e_minus = energies
+            gradient[atom][axis] = (e_plus - e_minus) / (2.0 * delta_bohr)
+
+    return gradient
+
+
+def max_abs_diff(
+    left: list[list[float]],
+    right: list[list[float]],
+) -> tuple[float, tuple[int, int]]:
+    worst = 0.0
+    where = (0, 0)
+    for atom, (left_row, right_row) in enumerate(zip(left, right)):
+        for axis, (lhs, rhs) in enumerate(zip(left_row, right_row)):
+            diff = abs(lhs - rhs)
+            if diff > worst:
+                worst = diff
+                where = (atom, axis)
+    return worst, where
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "input",
+        nargs="?",
+        type=Path,
+        default=Path(__file__).resolve().parent
+        / "inputs"
+        / "regression"
+        / "geometry"
+        / "water_rhf_gradient.hfinp",
+        help="base .hfinp; calculation field will be replaced as needed",
+    )
+    parser.add_argument(
+        "--build-dir",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent / "build",
+        help="directory containing hartree-fock binary (default: ./build)",
+    )
+    parser.add_argument(
+        "--delta",
+        type=float,
+        default=1.0e-3,
+        help="finite-difference step in Bohr (default 1e-3)",
+    )
+    parser.add_argument(
+        "--atol",
+        type=float,
+        default=2.0e-4,
+        help="component-wise tolerance (Ha/Bohr) on |g_analytic - g_fd|",
+    )
+    parser.add_argument(
+        "--keep-tmp",
+        action="store_true",
+        help="keep the temporary finite-difference working directory",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    executable = args.build_dir / "hartree-fock"
+    if not executable.exists():
+        raise SystemExit(f"hartree-fock binary not found at {executable}")
+    if not args.input.exists():
+        raise SystemExit(f"input file not found: {args.input}")
+
+    template = args.input.read_text(encoding="utf-8")
+    symbols, coords, charge, multiplicity = parse_coords_block(template)
+    natom = len(symbols)
+
+    tmp = tempfile.TemporaryDirectory(prefix="hartree-fock-hf-fd-")
+    workdir = Path(tmp.name)
+    if args.keep_tmp:
+        tmp._finalizer.detach()  # type: ignore[attr-defined]
+
+    analytic_input = render_input(
+        template, symbols, coords, charge, multiplicity, calculation="gradient"
+    )
+    analytic_path = workdir / "analytic.hfinp"
+    analytic_path.write_text(analytic_input, encoding="utf-8")
+    analytic_output = run_hartree_fock(executable, analytic_path)
+    analytic_gradient = parse_analytic_gradient(analytic_output, natom)
+
+    fd_gradient = central_difference_gradient(
+        executable,
+        template,
+        symbols,
+        coords,
+        charge,
+        multiplicity,
+        args.delta,
+        workdir,
+    )
+
+    print("Analytic gradient (Ha/Bohr):")
+    for atom, row in enumerate(analytic_gradient, start=1):
+        print(f"  Atom {atom}: {row[0]:14.8f}  {row[1]:14.8f}  {row[2]:14.8f}")
+    print("Finite-difference gradient (Ha/Bohr):")
+    for atom, row in enumerate(fd_gradient, start=1):
+        print(f"  Atom {atom}: {row[0]:14.8f}  {row[1]:14.8f}  {row[2]:14.8f}")
+
+    worst, (atom, axis) = max_abs_diff(analytic_gradient, fd_gradient)
+    print(
+        f"max |g_analytic - g_fd| = {worst:.3e} Ha/Bohr "
+        f"(atom {atom + 1}, axis {'xyz'[axis]})"
+    )
+    print(f"tolerance               = {args.atol:.3e} Ha/Bohr")
+
+    if args.keep_tmp:
+        print(f"work directory kept at: {workdir}")
+
+    if worst > args.atol:
+        print("FAIL: analytic HF gradient deviates from finite difference")
+        return 1
+
+    print("PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/inputs/regression/dft/water_dft_b3lyp_gradient.hfinp
+++ b/tests/inputs/regression/dft/water_dft_b3lyp_gradient.hfinp
@@ -1,0 +1,38 @@
+%begin_control
+    basis       sto-3g
+    calculation gradient
+    verbosity   normal
+    basis_type  cartesian
+%end_control
+
+%begin_scf
+    scf_type    rhf
+    use_diis    .true.
+    diis_dim    6
+    engine      os
+    guess       hcore
+    max_cycles  50
+    tol_energy  1.0e-8
+    tol_density 1.0e-8
+%end_scf
+
+%begin_dft
+    grid                coarse
+    exchange            b3lyp
+    correlation         pbe
+    print_grid_summary  .true.
+%end_dft
+
+%begin_geom
+    coord_type  cartesian
+    coord_units angstrom
+    use_symm    .false.
+%end_geom
+
+%begin_coords
+3
+0   1
+O     0.000000     0.000000     0.000000
+H     0.758602     0.000000     0.504284
+H    -0.758602     0.000000     0.504284
+%end_coords

--- a/tests/inputs/regression/geometry/water_rhf_geomopt_engine_compare.hfinp
+++ b/tests/inputs/regression/geometry/water_rhf_geomopt_engine_compare.hfinp
@@ -1,29 +1,31 @@
 %begin_control
     basis       sto-3g
-    calculation gradient
+    calculation geomopt
     verbosity   normal
     basis_type  cartesian
 %end_control
 
 %begin_scf
-    scf_type    uhf
-    guess       sad
+    scf_type    rhf
     use_diis    .true.
     diis_dim    8
     engine      os
-    level_shift 0.3
+    guess       hcore
+    max_cycles  50
+    tol_energy  1.0e-8
+    tol_density 1.0e-8
 %end_scf
 
 %begin_geom
     coord_type  cartesian
     coord_units angstrom
-    use_symm    .true.
+    use_symm    .false.
 %end_geom
 
 %begin_coords
 3
-0   3
-O     0.000000     0.000000     0.117176
-H     0.000000     0.756950    -0.468703
-H     0.000000    -0.756950    -0.468703
+0   1
+O     0.000000     0.000000     0.100000
+H     0.800000     0.000000    -0.500000
+H    -0.800000     0.000000    -0.500000
 %end_coords

--- a/tests/inputs/regression/geometry/water_rhf_gradient_hgp.hfinp
+++ b/tests/inputs/regression/geometry/water_rhf_gradient_hgp.hfinp
@@ -6,24 +6,23 @@
 %end_control
 
 %begin_scf
-    scf_type    uhf
-    guess       sad
+    scf_type    rhf
     use_diis    .true.
     diis_dim    8
-    engine      os
-    level_shift 0.3
+    engine      hgp
+    guess       hcore
 %end_scf
 
 %begin_geom
     coord_type  cartesian
     coord_units angstrom
-    use_symm    .true.
+    use_symm    .false.
 %end_geom
 
 %begin_coords
 3
-0   3
-O     0.000000     0.000000     0.117176
-H     0.000000     0.756950    -0.468703
-H     0.000000    -0.756950    -0.468703
+0   1
+O     0.000000     0.000000     0.000000
+H     0.758602     0.000000     0.504284
+H    -0.758602     0.000000     0.504284
 %end_coords

--- a/tests/inputs/regression/open_shell/water_triplet_uhf_gradient_hgp_sto3g.hfinp
+++ b/tests/inputs/regression/open_shell/water_triplet_uhf_gradient_hgp_sto3g.hfinp
@@ -10,7 +10,7 @@
     guess       sad
     use_diis    .true.
     diis_dim    8
-    engine      os
+    engine      hgp
     level_shift 0.3
 %end_scf
 

--- a/tests/regression_cases.json
+++ b/tests/regression_cases.json
@@ -514,6 +514,81 @@
       ]
     },
     {
+      "id": "water_rhf_gradient_hgp_core",
+      "input": "tests/inputs/regression/geometry/water_rhf_gradient_hgp.hfinp",
+      "executable": "tests/hf_gradient_fd.py",
+      "tags": [
+        "core",
+        "extended"
+      ],
+      "expected_exit_code": 0,
+      "contains": [
+        "Analytic gradient (Ha/Bohr):",
+        "Finite-difference gradient (Ha/Bohr):",
+        "PASS"
+      ]
+    },
+    {
+      "id": "water_rhf_gradient_engine_os_vs_hgp",
+      "input": "tests/inputs/regression/geometry/water_rhf_gradient.hfinp",
+      "executable": "tests/engine_gradient_compare.py",
+      "tags": [
+        "core",
+        "extended"
+      ],
+      "expected_exit_code": 0,
+      "contains": [
+        "OS gradient (Ha/Bohr):",
+        "HGP gradient (Ha/Bohr):",
+        "PASS"
+      ]
+    },
+    {
+      "id": "water_b3lyp_gradient_engine_os_vs_hgp",
+      "input": "tests/inputs/regression/dft/water_dft_b3lyp_gradient.hfinp",
+      "executable": "tests/engine_gradient_compare.py",
+      "tags": [
+        "core",
+        "extended"
+      ],
+      "expected_exit_code": 0,
+      "contains": [
+        "OS gradient (Ha/Bohr):",
+        "HGP gradient (Ha/Bohr):",
+        "PASS"
+      ]
+    },
+    {
+      "id": "water_hse06_gradient_engine_os_vs_hgp",
+      "input": "tests/inputs/regression/dft/water_dft_hse06_gradient.hfinp",
+      "executable": "tests/engine_gradient_compare.py",
+      "tags": [
+        "core",
+        "extended"
+      ],
+      "expected_exit_code": 0,
+      "contains": [
+        "OS gradient (Ha/Bohr):",
+        "HGP gradient (Ha/Bohr):",
+        "PASS"
+      ]
+    },
+    {
+      "id": "water_rhf_geomopt_engine_os_vs_hgp",
+      "input": "tests/inputs/regression/geometry/water_rhf_geomopt_engine_compare.hfinp",
+      "executable": "tests/engine_geomopt_compare.py",
+      "tags": [
+        "core",
+        "extended"
+      ],
+      "expected_exit_code": 0,
+      "contains": [
+        "Final Energy (OS)",
+        "Final Energy (HGP)",
+        "PASS"
+      ]
+    },
+    {
       "id": "h2_rmp2_gradient_smoke",
       "input": "tests/inputs/regression/post_hf/h2_rmp2_gradient.hfinp",
       "tags": [
@@ -924,6 +999,21 @@
           "metric": "gradient_max",
           "value": 0.5
         }
+      ]
+    },
+    {
+      "id": "water_triplet_uhf_gradient_hgp_core",
+      "input": "tests/inputs/regression/open_shell/water_triplet_uhf_gradient_hgp_sto3g.hfinp",
+      "executable": "tests/hf_gradient_fd.py",
+      "tags": [
+        "core",
+        "extended"
+      ],
+      "expected_exit_code": 0,
+      "contains": [
+        "Analytic gradient (Ha/Bohr):",
+        "Finite-difference gradient (Ha/Bohr):",
+        "PASS"
       ]
     },
     {

--- a/vault/00 - Index.md
+++ b/vault/00 - Index.md
@@ -24,7 +24,7 @@ Quantum chemistry engine in C++23. Main binaries: `hartree-fock` (HF/post-HF) an
 - [[CASSCF and SA-CASSCF]] — CASSCF/SA-CASSCF/RASSCF details
 - [[Coupled Cluster]] — RCCSD/UCCSD/RCCSDT/UCCSDT/RCCSDTQ + arbitrary-order
 - [[DFT]] — KS-DFT, TDDFT, PCM, libxc hybrids/range separation
-- [[Integral Engine]] — Obara-Saika / Rys ERI, shell pairs
+- [[Integral Engine]] — Obara-Saika / Rys / HGP ERI, shell pairs, dispatch
 - [[Gradients and GeomOpt]] — analytic gradients (RHF/UHF/RMP2/UMP2), L-BFGS, IC-BFGS
 
 ### Gotchas
@@ -33,6 +33,7 @@ Quantum chemistry engine in C++23. Main binaries: `hartree-fock` (HF/post-HF) an
 - [[Shell Pair Indexing]] — row-major ordering trap
 - [[Norm Factors]] — contracted norm folded into coefficients
 - [[Error Handling Pattern]] — std::expected throughout
+- [[HGP Screened inv_2_delta]] — HGP VRR coupling term must scale by boys_scale for screened kernels
 
 ### Status
 - [[Completion]] — what is done and validated
@@ -46,7 +47,7 @@ Quantum chemistry engine in C++23. Main binaries: `hartree-fock` (HF/post-HF) an
 | Entry point | `src/driver.cpp` |
 | Input parser | `src/io/io.cpp` |
 | Checkpoint I/O | `src/io/checkpoint.cpp` |
-| ERI engine | `src/integrals/os.cpp` |
+| ERI engines | `src/integrals/{os,rys,hgp}.cpp`; dispatch in `src/integrals/base.h` |
 | PCM solvation | `src/solvation/pcm.cpp` |
 | CASSCF main loop | `src/post_hf/casscf/casscf.cpp` (`run_mcscf_loop`) |
 | CC tensor backend | `src/post_hf/cc/tensor_backend.cpp` |

--- a/vault/Gotchas/HGP Screened inv_2_delta.md
+++ b/vault/Gotchas/HGP Screened inv_2_delta.md
@@ -1,0 +1,84 @@
+---
+name: HGP Screened inv_2_delta
+description: HGP VRR inv_2_delta must scale by boys_scale for screened kernels — silently wrong on mixed bra/ket AM otherwise
+type: gotcha
+priority: critical
+include_in_claude: true
+tags: [hgp, integrals, screened, range-separated, gotcha, vrr]
+---
+
+# HGP Screened inv_2_delta Gotcha
+
+## Symptom
+
+The HGP `_compute_eri_deriv_elem` returns correct values for Coulomb but
+wrong values for `LongRange` / `ShortRange` whenever the quartet has
+**matching-axis angular momentum on both bra and ket**. Concrete trigger
+patterns:
+
+- (p_y, s | p_y, s): wrong on the LongRange y-component of any centre that
+  raises the C / D shell.
+- More generally: any (μν|λσ) where the C-VRR cross-coupling term
+  `if (ax > 0) dst[m] += ax * inv_2_delta * cross[m+1]` fires.
+
+Coulomb is unaffected because `screen.boys_scale = 1` makes the missing
+factor a no-op.
+
+## Root Cause
+
+In `hgp_vrr` ([src/integrals/hgp.cpp](src/integrals/hgp.cpp)) the bra/ket
+coupling factor was computed as a bare `0.5 / delta` for every kernel:
+
+```cpp
+const double inv_2_delta = 0.5 / delta;  // wrong for screened kernels
+```
+
+OS at [src/integrals/os.cpp](src/integrals/os.cpp) builds the same factor
+with the screened scaling baked in:
+
+```cpp
+const double inv_2_delta =
+    (0.5 / delta) *
+    ((kernel == HartreeFock::ERIKernel::Coulomb) ? 1.0 : screen.boys_scale);
+```
+
+`inv_2_delta` is the prefactor for the cross-coupling term in the C-VRR
+recurrence — it only fires when both an A-axis and the matching C-axis
+carry angular momentum (lines around `if (ax > 0) ... cross[m+1]` in the
+C-VRR x/y/z blocks). For Coulomb, `boys_scale = 1`, so the bare form
+happens to be correct. For LongRange / ShortRange the factor is
+`boys_scale = λ = ω² / (ω² + ρ)`, and skipping it shifts the cross-term
+weight, corrupting any contracted ERI whose VRR path actually traverses
+that term.
+
+## Why the existing tests missed it for so long
+
+The early screened tests exercised s-s-s-s (no AM anywhere, cross term
+never fires) and p-s-s-s with raises only on the bra (`lCDx = lCDy = lCDz
+= 0`, the entire C-VRR loop is skipped). The bug surfaces only on the
+(p|s|p|s) mixed-bra/ket pattern, which the targeted derivative gate
+introduced when it added p-s-p-s coverage.
+
+## The Fix
+
+Apply the same conditional scaling OS uses:
+
+```cpp
+const double inv_2_delta =
+    (0.5 / delta) *
+    ((kernel == HartreeFock::ERIKernel::Coulomb) ? 1.0 : screen.boys_scale);
+```
+
+Validated by the `test_hgp_unweighted_screened_eri_against_os` gate in
+[tests/eri_derivative_kernels.cpp](tests/eri_derivative_kernels.cpp):
+2352-quartet OS↔HGP sweep on water/STO-3G clean to ~4e-15, plus targeted
+checks on s-s-s-s, p-s-s-s, and p-s-p-s for all three kernels.
+
+## Rule
+
+Any screened-kernel scaling that touches the OS recurrence variables
+(`inv_2_zetaAB`, `inv_2_zetaCD`, `inv_2_delta`, `WP*`, `WQ*`, `T`,
+`prefactor`) must be mirrored exactly in the HGP `hgp_vrr` — they share
+the same recurrence algebra and any kernel-aware factor present in one
+must be present in the other. When in doubt, diff the two engines'
+seed/recurrence blocks side by side.

--- a/vault/Implementation/Gradients and GeomOpt.md
+++ b/vault/Implementation/Gradients and GeomOpt.md
@@ -15,11 +15,50 @@ tags: [gradient, geomopt, lbfgs, hessian, frequency]
 
 Components:
 - One-electron gradient: ∂H_core/∂R (kinetic + nuclear attraction derivatives)
-- Two-electron gradient: ∂ERI/∂R (Obara-Saika derivative integrals)
+- Two-electron gradient: ∂ERI/∂R, dispatched per engine
 - Nuclear repulsion gradient: ∂V_nn/∂R
 - Orbital response (Pulay terms): couples density matrix response to basis function derivatives
 
 For MP2: requires orbital response (Z-vector / coupled-perturbed HF) to handle the response of the HF orbitals to the nuclear displacement.
+
+### Derivative-ERI engine dispatch
+
+`compute_eri_deriv_dispatch` in `src/gradient/gradient.cpp` selects the
+derivative engine off `calc._integral._engine` and is **engine-agnostic for
+every kernel** (Coulomb, LongRange, ShortRange):
+
+- `IntegralMethod::HeadGordonPople` → `HeadGordonPople::_compute_eri_deriv_elem`
+- everything else → `ObaraSaika::_compute_eri_deriv_elem`
+
+The 1-electron derivative integrals (`_compute_1e_deriv_A`,
+`_compute_nuclear_deriv_A_elem`, `_compute_nuclear_deriv_C_elem`) live only
+in `src/integrals/os.cpp`; HGP has no separate implementation for them and
+always uses OS. They are cheap relative to the 2e term, so this is not a
+performance gap.
+
+The MP2 / UMP2 gradient code in `src/post_hf/mp2_gradient.cpp` calls
+`ObaraSaika::_compute_eri_deriv_elem` directly at three sites; it bypasses
+`compute_eri_deriv_dispatch`, so the HGP engine is not used for MP2 gradient
+response intermediates even when selected. Values agree with the OS path to
+~1e-15; the asymmetry is performance/coverage, not correctness.
+
+### Cross-engine validation
+
+Engine-agnostic gradient correctness is gated by four regression cases that
+run the same input twice (engine os, engine hgp) and compare:
+
+| ID | What it tests |
+|---|---|
+| `water_rhf_gradient_engine_os_vs_hgp` | RHF/STO-3G analytic gradient |
+| `water_b3lyp_gradient_engine_os_vs_hgp` | B3LYP/STO-3G gradient (HF-like Coulomb path) |
+| `water_hse06_gradient_engine_os_vs_hgp` | HSE06/STO-3G gradient — exercises the LongRange derivative dispatch |
+| `water_rhf_geomopt_engine_os_vs_hgp` | RHF/STO-3G geomopt: |ΔE| ≤ 1e-8 Eh and geom RMSD ≤ 1e-5 Å |
+
+Drivers: `tests/engine_gradient_compare.py` and
+`tests/engine_geomopt_compare.py`. Binary (`hartree-fock` vs `planck-dft`)
+is auto-selected from the presence of `%begin_dft` in the input. Per-
+component tolerance on the gradient cases is 1e-7 Ha/Bohr (limited by the
+8-decimal print precision of `Atom N:` lines).
 
 ## UMP2 Gradient (commit 22c0645)
 

--- a/vault/Implementation/Integral Engine.md
+++ b/vault/Implementation/Integral Engine.md
@@ -1,19 +1,22 @@
 ---
 name: Integral Engine
-description: Obara-Saika and Rys quadrature ERI engines, shell pairs, dispatch
+description: Obara-Saika, Rys, and HGP ERI engines, shell pairs, dispatch
 type: implementation
 priority: high
 include_in_claude: true
-tags: [integrals, obara-saika, rys, eri, shell-pairs]
+tags: [integrals, obara-saika, rys, hgp, eri, shell-pairs]
 ---
 
 # Integral Engine
 
 ## Overview
 
-Two ERI engines, selected via `IntegralMethod`:
+Three ERI engines, selected via `IntegralMethod`:
 - `ObaraSaika` — Obara-Saika horizontal/vertical recurrences
 - `RysQuadrature` — Rys quadrature (alternative)
+- `HeadGordonPople` — HGP variant with VRR built once per primitive pair and
+  HRR hoisted to the contracted shell-quartet level (`hgp` / `head-gordon-pople`
+  in input)
 - `Auto` — dispatch based on angular momenta (picks faster engine per shell quartet)
 
 ## Shell Pairs
@@ -46,6 +49,63 @@ Standard OS scheme:
 
 OpenMP parallelized over shell-pair loops when `USE_OPENMP` is defined.
 
+## HGP Engine (`src/integrals/hgp.cpp`)
+
+The HGP engine implements the Head-Gordon-Pople rearrangement of the OS
+recurrences: VRR runs per primitive pair to build the `(a0|c0; m)` block,
+those blocks are contracted across primitives into a single `(a0|c0)`
+accumulator, and the two HRR passes (CD then AB transfer) run **once per
+contracted shell quartet** instead of once per primitive pair. Same final
+ERI value as OS — the savings come from amortizing HRR over the primitive
+loop. Thread-local scratch (`g_hgp_scratch`) is resized per quartet and
+reused.
+
+Public entry points mirror OS one-for-one:
+
+- `_compute_2e` (full ERI tensor) and `_compute_2e_fock` / `_fock_uhf`
+  (direct SCF builds)
+- `_contracted_eri_elem` (single contracted quartet, used by Fock builders
+  and the gradient lowering term)
+- `_compute_eri_deriv_elem` (12-component derivative, used by the gradient
+  dispatcher)
+- `_build_skeleton_eri_symm` and `_compute_2e_fock_{symm,symm_spherical}` in
+  `src/symmetry/hgp_symm.cpp` — full-point-group direct SCF, same Cartesian-
+  skin pattern OS and Rys use
+
+### Screened kernels (LongRange / ShortRange)
+
+HGP serves screened kernels natively for all three entry points (no OS
+detour). The screened scaling is applied inside `hgp_vrr`:
+
+- Boys-argument scale `T = boys_scale · rho · |P-Q|²`
+- WP/WQ vectors scaled by `wpwq_scale = screen.rho / rho`
+- Prefactor scaled by `screen.prefactor_scale`
+- C-VRR bra/ket coupling term `inv_2_delta` scaled by `boys_scale` for
+  non-Coulomb kernels — see [[HGP Screened inv_2_delta]] for the bug this
+  fixed
+
+### Dispatcher
+
+- SCF Fock builds dispatch through `src/integrals/base.h`:
+  `engine == HeadGordonPople` routes to the HGP entries.
+- Full-symmetry direct SCF dispatches through `src/scf/scf.cpp`
+  (`full_symmetry_fock_{rhf,uhf}` and `full_symmetry_build_skeleton`).
+- Analytic gradient dispatches through `compute_eri_deriv_dispatch` in
+  `src/gradient/gradient.cpp` — engine-agnostic for all kernels (Coulomb,
+  LongRange, ShortRange).
+- MP2 / UMP2 analytic gradient (`src/post_hf/mp2_gradient.cpp`) calls
+  `ObaraSaika::_compute_eri_deriv_elem` directly; bypasses the dispatcher,
+  so HGP is not used for the MP2 gradient response intermediates even when
+  the engine is selected. Not a correctness bug (values match OS to ~1e-15)
+  but a latent asymmetry.
+
+### Test hooks retained for historical gates
+
+`_contracted_eri_elem_native_test` and `_compute_eri_deriv_elem_native_test`
+are now thin aliases of the production entries. They predate the screened-
+guard lift, when the test hooks were the only way to exercise the native
+path. Kept so existing test code links unchanged.
+
 ## Index Placement
 
 After computing a block of ERIs for shell quartet (μν|λσ), the result is placed at:
@@ -58,4 +118,9 @@ This requires `ContractedView._index` to be correctly set. **Never use `invert_p
 
 - `src/integrals/os.cpp` + `os.h` — Obara-Saika ERI
 - `src/integrals/rys.cpp` — Rys quadrature ERI
+- `src/integrals/hgp.cpp` + `hgp.h` — HGP ERI (VRR-per-pair + HRR-outside)
+- `src/integrals/base.h` — engine-dispatch wrappers for `_compute_2e` /
+  `_compute_2e_fock` / `_compute_2e_fock_uhf`
+- `src/symmetry/{os,rys,hgp}_symm.cpp` — full-point-group skeleton + Fock
+  for each engine; SCF dispatches through `src/scf/scf.cpp`
 - `src/integrals/shellpair.cpp` + `shellpair.h` — shell pair data and construction

--- a/vault/Status/Completion.md
+++ b/vault/Status/Completion.md
@@ -9,7 +9,7 @@ tags: [status, completion, validated, canonical]
 
 # Completion Status
 
-Last updated: 2026-05-27
+Last updated: 2026-05-28
 
 This is the canonical completion-status document for the repository.
 Subsystem handoff, plan, benchmark, and fix-summary notes may still exist for
@@ -30,7 +30,7 @@ historical design context, but they are no longer the source of truth for
 
 ### Direct SCF and full point-group symmetry
 
-- Obara-Saika and Rys direct Fock engines, with auto-dispatch by angular momentum
+- Obara-Saika, Rys, and HGP direct Fock engines, with auto-dispatch by angular momentum
 - Full point-group ERI reduction for direct RHF/UHF in the Cartesian basis
 - Full point-group ERI reduction for direct RHF/UHF in the spherical-harmonic basis
 - Metric-correct spherical group operators
@@ -141,6 +141,16 @@ historical design context, but they are no longer the source of truth for
 - BSSE / ghost-atom infrastructure and CP driver
 - Full-symmetry direct-SCF performance improvements: persisted skeleton ERI and
   monomial-group-operator fast path
+- HGP screened-derivative correctness: `hgp_vrr` now scales the C-VRR
+  `inv_2_delta` cross-coupling term by `screen.boys_scale` for non-Coulomb
+  kernels, matching OS. The screened-kernel OS fallback inside HGP
+  `_contracted_eri_elem` is removed, and the gradient dispatcher's
+  Coulomb-only HGP guard is lifted. Net effect: range-separated DFT
+  gradients (HSE06 etc.) now run natively through HGP when the engine is
+  selected. Gated by a 2352-quartet OS↔HGP sweep on water/STO-3G (max diff
+  ~4e-15) plus four end-to-end cross-engine comparison regressions:
+  `water_{rhf,b3lyp,hse06}_gradient_engine_os_vs_hgp` and
+  `water_rhf_geomopt_engine_os_vs_hgp`. See [[HGP Screened inv_2_delta]].
 
 ## CASSCF PySCF Gate Table
 

--- a/vault/Status/Open Work.md
+++ b/vault/Status/Open Work.md
@@ -9,7 +9,7 @@ tags: [status, open-work, canonical, roadmap]
 
 # Open Work
 
-Last updated: 2026-05-27
+Last updated: 2026-05-28
 
 This is the canonical open-work document for the repository.
 Use it with `vault/Status/Completion.md`. Older status snapshots and handoff
@@ -118,3 +118,16 @@ Gate:
 - Eliminate remaining reversed-shell-pair reconstruction churn in gradient paths outside the already-fixed RHF path
 - Deduplicate the full-group AO-transform machinery that still exists in both `group_operations.cpp` and `mo_symmetry.cpp`
 - Refactor `Calculator` only where it buys real safety or clarity: the leading candidates are grouping the loose MP2/UMP2 result cache and introducing a geometry-derived working-state object with a single invalidation point
+- Route MP2 / UMP2 gradient derivative-ERI calls in
+  `src/post_hf/mp2_gradient.cpp` (lines 371, 525, 726) through
+  `compute_eri_deriv_dispatch` instead of hardcoding
+  `ObaraSaika::_compute_eri_deriv_elem`. Today the MP2 response
+  intermediates always use OS even when the user picked HGP — values agree
+  to ~1e-15 so this is performance/coverage, not correctness.
+- HGP screened-Fock and screened-`_compute_2e` paths are now natively wired
+  (the screened guard in `_contracted_eri_elem` was lifted) and validated
+  at the quartet level against OS for water/STO-3G. An end-to-end
+  screened-DFT SCF *energy* regression that selects `engine hgp` on a
+  range-separated functional (HSE06 / ωB97X) would gate the Fock-side use
+  of the screened HGP path more strongly than the current per-quartet
+  sweep does.


### PR DESCRIPTION
## Summary

- Fix `hgp_vrr` `inv_2_delta` to scale by `screen.boys_scale` for non-Coulomb kernels (matched OS behaviour). The C-VRR bra/ket coupling term was silently wrong on any quartet with matched-axis AM on both bra and ket (e.g. p-s-p-s) under LongRange / ShortRange kernels.
- Drop the OS detour in HGP `_contracted_eri_elem` and `_compute_eri_deriv_elem` for screened kernels — both now run native HGP end-to-end.
- Lift the Coulomb-only HGP guard in `compute_eri_deriv_dispatch` (`src/gradient/gradient.cpp`). Range-separated DFT gradients (HSE06 etc.) now actually use HGP when the engine is selected, instead of silently falling back to OS.
- Add a targeted + sweep gate (`test_hgp_unweighted_screened_eri_against_os` in `tests/eri_derivative_kernels.cpp`): targeted check on s-s-s-s, p-s-s-s, p-s-p-s across all three kernels, plus a 2352-quartet OS↔HGP sweep on water/STO-3G (max diff ~4e-15).
- Add four cross-engine end-to-end regressions driven by new comparator scripts:
  - `water_rhf_gradient_engine_os_vs_hgp`
  - `water_b3lyp_gradient_engine_os_vs_hgp`
  - `water_hse06_gradient_engine_os_vs_hgp` (exercises the lifted LongRange path)
  - `water_rhf_geomopt_engine_os_vs_hgp`
- Update vault docs: HGP is now a first-class engine in the Integral Engine and Gradients notes, the inv_2_delta gotcha is pinned under `vault/Gotchas/`, and the Status/Completion + Open Work notes are refreshed.

## Test plan

- [x] `planck-eri-derivative-kernels` (includes new targeted gate + 2352-quartet sweep)
- [x] `water_rhf_gradient_engine_os_vs_hgp` regression
- [x] `water_b3lyp_gradient_engine_os_vs_hgp` regression
- [x] `water_hse06_gradient_engine_os_vs_hgp` regression
- [x] `water_rhf_geomopt_engine_os_vs_hgp` regression
- [ ] Full regression suite on CI