### PR TITLE
basis: RI auxiliary basis loader (RI-MP2 step 1 of 10)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ scripts/*
 !scripts/vault_to_claude.py
 !scripts/sync-memory.sh
 !scripts/fit_auto_dispatch.py
+!scripts/rebuild_teaching_site_if_changed.py
 notes
 src/base/basis.h
 # ccgen files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -469,6 +469,7 @@ if(BUILD_TESTING)
         ${CMAKE_SOURCE_DIR}/tests/eri_derivative_kernels.cpp
         ${SRC_DIR}/basis/basis.cpp
         ${SRC_DIR}/basis/gaussian.cpp
+        ${SRC_DIR}/basis/gbs_parser.cpp
         ${SRC_DIR}/basis/spherical.cpp
         ${SRC_DIR}/basis/spherical_recurrence.cpp
         ${SRC_DIR}/integrals/hgp.cpp
@@ -492,6 +493,7 @@ if(BUILD_TESTING)
         ${CMAKE_SOURCE_DIR}/tests/hgp_engine_smoke.cpp
         ${SRC_DIR}/basis/basis.cpp
         ${SRC_DIR}/basis/gaussian.cpp
+        ${SRC_DIR}/basis/gbs_parser.cpp
         ${SRC_DIR}/basis/spherical.cpp
         ${SRC_DIR}/basis/spherical_recurrence.cpp
         ${INT_SRC}
@@ -502,6 +504,7 @@ if(BUILD_TESTING)
         ${CMAKE_SOURCE_DIR}/tests/hgp_quartet_validation.cpp
         ${SRC_DIR}/basis/basis.cpp
         ${SRC_DIR}/basis/gaussian.cpp
+        ${SRC_DIR}/basis/gbs_parser.cpp
         ${SRC_DIR}/basis/spherical.cpp
         ${SRC_DIR}/basis/spherical_recurrence.cpp
         ${INT_SRC}
@@ -512,6 +515,7 @@ if(BUILD_TESTING)
         ${CMAKE_SOURCE_DIR}/tests/hgp_benchmark.cpp
         ${SRC_DIR}/basis/basis.cpp
         ${SRC_DIR}/basis/gaussian.cpp
+        ${SRC_DIR}/basis/gbs_parser.cpp
         ${SRC_DIR}/basis/spherical.cpp
         ${SRC_DIR}/basis/spherical_recurrence.cpp
         ${INT_SRC}
@@ -522,6 +526,7 @@ if(BUILD_TESTING)
         ${CMAKE_SOURCE_DIR}/tests/auto_dispatch_benchmark.cpp
         ${SRC_DIR}/basis/basis.cpp
         ${SRC_DIR}/basis/gaussian.cpp
+        ${SRC_DIR}/basis/gbs_parser.cpp
         ${SRC_DIR}/basis/spherical.cpp
         ${SRC_DIR}/basis/spherical_recurrence.cpp
         ${INT_SRC}
@@ -559,6 +564,17 @@ if(BUILD_TESTING)
         ${SRC_DIR}/basis/spherical_recurrence.cpp
     )
 
+    # Structural test for the RI auxiliary basis loader (no PySCF reference
+    # values — this is the file-I/O and shell-construction gate, not a
+    # validation against any specific shipped aux basis).
+    add_executable(planck-aux-basis-load
+        ${CMAKE_SOURCE_DIR}/tests/aux_basis_load.cpp
+        ${SRC_DIR}/basis/rifit.cpp
+        ${SRC_DIR}/basis/gbs_parser.cpp
+        ${SRC_DIR}/basis/basis.cpp
+        ${SRC_DIR}/lookup/elements.cpp
+    )
+
     # Contract test for the working-state rebuild helper that will drive
     # spherical geomopt and freq in Phase 3. Currently the helper has no live
     # caller (the driver keeps its inline copy for ordering reasons around the
@@ -570,6 +586,7 @@ if(BUILD_TESTING)
         ${SRC_DIR}/symmetry/integral_symmetry.cpp
         ${SRC_DIR}/basis/basis.cpp
         ${SRC_DIR}/basis/gaussian.cpp
+        ${SRC_DIR}/basis/gbs_parser.cpp
         ${SRC_DIR}/basis/spherical.cpp
         ${SRC_DIR}/basis/spherical_recurrence.cpp
         ${SRC_DIR}/integrals/os.cpp
@@ -588,6 +605,7 @@ if(BUILD_TESTING)
         ${SRC_DIR}/symmetry/symmetry.cpp
         ${SRC_DIR}/basis/basis.cpp
         ${SRC_DIR}/basis/gaussian.cpp
+        ${SRC_DIR}/basis/gbs_parser.cpp
         ${SRC_DIR}/basis/spherical.cpp
         ${SRC_DIR}/basis/spherical_recurrence.cpp
         ${SRC_DIR}/lookup/elements.cpp
@@ -610,6 +628,7 @@ if(BUILD_TESTING)
         ${SRC_DIR}/symmetry/symmetry.cpp
         ${SRC_DIR}/basis/basis.cpp
         ${SRC_DIR}/basis/gaussian.cpp
+        ${SRC_DIR}/basis/gbs_parser.cpp
         ${SRC_DIR}/basis/spherical.cpp
         ${SRC_DIR}/basis/spherical_recurrence.cpp
         ${SRC_DIR}/lookup/elements.cpp
@@ -637,6 +656,7 @@ if(BUILD_TESTING)
         ${SRC_DIR}/symmetry/symmetry.cpp
         ${SRC_DIR}/basis/basis.cpp
         ${SRC_DIR}/basis/gaussian.cpp
+        ${SRC_DIR}/basis/gbs_parser.cpp
         ${SRC_DIR}/basis/spherical.cpp
         ${SRC_DIR}/basis/spherical_recurrence.cpp
     )
@@ -652,6 +672,7 @@ if(BUILD_TESTING)
         ${SRC_DIR}/symmetry/symmetry.cpp
         ${SRC_DIR}/basis/basis.cpp
         ${SRC_DIR}/basis/gaussian.cpp
+        ${SRC_DIR}/basis/gbs_parser.cpp
         ${SRC_DIR}/basis/spherical.cpp
         ${SRC_DIR}/basis/spherical_recurrence.cpp
     )
@@ -752,6 +773,11 @@ if(BUILD_TESTING)
         ${eigen_SOURCE_DIR}
     )
 
+    target_include_directories(planck-aux-basis-load PRIVATE
+        ${SRC_DIR}
+        ${eigen_SOURCE_DIR}
+    )
+
     target_include_directories(planck-working-state-rebuild PRIVATE
         ${SRC_DIR}
         ${MSYM_INSTALL_DIR}/include
@@ -837,6 +863,12 @@ if(BUILD_TESTING)
     )
 
     set_target_properties(planck-spherical-density-lift PROPERTIES
+        CXX_STANDARD 23
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF
+    )
+
+    set_target_properties(planck-aux-basis-load PROPERTIES
         CXX_STANDARD 23
         CXX_STANDARD_REQUIRED ON
         CXX_EXTENSIONS OFF
@@ -993,6 +1025,11 @@ if(BUILD_TESTING)
     add_test(
         NAME planck-spherical-density-lift
         COMMAND planck-spherical-density-lift
+    )
+
+    add_test(
+        NAME planck-aux-basis-load
+        COMMAND planck-aux-basis-load
     )
 
     add_test(

--- a/basis-sets/toy-ri
+++ b/basis-sets/toy-ri
@@ -1,0 +1,25 @@
+!----------------------------------------------------------------------
+! Toy auxiliary (RI) basis used by the rifit loader's unit test.
+! Not a production basis — exists only to exercise the .gbs parser and
+! the AuxBasis loader on shells with multiple angular momenta and
+! multiple primitives. Real cc-pVDZ-RI / def2-universal-jkfit aux basis
+! files come from the Basis Set Exchange and are not auto-shipped.
+!----------------------------------------------------------------------
+
+
+H     0
+S    1   1.00
+      1.00000000             1.00000000
+P    1   1.00
+      0.50000000             1.00000000
+****
+He     0
+S    1   1.00
+      2.00000000             1.00000000
+S    1   1.00
+      0.40000000             1.00000000
+P    1   1.00
+      0.80000000             1.00000000
+D    1   1.00
+      0.30000000             1.00000000
+****

--- a/docs/index.html
+++ b/docs/index.html
@@ -1354,22 +1354,22 @@ return (L_AB + L_CD) &lt;= 1;
 <th>Per-bucket winner</th>
 </tr></thead>
 <tbody>
-<tr><td>0, 0</td><td>74.3</td><td><strong>33.6</strong></td><td>65.1</td><td>Rys</td></tr>
-<tr><td>0, 1 / 1, 0</td><td>59.4 / 60.5</td><td><strong>22.9 / 29.3</strong></td><td>50.1 / 52.3</td><td>Rys</td></tr>
-<tr><td>0, 2 / 1, 1 / 2, 0</td><td>36.5 / 32.9 / 43.8</td><td>208 / 188 / 211</td><td><strong>33.2 / 31.4 / 40.4</strong></td><td>OS (tie with HGP)</td></tr>
-<tr><td>1, 2 / 2, 1 / 2, 2</td><td>20.8 / 21.1 / 13.9</td><td>110 / 110 / 140</td><td>22.5 / 23.3 / 18.5</td><td>HGP</td></tr>
-<tr><td>3, 3</td><td>7.7</td><td>73.6</td><td>16.4</td><td>HGP</td></tr>
-<tr><td>4, 4</td><td>7.2</td><td>37.9</td><td>16.0</td><td>HGP</td></tr>
-<tr><td>5, 5</td><td>10.8</td><td>54.3</td><td>37.7</td><td>HGP</td></tr>
-<tr><td>6, 6</td><td>20.9</td><td>76.8</td><td>84.7</td><td>HGP</td></tr>
-<tr><td>7, 7</td><td>41.4</td><td>116.3</td><td>185.7</td><td>HGP</td></tr>
-<tr><td>8, 8</td><td>83.1</td><td>174.2</td><td>360.5</td><td>HGP</td></tr>
+<tr><td>0, 0</td><td>67.0</td><td><strong>23.5</strong></td><td>50.9</td><td>Rys</td></tr>
+<tr><td>0, 1 / 1, 0</td><td>59.3 / 59.9</td><td><strong>22.4 / 22.5</strong></td><td>48.3 / 49.5</td><td>Rys</td></tr>
+<tr><td>0, 2 / 1, 1 / 2, 0</td><td>36.2 / 31.1 / 37.8</td><td>219 / 185 / 223</td><td><strong>34.8 / 29.3 / 34.1</strong></td><td>OS (tie with HGP)</td></tr>
+<tr><td>1, 2 / 2, 1 / 2, 2</td><td><strong>20.4 / 20.7</strong> / 14.1</td><td>112 / 114 / 144</td><td>21.9 / 21.8 / 18.6</td><td>HGP</td></tr>
+<tr><td>3, 3</td><td>7.2</td><td>73.6</td><td>16.1</td><td>HGP</td></tr>
+<tr><td>4, 4</td><td>5.3</td><td>38.1</td><td>14.5</td><td>HGP</td></tr>
+<tr><td>5, 5</td><td>10.0</td><td>53.7</td><td>35.9</td><td>HGP</td></tr>
+<tr><td>6, 6</td><td>20.3</td><td>76.0</td><td>82.2</td><td>HGP</td></tr>
+<tr><td>7, 7</td><td>30.4</td><td>107.0</td><td>135.0</td><td>HGP</td></tr>
+<tr><td>8, 8</td><td>81.5</td><td>170.7</td><td>354.0</td><td>HGP</td></tr>
 </tbody></table></div>
 <p>Three things to notice in the table and curves:</p>
 <ol>
-<li><strong>Rys owns only the bottom band</strong>, <span class="math-inline">\(L_{AB} + L_{CD} \le 1\)</span>. At <span class="math-inline">\((0,0)\)</span> Rys is roughly 2.2× faster than HGP because the entire 6D OS stack is overkill for <span class="math-inline">\((ss|ss)\)</span>; the one Rys root plus its weight delivers the same value with less arithmetic. By <span class="math-inline">\((0,2)\)</span> / <span class="math-inline">\((1,1)\)</span> the second Rys root has to fire and the per-root overhead (root finding + 1D coefficient build) buries the savings — Rys loses to both HGP and OS by 5–8×.</li>
+<li><strong>Rys owns only the bottom band</strong>, <span class="math-inline">\(L_{AB} + L_{CD} \le 1\)</span>. At <span class="math-inline">\((0,0)\)</span> Rys is roughly 2.9× faster than HGP because the entire 6D OS stack is overkill for <span class="math-inline">\((ss|ss)\)</span>; the one Rys root plus its weight delivers the same value with less arithmetic. By <span class="math-inline">\((0,2)\)</span> / <span class="math-inline">\((1,1)\)</span> the second Rys root has to fire and the per-root overhead (root finding + 1D coefficient build) buries the savings — Rys loses to both HGP and OS by 6–7×.</li>
 <li><strong>The OS-wins band is one bucket wide</strong> and the margin over HGP is in single-µs territory (HGP within ~10% of OS at <span class="math-inline">\((0,2)\)</span>/(1,1)/(2,0)). Because Lsum = 2 there is no clean integer separator between an &quot;OS strip&quot; and the HGP region; the calibration deliberately rounds Lsum = 2 into the HGP camp and accepts a measured maximum overhead of zero against the per-bucket winner across the calibration set (see the per-case stats below). The simpler rule beats a three-way table here precisely because the OS / HGP gap at Lsum = 2 is within the noise of repeated benchmark runs.</li>
-<li><strong>For Lsum <span class="math-inline">\(\ge\)</span> 3, HGP wins by a wide and growing margin</strong>. At Lsum = 6 (so e.g. <span class="math-inline">\((3,3)\)</span>) HGP is <span class="math-inline">\(\sim\)</span>10× faster than Rys and <span class="math-inline">\(\sim\)</span>2× faster than OS; at the high-L helium tail (Lsum = 16, <span class="math-inline">\((8,8)\)</span> on cc-pV5Z) HGP is <span class="math-inline">\(\sim\)</span>2.1× faster than Rys and <span class="math-inline">\(\sim\)</span>4.3× faster than OS. The HRR-outside-the-primitive-loop factorization compounds precisely where it should.</li>
+<li><strong>For Lsum <span class="math-inline">\(\ge\)</span> 3, HGP wins by a wide and growing margin</strong>. At Lsum = 6 (so e.g. <span class="math-inline">\((3,3)\)</span>) HGP is <span class="math-inline">\(\sim\)</span>10× faster than Rys and <span class="math-inline">\(\sim\)</span>2.2× faster than OS; at the high-L helium tail (Lsum = 16, <span class="math-inline">\((8,8)\)</span> on cc-pV5Z) HGP is <span class="math-inline">\(\sim\)</span>2.1× faster than Rys and <span class="math-inline">\(\sim\)</span>4.3× faster than OS. The HRR-outside-the-primitive-loop factorization compounds precisely where it should.</li>
 </ol>
 <p>Per-case sanity stats from <code>docs/auto_dispatch_fit.json</code>:</p>
 <div class="table-wrap"><table>
@@ -1489,6 +1489,7 @@ r_{12})/r_{12}\)</span>) drop in exactly as in OS: the long-range damping enters
 <p>The HGP contracted-ERI kernel composes cleanly with the petite-list / skeleton-Fock symmetrization scheme described in §8. Pair- and quartet-orbits under the molecular point group are built once and tagged with their AO permutation phases; only the canonical representative of each orbit is evaluated, and the phase-weighted result is then scattered to the orbit&#x27;s other quartets. The same signed-AO permutation infrastructure works in both Cartesian and spherical-harmonic bases — the spherical path inserts the <span class="math-inline">\(C\)</span>-to-spherical transform on the contracted block just before the scatter, exactly as in the OS and Rys symmetry-reduced variants.</p>
 <h3 id="why-hgp-wins-in-practice-measured-timings">Why HGP Wins in Practice — Measured Timings</h3>
 <p>The theoretical argument above (HRR factored <em>outside</em> the primitive contraction loops, smaller VRR scratch than Rys at low-to-medium <span class="math-inline">\(L\)</span>) is confirmed by a direct head-to-head benchmark of all three engines (OS, Rys, HGP) on the same molecules and bases inside this codebase. The table below reports wall-clock time per ERI build (in milliseconds, lower is better) for the three engines, in three modes: no symmetry (<code>nosym</code>), the legacy D2h coordinate-axis reduction (<code>d2h</code>), and the full point-group reduction (<code>full</code>). All runs use the same shell-pair list, Schwarz screening, and OpenMP settings; only the contracted-quartet kernel and the symmetry walker change.</p>
+<p>The numbers below are the median of 7 repetitions per configuration, from a <strong><code>-O3</code>-compiled, OpenMP-enabled</strong> binary; <code>nbasis</code> is the number of basis functions, <code>|G|</code> the full point-group order, and &quot;D2h ops&quot; the number of those operations the legacy coordinate-axis reduction can actually use. An earlier version of this section was timed from a <strong><code>-O0</code> (unoptimized) serial</strong> build; the engine <em>ordering</em> differs between the two — see pattern 2 below — so these numbers should not be compared directly against that older run.</p>
 <div class="table-wrap"><table>
 <thead><tr>
 <th>Molecule / basis</th>
@@ -1499,59 +1500,62 @@ r_{12})/r_{12}\)</span>) drop in exactly as in OS: the long-range damping enters
 <th>full ms</th>
 </tr></thead>
 <tbody>
-<tr><td>H₂O / STO-3G (C2v)</td><td>7</td><td>OS</td><td>9.40</td><td>5.05</td><td>7.57</td></tr>
-<tr><td>H₂O / STO-3G (C2v)</td><td>7</td><td>Rys</td><td>44.52</td><td>24.74</td><td>39.03</td></tr>
-<tr><td>H₂O / STO-3G (C2v)</td><td>7</td><td><strong>HGP</strong></td><td>9.62</td><td>5.07</td><td>7.49</td></tr>
-<tr><td>H₂O / STO-3G (C2v)</td><td>7</td><td>Auto</td><td>19.41</td><td>15.04</td><td><strong>7.49</strong></td></tr>
-<tr><td>NH₃ / STO-3G (C3v)</td><td>8</td><td>OS</td><td>13.56</td><td>9.09</td><td>8.50</td></tr>
-<tr><td>NH₃ / STO-3G (C3v)</td><td>8</td><td>Rys</td><td>56.74</td><td>38.38</td><td>39.60</td></tr>
-<tr><td>NH₃ / STO-3G (C3v)</td><td>8</td><td><strong>HGP</strong></td><td>13.89</td><td>9.10</td><td>8.51</td></tr>
-<tr><td>NH₃ / STO-3G (C3v)</td><td>8</td><td>Auto</td><td>23.40</td><td>18.59</td><td><strong>8.51</strong></td></tr>
-<tr><td>CH₄ / STO-3G (Td)</td><td>9</td><td>OS</td><td>18.74</td><td>7.61</td><td>9.34</td></tr>
-<tr><td>CH₄ / STO-3G (Td)</td><td>9</td><td>Rys</td><td>70.07</td><td>33.53</td><td>42.34</td></tr>
-<tr><td>CH₄ / STO-3G (Td)</td><td>9</td><td><strong>HGP</strong></td><td>19.80</td><td>7.86</td><td>9.37</td></tr>
-<tr><td>CH₄ / STO-3G (Td)</td><td>9</td><td>Auto</td><td>28.63</td><td>16.34</td><td><strong>9.37</strong></td></tr>
-<tr><td>H₂O / <code>6-31G**</code> (C2v)</td><td>25</td><td>OS</td><td>143.85</td><td>58.75</td><td>106.71</td></tr>
-<tr><td>H₂O / <code>6-31G**</code> (C2v)</td><td>25</td><td>Rys</td><td>746.63</td><td>247.51</td><td>517.99</td></tr>
-<tr><td>H₂O / <code>6-31G**</code> (C2v)</td><td>25</td><td><strong>HGP</strong></td><td><strong>121.33</strong></td><td><strong>52.11</strong></td><td><strong>89.19</strong></td></tr>
-<tr><td>H₂O / <code>6-31G**</code> (C2v)</td><td>25</td><td>Auto</td><td>146.79</td><td>78.17</td><td><strong>89.19</strong></td></tr>
-<tr><td>NH₃ / 6-31G (C3v)</td><td>15</td><td>OS</td><td>43.68</td><td>28.30</td><td>25.79</td></tr>
-<tr><td>NH₃ / 6-31G (C3v)</td><td>15</td><td>Rys</td><td>153.44</td><td>96.16</td><td>97.47</td></tr>
-<tr><td>NH₃ / 6-31G (C3v)</td><td>15</td><td><strong>HGP</strong></td><td>46.49</td><td>29.87</td><td>27.20</td></tr>
-<tr><td>NH₃ / 6-31G (C3v)</td><td>15</td><td>Auto</td><td>52.33</td><td>39.33</td><td><strong>27.20</strong></td></tr>
-<tr><td>NH₃ / <code>6-31G*</code> (C3v)</td><td>21</td><td>OS</td><td>106.20</td><td>65.86</td><td>71.19</td></tr>
-<tr><td>NH₃ / <code>6-31G*</code> (C3v)</td><td>21</td><td>Rys</td><td>534.84</td><td>299.01</td><td>332.54</td></tr>
-<tr><td>NH₃ / <code>6-31G*</code> (C3v)</td><td>21</td><td><strong>HGP</strong></td><td><strong>95.65</strong></td><td><strong>59.12</strong></td><td><strong>59.68</strong></td></tr>
-<tr><td>NH₃ / <code>6-31G*</code> (C3v)</td><td>21</td><td>Auto</td><td>112.21</td><td>80.80</td><td><strong>59.68</strong></td></tr>
-<tr><td>NH₃ / <code>6-31G**</code> (C3v)</td><td>30</td><td>OS</td><td><strong>247.32</strong></td><td><strong>154.81</strong></td><td>124.24</td></tr>
-<tr><td>NH₃ / <code>6-31G**</code> (C3v)</td><td>30</td><td>Rys</td><td>1259.08</td><td>688.02</td><td>555.16</td></tr>
-<tr><td>NH₃ / <code>6-31G**</code> (C3v)</td><td>30</td><td>HGP</td><td>338.01</td><td>210.33</td><td>168.25</td></tr>
-<tr><td>NH₃ / <code>6-31G**</code> (C3v)</td><td>30</td><td>Auto</td><td>362.03</td><td>220.94</td><td>168.25</td></tr>
-<tr><td>CH₄ / <code>6-31G**</code> (Td)</td><td>35</td><td>OS</td><td>446.69</td><td>185.21</td><td>186.83</td></tr>
-<tr><td>CH₄ / <code>6-31G**</code> (Td)</td><td>35</td><td>Rys</td><td>2076.66</td><td>573.86</td><td>583.78</td></tr>
-<tr><td>CH₄ / <code>6-31G**</code> (Td)</td><td>35</td><td><strong>HGP</strong></td><td><strong>348.04</strong></td><td><strong>144.99</strong></td><td><strong>146.34</strong></td></tr>
-<tr><td>CH₄ / <code>6-31G**</code> (Td)</td><td>35</td><td>Auto</td><td>397.18</td><td>187.77</td><td><strong>146.34</strong></td></tr>
+<tr><td>H₂O / STO-3G (C2v, \</td><td>G\</td><td>=4)</td><td>7</td><td>OS</td><td>0.739</td><td>0.381</td><td>0.531</td></tr>
+<tr><td>H₂O / STO-3G (C2v, \</td><td>G\</td><td>=4)</td><td>7</td><td>Rys</td><td>3.034</td><td>1.502</td><td>2.394</td></tr>
+<tr><td>H₂O / STO-3G (C2v, \</td><td>G\</td><td>=4)</td><td>7</td><td><strong>HGP</strong></td><td><strong>0.376</strong></td><td><strong>0.239</strong></td><td><strong>0.322</strong></td></tr>
+<tr><td>H₂O / STO-3G (C2v, \</td><td>G\</td><td>=4)</td><td>7</td><td>Auto</td><td>0.455</td><td>0.284</td><td><strong>0.322</strong></td></tr>
+<tr><td>NH₃ / STO-3G (C3v, \</td><td>G\</td><td>=6)</td><td>8</td><td>OS</td><td>0.833</td><td>0.573</td><td>0.530</td></tr>
+<tr><td>NH₃ / STO-3G (C3v, \</td><td>G\</td><td>=6)</td><td>8</td><td>Rys</td><td>3.999</td><td>2.569</td><td>2.683</td></tr>
+<tr><td>NH₃ / STO-3G (C3v, \</td><td>G\</td><td>=6)</td><td>8</td><td><strong>HGP</strong></td><td><strong>0.473</strong></td><td><strong>0.354</strong></td><td><strong>0.346</strong></td></tr>
+<tr><td>NH₃ / STO-3G (C3v, \</td><td>G\</td><td>=6)</td><td>8</td><td>Auto</td><td>0.684</td><td>0.471</td><td><strong>0.346</strong></td></tr>
+<tr><td>CH₄ / STO-3G (Td, \</td><td>G\</td><td>=24)</td><td>9</td><td>OS</td><td>1.134</td><td>0.506</td><td>0.575</td></tr>
+<tr><td>CH₄ / STO-3G (Td, \</td><td>G\</td><td>=24)</td><td>9</td><td>Rys</td><td>5.474</td><td>2.045</td><td>2.782</td></tr>
+<tr><td>CH₄ / STO-3G (Td, \</td><td>G\</td><td>=24)</td><td>9</td><td><strong>HGP</strong></td><td><strong>0.620</strong></td><td><strong>0.316</strong></td><td><strong>0.361</strong></td></tr>
+<tr><td>CH₄ / STO-3G (Td, \</td><td>G\</td><td>=24)</td><td>9</td><td>Auto</td><td>0.983</td><td>0.437</td><td><strong>0.361</strong></td></tr>
+<tr><td>H₂O / <code>6-31G**</code> (C2v, \</td><td>G\</td><td>=4)</td><td>25</td><td>OS</td><td>8.837</td><td>4.010</td><td>6.711</td></tr>
+<tr><td>H₂O / <code>6-31G**</code> (C2v, \</td><td>G\</td><td>=4)</td><td>25</td><td>Rys</td><td>53.027</td><td>17.695</td><td>37.180</td></tr>
+<tr><td>H₂O / <code>6-31G**</code> (C2v, \</td><td>G\</td><td>=4)</td><td>25</td><td><strong>HGP</strong></td><td><strong>6.214</strong></td><td><strong>2.996</strong></td><td><strong>4.437</strong></td></tr>
+<tr><td>H₂O / <code>6-31G**</code> (C2v, \</td><td>G\</td><td>=4)</td><td>25</td><td>Auto</td><td>6.345</td><td>3.176</td><td><strong>4.437</strong></td></tr>
+<tr><td>NH₃ / 6-31G (C3v, \</td><td>G\</td><td>=6)</td><td>15</td><td>OS</td><td>2.688</td><td>1.790</td><td>1.619</td></tr>
+<tr><td>NH₃ / 6-31G (C3v, \</td><td>G\</td><td>=6)</td><td>15</td><td>Rys</td><td>13.176</td><td>7.788</td><td>7.377</td></tr>
+<tr><td>NH₃ / 6-31G (C3v, \</td><td>G\</td><td>=6)</td><td>15</td><td><strong>HGP</strong></td><td><strong>1.270</strong></td><td><strong>0.946</strong></td><td><strong>0.836</strong></td></tr>
+<tr><td>NH₃ / 6-31G (C3v, \</td><td>G\</td><td>=6)</td><td>15</td><td>Auto</td><td>2.226</td><td>1.510</td><td><strong>0.836</strong></td></tr>
+<tr><td>NH₃ / <code>6-31G*</code> (C3v, \</td><td>G\</td><td>=6)</td><td>21</td><td>OS</td><td>6.393</td><td>4.161</td><td>4.135</td></tr>
+<tr><td>NH₃ / <code>6-31G*</code> (C3v, \</td><td>G\</td><td>=6)</td><td>21</td><td>Rys</td><td>38.083</td><td>23.032</td><td>22.801</td></tr>
+<tr><td>NH₃ / <code>6-31G*</code> (C3v, \</td><td>G\</td><td>=6)</td><td>21</td><td><strong>HGP</strong></td><td><strong>3.697</strong></td><td><strong>2.558</strong></td><td><strong>2.532</strong></td></tr>
+<tr><td>NH₃ / <code>6-31G*</code> (C3v, \</td><td>G\</td><td>=6)</td><td>21</td><td>Auto</td><td>4.673</td><td>3.079</td><td><strong>2.532</strong></td></tr>
+<tr><td>NH₃ / <code>6-31G**</code> (C3v, \</td><td>G\</td><td>=6)</td><td>30</td><td>OS</td><td>14.494</td><td>9.490</td><td>7.127</td></tr>
+<tr><td>NH₃ / <code>6-31G**</code> (C3v, \</td><td>G\</td><td>=6)</td><td>30</td><td>Rys</td><td>97.369</td><td>53.524</td><td>39.379</td></tr>
+<tr><td>NH₃ / <code>6-31G**</code> (C3v, \</td><td>G\</td><td>=6)</td><td>30</td><td><strong>HGP</strong></td><td><strong>9.274</strong></td><td><strong>6.879</strong></td><td><strong>4.753</strong></td></tr>
+<tr><td>NH₃ / <code>6-31G**</code> (C3v, \</td><td>G\</td><td>=6)</td><td>30</td><td>Auto</td><td>10.637</td><td>7.660</td><td><strong>4.753</strong></td></tr>
+<tr><td>CH₄ / <code>6-31G**</code> (Td, \</td><td>G\</td><td>=24)</td><td>35</td><td>OS</td><td>22.981</td><td>10.391</td><td>8.160</td></tr>
+<tr><td>CH₄ / <code>6-31G**</code> (Td, \</td><td>G\</td><td>=24)</td><td>35</td><td>Rys</td><td>155.936</td><td>44.731</td><td>40.797</td></tr>
+<tr><td>CH₄ / <code>6-31G**</code> (Td, \</td><td>G\</td><td>=24)</td><td>35</td><td><strong>HGP</strong></td><td><strong>14.824</strong></td><td><strong>8.572</strong></td><td><strong>5.871</strong></td></tr>
+<tr><td>CH₄ / <code>6-31G**</code> (Td, \</td><td>G\</td><td>=24)</td><td>35</td><td>Auto</td><td>17.490</td><td>8.749</td><td><strong>5.871</strong></td></tr>
 </tbody></table></div>
 <p>Reading the table, four patterns stand out.</p>
-<p><strong>1. Rys is dominated by both HGP and OS at every basis tested here.</strong> This is the expected regime: STO-3G through 6-31G(d,p) puts maximum angular momentum at <span class="math-inline">\(d\)</span>, which sits squarely in the low-to-medium-<span class="math-inline">\(L\)</span> window where the OS/HGP flop count is smaller than the Rys-quadrature flop count. On 6-31G(d,p) / CH₄ (Td) the spread reaches <span class="math-inline">\(\sim\)</span>4.7× on <code>nosym</code> and <span class="math-inline">\(\sim\)</span>3.1× on <code>d2h</code>; Rys is not really a competitor here, and the auto-dispatch model in §11 would only prefer Rys at higher <span class="math-inline">\(L\)</span> where the OS/HGP scratch buffers blow up faster than Rys&#x27;s fixed root count. Rys&#x27;s natural niche is the high-<span class="math-inline">\(L\)</span> tail, not the bulk of routine basis sets.</p>
-<p><strong>2. HGP wins outright on most polarized bases, but the spread is not uniform.</strong> On STO-3G, HGP and OS are within <span class="math-inline">\(\sim\)</span>1–6% of each other in any of the three symmetry modes — STO-3G has <span class="math-inline">\(K = 3\)</span> primitives per contraction and only <span class="math-inline">\(s/p\)</span> shells, so neither the HRR-outside factorization nor the smaller VRR scratch produces much headroom. Moving to 6-31G(d,p) with d-functions and deeper contractions, HGP starts to win outright on most cases:</p>
+<p><strong>1. Rys is dominated by both HGP and OS at every basis tested here.</strong> This is the expected regime: STO-3G through 6-31G(d,p) puts maximum angular momentum at <span class="math-inline">\(d\)</span>, which sits squarely in the low-to-medium-<span class="math-inline">\(L\)</span> window where the OS/HGP flop count is smaller than the Rys-quadrature flop count. On 6-31G(d,p) / CH₄ (Td) the spread reaches <span class="math-inline">\(\sim\)</span>10.5× over HGP on <code>nosym</code> and <span class="math-inline">\(\sim\)</span>5.2× on <code>d2h</code>; Rys is not really a competitor here, and the auto-dispatch model in §11 would only prefer Rys at higher <span class="math-inline">\(L\)</span> where the OS/HGP scratch buffers blow up faster than Rys&#x27;s fixed root count. Rys&#x27;s natural niche is the high-<span class="math-inline">\(L\)</span> tail, not the bulk of routine basis sets.</p>
+<p><strong>2. HGP is the fastest engine on every case in the table.</strong> Unlike an earlier <code>-O0</code> serial run of this same benchmark — where HGP and OS were within a few percent of each other on STO-3G and OS actually edged ahead on the larger NH₃ basis — the <code>-O3</code> build here puts HGP clearly in front everywhere, by roughly 1.4–2.0× over OS on <code>nosym</code>. The optimization level matters because HGP&#x27;s hot loop is the tight per-primitive VRR into a small <span class="math-inline">\((a0|c0)\)</span> block with the HRR hoisted out; <code>-O3</code> vectorizes and unrolls that kernel aggressively, whereas OS&#x27;s larger per-primitive scratch traffic leaves less on the table. At <code>-O0</code> those advantages are masked, which is why the ordering flips:</p>
 <div class="table-wrap"><table>
 <thead><tr>
 <th>Case</th>
 <th>OS <code>nosym</code></th>
 <th>HGP <code>nosym</code></th>
-<th>HGP / OS</th>
+<th>OS / HGP</th>
 </tr></thead>
 <tbody>
-<tr><td>H₂O / <code>6-31G**</code></td><td>143.85</td><td>121.33</td><td>0.84</td></tr>
-<tr><td>NH₃ / <code>6-31G*</code></td><td>106.20</td><td>95.65</td><td>0.90</td></tr>
-<tr><td>CH₄ / <code>6-31G**</code></td><td>446.69</td><td>348.04</td><td>0.78</td></tr>
+<tr><td>H₂O / STO-3G</td><td>0.739</td><td>0.376</td><td>1.97×</td></tr>
+<tr><td>CH₄ / STO-3G</td><td>1.134</td><td>0.620</td><td>1.83×</td></tr>
+<tr><td>H₂O / <code>6-31G**</code></td><td>8.837</td><td>6.214</td><td>1.42×</td></tr>
+<tr><td>NH₃ / <code>6-31G*</code></td><td>6.393</td><td>3.697</td><td>1.73×</td></tr>
+<tr><td>NH₃ / <code>6-31G**</code></td><td>14.494</td><td>9.274</td><td>1.56×</td></tr>
+<tr><td>CH₄ / <code>6-31G**</code></td><td>22.981</td><td>14.824</td><td>1.55×</td></tr>
 </tbody></table></div>
-<p>That is exactly the regime where the HGP analysis predicts wins: the HRR is removed from the <span class="math-inline">\(K^4\)</span> primitive loop, and at the same time the larger <span class="math-inline">\((a0|c0)\)</span> reduced block being VRR&#x27;d inside the loop avoids materializing the full <span class="math-inline">\((ab|cd)\)</span> tensor at every primitive step.</p>
-<p><strong>3. NH₃ / 6-31G(d,p) is the working outlier.</strong> On NH₃ with the larger Pople polarized basis (30 functions, C3v), HGP is <span class="math-inline">\(\sim\)</span>37% <strong>slower</strong> than OS in every symmetry mode (<code>nosym</code> 338.0 vs 247.3, <code>d2h</code> 210.3 vs 154.8, <code>full</code> 168.2 vs 124.2 ms). The same molecule with the smaller <code>6-31G*</code> (21 functions) flips the ordering back: HGP is the fastest engine across all three modes. So the slowdown is not &quot;NH₃&quot; or &quot;6-31G(d,p)&quot; in isolation — it shows up specifically where the per-quartet HGP cost in the current implementation overcomes the HRR-outside savings on NH₃&#x27;s shell composition once <span class="math-inline">\(p\)</span>-functions on H and <span class="math-inline">\(d\)</span>-functions on N are both present. The case is worth keeping pinned as a counter-example: HGP is the right default, but the assumption &quot;HGP <span class="math-inline">\(\leq\)</span> OS everywhere&quot; is empirically false on this codebase today.</p>
-<p><strong>4. HGP cooperates with symmetry well, with the largest absolute wins on the biggest polarized bases.</strong> On CH₄ / 6-31G(d,p) under Td (<span class="math-inline">\(|G|=24\)</span>), HGP <code>full</code> runs at 146.3 ms vs OS <code>full</code> at 186.8 ms (a 1.28× HGP-over-OS win), and the within-engine symmetry speedup is 2.38× for HGP and 2.39× for OS — the two engines amortize the orbit walk equally well, so the kernel-level HGP advantage shows through to the final time. On H₂O / 6-31G(d,p) under C2v the same pattern holds (HGP <code>full</code> 89.2 ms vs OS <code>full</code> 106.7 ms; 1.20× faster). The NH₃ / 6-31G(d,p) regression survives under symmetry too (HGP <code>full</code> 168.2 ms vs OS <code>full</code> 124.2 ms), confirming it is a per-quartet HGP/OS cost issue rather than a symmetry-machinery issue.</p>
-<p>Auto-dispatch follows HGP exactly under <code>full</code> symmetry — for every case in the table the <code>Auto full</code> column matches <code>HGP full</code> to the millisecond, because the dispatch logic in §11 picks HGP for the low-to-medium-<span class="math-inline">\(L\)</span> blocks that dominate these bases. Without symmetry, <code>Auto</code> is consistently slower than HGP alone (e.g. H₂O / 6-31G(d,p) <code>nosym</code>: Auto 146.8 vs HGP 121.3 ms): the dispatch overhead is real, and it pays off only once the orbit walk amortizes it across the symmetry-reduced quartet set.</p>
-<p>Putting these together: <strong>for the routine quantum-chemistry case — Pople-style contracted bases up through 6-31G(d,p) and similar valence-double/triple-zeta sets with d polarization — HGP is still the engine to default to</strong>, with the caveat that NH₃ / 6-31G(d,p) is a measured counter-example to &quot;HGP is never slower than OS.&quot; OS is the right fallback for tiny, lightly contracted bases where the HGP/OS gap closes (and for the NH₃ / 6-31G(d,p) family), and Rys is reserved for high-<span class="math-inline">\(L\)</span> work (f/g/h) where the OS-and-HGP recurrence stacks would otherwise dominate. The OS-vs-Rys auto-dispatch model in §11 applies essentially unchanged to HGP-vs-Rys; HGP simply lowers the OS flop estimate further, which is why the auto-dispatch threshold moves toward higher <span class="math-inline">\(L\)</span> once HGP is the low-L path.</p>
+<p>That is exactly the regime where the HGP analysis predicts wins: the HRR is removed from the <span class="math-inline">\(K^4\)</span> primitive loop, and at the same time the larger <span class="math-inline">\((a0|c0)\)</span> reduced block being VRR&#x27;d inside the loop avoids materializing the full <span class="math-inline">\((ab|cd)\)</span> tensor at every primitive step. The win even holds on STO-3G (<span class="math-inline">\(K = 3\)</span> primitives, <span class="math-inline">\(s/p\)</span> only), where the earlier <code>-O0</code> serial measurement had shown essentially no gap.</p>
+<p><strong>3. The NH₃ / 6-31G(d,p) &quot;OS beats HGP&quot; outlier is gone — but read the build flags first.</strong> A prior <code>-O0</code> serial version of this benchmark recorded HGP as <span class="math-inline">\(\sim\)</span>37% <em>slower</em> than OS on NH₃ / 6-31G(d,p) in every symmetry mode, and the guide kept that case pinned as a counter-example to &quot;HGP <span class="math-inline">\(\leq\)</span> OS everywhere.&quot; On the current <code>-O3</code> build HGP is the fastest engine on that case in all three modes (<code>nosym</code> 9.274 vs 14.494, <code>d2h</code> 6.879 vs 9.490, <code>full</code> 4.753 vs 7.127 ms). So the counter-example did not vanish because the kernel changed — it vanished because the optimizer closed the gap that the unoptimized build had exposed. The honest takeaway is that &quot;HGP at least matches OS&quot; holds across this benchmark set <strong>when compiled <code>-O3</code></strong>; at <code>-O0</code> the ordering is implementation-traffic-bound and can reverse, so the engine default should be reasoned about on optimized builds only.</p>
+<p><strong>4. HGP cooperates with symmetry well, with the largest absolute wins on the biggest polarized bases.</strong> On CH₄ / 6-31G(d,p) under Td (<span class="math-inline">\(|G|=24\)</span>), HGP <code>full</code> runs at 5.871 ms vs OS <code>full</code> at 8.160 ms (a 1.39× HGP-over-OS win), and the within-engine symmetry speedup (<code>nosym</code>→<code>full</code>) is 2.52× for HGP and 2.82× for OS — both engines amortize the orbit walk well, and the kernel-level HGP advantage carries through to the final time. On H₂O / 6-31G(d,p) under C2v the same pattern holds (HGP <code>full</code> 4.437 ms vs OS <code>full</code> 6.711 ms; 1.51× faster). NH₃ / 6-31G(d,p) now agrees: HGP <code>full</code> 4.753 ms vs OS <code>full</code> 7.127 ms, a 1.50× HGP win that tracks the <code>nosym</code> ordering rather than reversing it.</p>
+<p>Auto-dispatch follows HGP exactly under <code>full</code> symmetry — for every case in the table the <code>Auto full</code> column matches <code>HGP full</code> to the millisecond, because the dispatch logic in §11 picks HGP for the low-to-medium-<span class="math-inline">\(L\)</span> blocks that dominate these bases. Without symmetry, <code>Auto</code> is consistently slower than HGP alone (e.g. H₂O / 6-31G(d,p) <code>nosym</code>: Auto 6.345 vs HGP 6.214 ms; CH₄ / 6-31G(d,p) <code>nosym</code>: Auto 17.490 vs HGP 14.824 ms): the dispatch overhead is real, and it pays off only once the orbit walk amortizes it across the symmetry-reduced quartet set.</p>
+<p>Putting these together: <strong>for the routine quantum-chemistry case — Pople-style contracted bases up through 6-31G(d,p) and similar valence-double/triple-zeta sets with d polarization — HGP is the engine to default to</strong>, and on this <code>-O3</code> build it is the fastest engine on every case in the table, including the tiny STO-3G systems where the <code>-O0</code> gap had been negligible. OS remains a reasonable fallback for tiny, lightly contracted bases where the HGP/OS gap narrows, and Rys is reserved for high-<span class="math-inline">\(L\)</span> work (f/g/h) where the OS-and-HGP recurrence stacks would otherwise dominate. The OS-vs-Rys auto-dispatch model in §11 applies essentially unchanged to HGP-vs-Rys; HGP simply lowers the OS flop estimate further, which is why the auto-dispatch threshold moves toward higher <span class="math-inline">\(L\)</span> once HGP is the low-L path.</p>
 <h3 id="implementation-files">Implementation Files</h3>
 <div class="table-wrap"><table>
 <thead><tr>

--- a/scripts/rebuild_teaching_site_if_changed.py
+++ b/scripts/rebuild_teaching_site_if_changed.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Rebuild the teaching site if the source markdown was just edited.
+
+Invoked from .claude/settings.json as a PostToolUse hook on Write|Edit.
+Claude Code passes the tool event as JSON on stdin; we read it, check
+whether the edited path was the teaching-guide markdown, and run
+docs/build_teaching_site.py only when it was. Every other edit is a
+no-op so the hook stays cheap.
+
+Watched source: docs/PLANCK_TEACHING_GUIDE.md
+Generated output: docs/index.html
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WATCHED = REPO_ROOT / "docs" / "PLANCK_TEACHING_GUIDE.md"
+BUILDER = REPO_ROOT / "docs" / "build_teaching_site.py"
+
+
+def edited_path_from_stdin() -> Path | None:
+    """Parse the hook event JSON and return the edited file path, if any.
+
+    Returns None when stdin is empty, unparseable, or the event does not
+    name a file_path. We deliberately treat any error as "skip" rather
+    than failing the hook — a hook failure noisily interrupts the session.
+    """
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return None
+    try:
+        event = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    tool_input = event.get("tool_input") or {}
+    path_str = tool_input.get("file_path")
+    if not isinstance(path_str, str) or not path_str:
+        return None
+    return Path(path_str).resolve()
+
+
+def main() -> int:
+    edited = edited_path_from_stdin()
+    if edited is None or edited != WATCHED.resolve():
+        return 0
+
+    # Rebuild. Pipe both streams to /dev/null so a passing build is silent
+    # in the session log; show stderr only if it fails so the user notices.
+    proc = subprocess.run(
+        [sys.executable, str(BUILDER)],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        sys.stderr.write(
+            f"[teaching-site] rebuild failed (exit {proc.returncode})\n"
+            f"{proc.stderr}"
+        )
+    return proc.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/basis/gaussian.cpp
+++ b/src/basis/gaussian.cpp
@@ -5,163 +5,16 @@
 
 #include "base/tables.h"
 #include "basis.h"
+#include "gbs_parser.h"
 #include "lookup/elements.h"
 #include "spherical.h"
 
-struct GbsPrimitive
-{
-    double exponent;
-    double coefficient;
-};
-
-struct GbsShell
-{
-    std::string label; // "S", "P", "D", ...
-    std::vector<GbsPrimitive> primitives;
-};
-
-static bool starts_with_alpha(const std::string &line)
-{
-    // Iterate over each characters
-    for (char c : line)
-    {
-        // Check if it is not a blanck space
-        if (!std::isspace(static_cast<unsigned char>(c)))
-        {
-            // Check if the character is an alphabet [a-z, A-Z]
-            return std::isalpha(static_cast<unsigned char>(c));
-        }
-    }
-    return false;
-}
-
-static bool is_shell_label(const std::string &s)
-{
-    return s == "S" || s == "P" || s == "D" ||
-           s == "F" || s == "G" || s == "H" ||
-           s == "I" || s == "SP";
-}
-
-// Replace D+ with E+
-static inline void normalize_fortran_exponents(std::string &line)
-{
-    for (char &c : line)
-        if (c == 'D' || c == 'd')
-            c = 'E';
-}
-
-using BasisSet = std::unordered_map<std::string, std::vector<GbsShell>>;
-
-static std::expected<BasisSet, std::string> read_gbs(std::ifstream &input)
-{
-    BasisSet basis;
-    std::string line;
-    std::string current_element;
-
-    while (std::getline(input, line))
-    {
-        // Skip comments and empty lines
-        if (line.empty())
-        {
-            continue;
-        }
-
-        if (line.starts_with("!"))
-        {
-            continue;
-        }
-
-        // If end of current block reached, continue
-        if (line == "****")
-        {
-            current_element.clear();
-            continue;
-        }
-
-        std::istringstream header(line);
-        std::string symbol;
-        int charge;
-
-        {
-            // Check if header has two elements [Element name, Charge] and only two elements
-            if ((header >> symbol >> charge) && header.eof())
-            {
-                auto element = element_from_symbol(symbol);
-                if (!element)
-                    return std::unexpected(element.error());
-                current_element = symbol;
-                basis.try_emplace(symbol); // Place element
-                continue;
-            }
-        }
-
-        // Check if next line starts with a letter (usually shell header)
-        if (!starts_with_alpha(line))
-        {
-            return std::unexpected("Expected shell header, got: " + line);
-        }
-
-        // Check if an element has been identified
-        if (current_element.empty())
-        {
-            return std::unexpected("Shell before element header");
-        }
-
-        std::istringstream iss(line);
-        std::string label;
-        std::size_t nprim;
-        double scale = 1.0;
-
-        iss >> label >> nprim >> scale;
-
-        if (!iss || !is_shell_label(label))
-        {
-            return std::unexpected("Malformed shell line: " + line);
-        }
-
-        // Special case in Gaussian94 basis sets
-        if (label == "SP")
-        {
-            // Constrcut separate s and p-type shells
-            GbsShell s{"S"}, p{"P"};
-
-            for (std::size_t i = 0; i < nprim; ++i)
-            {
-                std::getline(input, line);
-                normalize_fortran_exponents(line);
-
-                std::istringstream prim(line);
-                double expn, cs, cp;
-                prim >> expn >> cs >> cp;
-
-                s.primitives.push_back({expn, cs * scale});
-                p.primitives.push_back({expn, cp * scale});
-            }
-
-            // Place the shells
-            basis[current_element].push_back(std::move(s));
-            basis[current_element].push_back(std::move(p));
-        }
-        // Regular case
-        else
-        {
-            GbsShell shell{label};
-            for (std::size_t i = 0; i < nprim; ++i)
-            {
-                std::getline(input, line);
-                normalize_fortran_exponents(line);
-
-                std::istringstream prim(line);
-                double expn, cs;
-                prim >> expn >> cs;
-
-                shell.primitives.push_back({expn, cs * scale});
-            }
-            basis[current_element].push_back(std::move(shell));
-        }
-    }
-    return basis;
-}
+// Shared .gbs parsing now lives in gbs_parser.cpp so that both the orbital
+// loader below and the RI auxiliary loader in rifit.cpp can use it without
+// duplicating the parse code.
+using HartreeFock::BasisFunctions::detail::GbsPrimitive;
+using HartreeFock::BasisFunctions::detail::GbsShell;
+using BasisSet = HartreeFock::BasisFunctions::detail::GbsBasisSet;
 
 int HartreeFock::BasisFunctions::double_factorial(int n)
 {
@@ -222,7 +75,7 @@ std::expected<HartreeFock::Basis, std::string> HartreeFock::BasisFunctions::read
     }
 
     // Parse the complete basis set
-    auto gbs_res = read_gbs(file);
+    auto gbs_res = HartreeFock::BasisFunctions::detail::read_gbs(file);
     if (!gbs_res)
         return std::unexpected(gbs_res.error());
     BasisSet gbs = std::move(*gbs_res);

--- a/src/basis/gbs_parser.cpp
+++ b/src/basis/gbs_parser.cpp
@@ -1,0 +1,120 @@
+#include "gbs_parser.h"
+
+#include <cctype>
+#include <sstream>
+
+#include "lookup/elements.h"
+
+namespace
+{
+    bool starts_with_alpha(const std::string &line)
+    {
+        for (char c : line)
+        {
+            if (!std::isspace(static_cast<unsigned char>(c)))
+                return std::isalpha(static_cast<unsigned char>(c));
+        }
+        return false;
+    }
+
+    bool is_shell_label(const std::string &s)
+    {
+        return s == "S" || s == "P" || s == "D" ||
+               s == "F" || s == "G" || s == "H" ||
+               s == "I" || s == "SP";
+    }
+
+    // Replace Fortran-style D-exponents ("1.0D+01") with E-exponents ("1.0E+01")
+    // so that std::istringstream parses them.
+    void normalize_fortran_exponents(std::string &line)
+    {
+        for (char &c : line)
+            if (c == 'D' || c == 'd')
+                c = 'E';
+    }
+} // namespace
+
+namespace HartreeFock::BasisFunctions::detail
+{
+    std::expected<GbsBasisSet, std::string> read_gbs(std::ifstream &input)
+    {
+        GbsBasisSet basis;
+        std::string line;
+        std::string current_element;
+
+        while (std::getline(input, line))
+        {
+            if (line.empty() || line.starts_with("!"))
+                continue;
+
+            // End of current element block
+            if (line == "****")
+            {
+                current_element.clear();
+                continue;
+            }
+
+            std::istringstream header(line);
+            std::string symbol;
+            int charge;
+            if ((header >> symbol >> charge) && header.eof())
+            {
+                auto element = element_from_symbol(symbol);
+                if (!element)
+                    return std::unexpected(element.error());
+                current_element = symbol;
+                basis.try_emplace(symbol);
+                continue;
+            }
+
+            if (!starts_with_alpha(line))
+                return std::unexpected("Expected shell header, got: " + line);
+
+            if (current_element.empty())
+                return std::unexpected("Shell before element header");
+
+            std::istringstream iss(line);
+            std::string label;
+            std::size_t nprim;
+            double scale = 1.0;
+            iss >> label >> nprim >> scale;
+
+            if (!iss || !is_shell_label(label))
+                return std::unexpected("Malformed shell line: " + line);
+
+            // Gaussian94 "SP" — one primitive list, two coefficient columns;
+            // expand into separate S and P shells.
+            if (label == "SP")
+            {
+                GbsShell s{"S"}, p{"P"};
+                for (std::size_t i = 0; i < nprim; ++i)
+                {
+                    std::getline(input, line);
+                    normalize_fortran_exponents(line);
+                    std::istringstream prim(line);
+                    double expn, cs, cp;
+                    prim >> expn >> cs >> cp;
+                    s.primitives.push_back({expn, cs * scale});
+                    p.primitives.push_back({expn, cp * scale});
+                }
+                basis[current_element].push_back(std::move(s));
+                basis[current_element].push_back(std::move(p));
+            }
+            else
+            {
+                GbsShell shell{label};
+                for (std::size_t i = 0; i < nprim; ++i)
+                {
+                    std::getline(input, line);
+                    normalize_fortran_exponents(line);
+                    std::istringstream prim(line);
+                    double expn, cs;
+                    prim >> expn >> cs;
+                    shell.primitives.push_back({expn, cs * scale});
+                }
+                basis[current_element].push_back(std::move(shell));
+            }
+        }
+        return basis;
+    }
+} // namespace HartreeFock::BasisFunctions::detail

--- a/src/basis/gbs_parser.h
+++ b/src/basis/gbs_parser.h
@@ -1,0 +1,40 @@
+#ifndef HF_BASIS_GBS_PARSER_H
+#define HF_BASIS_GBS_PARSER_H
+
+// Private header — Gaussian94 (.gbs) parser shared between the orbital basis
+// loader (gaussian.cpp) and the RI auxiliary basis loader (rifit.cpp).
+// The on-disk format is identical for orbital and aux basis sets, so the
+// element→shells→primitives reader is the only thing that needs to be shared.
+// Everything downstream (Shell construction, normalization, AO indexing,
+// spherical transform) differs between the two roles and stays in the
+// respective .cpp files.
+
+#include <expected>
+#include <fstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace HartreeFock::BasisFunctions::detail
+{
+    struct GbsPrimitive
+    {
+        double exponent;
+        double coefficient;
+    };
+
+    struct GbsShell
+    {
+        std::string label; // "S", "P", "D", ...
+        std::vector<GbsPrimitive> primitives;
+    };
+
+    using GbsBasisSet = std::unordered_map<std::string, std::vector<GbsShell>>;
+
+    // Parse a Gaussian94 (.gbs) stream into element-keyed shell descriptors.
+    // Handles the SP "fused" shell type by splitting into separate S and P shells.
+    // Returns the parsed element→shells map on success or a human-readable error.
+    std::expected<GbsBasisSet, std::string> read_gbs(std::ifstream &input);
+} // namespace HartreeFock::BasisFunctions::detail
+
+#endif // HF_BASIS_GBS_PARSER_H

--- a/src/basis/rifit.cpp
+++ b/src/basis/rifit.cpp
@@ -1,0 +1,108 @@
+#include "rifit.h"
+
+#include <algorithm>
+#include <fstream>
+
+#include "basis.h"      // primitive_normalization, contracted_normalization, _map_shell_to_L
+#include "gbs_parser.h" // shared .gbs reader
+#include "lookup/elements.h"
+
+namespace HartreeFock::BasisFunctions
+{
+    std::expected<AuxBasis, std::string> read_ri_basis(
+        const std::string &file_name,
+        const Molecule &molecule)
+    {
+        // Mirror the orbital loader's case-insensitive open path so users can
+        // write `ri_basis cc-pVDZ-RI` regardless of how the file was named on
+        // disk.
+        auto make_lowercase_path = [](const std::string &path) {
+            const auto sep = path.find_last_of("/\\");
+            if (sep == std::string::npos)
+            {
+                std::string lower = path;
+                std::transform(lower.begin(), lower.end(), lower.begin(),
+                               [](unsigned char c) { return std::tolower(c); });
+                return lower;
+            }
+            std::string name = path.substr(sep + 1);
+            std::transform(name.begin(), name.end(), name.begin(),
+                           [](unsigned char c) { return std::tolower(c); });
+            return path.substr(0, sep + 1) + name;
+        };
+
+        std::ifstream file(file_name);
+        if (!file)
+        {
+            const std::string lower_path = make_lowercase_path(file_name);
+            if (lower_path != file_name)
+                file.open(lower_path);
+        }
+        if (!file)
+            return std::unexpected("Cannot open RI auxiliary basis file: " + file_name);
+
+        auto gbs_res = detail::read_gbs(file);
+        if (!gbs_res)
+            return std::unexpected(gbs_res.error());
+        const auto &gbs = *gbs_res;
+
+        AuxBasis aux;
+        aux.cartesian = true;
+
+        for (std::size_t i = 0; i < molecule.natoms; ++i)
+        {
+            auto element_data = element_from_z(molecule.atomic_numbers[i]);
+            if (!element_data)
+                return std::unexpected(element_data.error());
+            const std::string element(element_data->symbol);
+
+            auto it = gbs.find(element);
+            if (it == gbs.end())
+                return std::unexpected(
+                    "RI auxiliary basis missing element: " + element);
+
+            for (const detail::GbsShell &gbs_shell : it->second)
+            {
+                Shell shell;
+                shell._center = molecule._standard.row(i).transpose();
+                auto shell_type = _map_shell_to_L(gbs_shell.label);
+                if (!shell_type)
+                    return std::unexpected(shell_type.error());
+                shell._shell = *shell_type;
+                shell._atom_index = i;
+
+                const std::size_t nprim = gbs_shell.primitives.size();
+                shell._primitives.resize(nprim);
+                shell._coefficients.resize(nprim);
+                for (std::size_t k = 0; k < nprim; ++k)
+                {
+                    shell._primitives[k] = gbs_shell.primitives[k].exponent;
+                    shell._coefficients[k] = gbs_shell.primitives[k].coefficient;
+                }
+
+                const unsigned int L = static_cast<unsigned int>(shell._shell);
+
+                // Same normalization convention as the orbital basis: primitive
+                // norms held separately, contracted norm pre-folded into the
+                // contraction coefficients. The 3-center integral engine relies
+                // on this contract (see the Norm Factors gotcha in docs).
+                shell._normalizations = primitive_normalization(L, shell._primitives);
+                auto contracted = contracted_normalization(
+                    L, shell._primitives, shell._coefficients, shell._normalizations);
+                if (!contracted)
+                    return std::unexpected(contracted.error());
+                shell._coefficients = shell._coefficients * (*contracted);
+
+                // Cartesian function count for this shell: (L+1)(L+2)/2.
+                const std::size_t n_cart =
+                    (static_cast<std::size_t>(L) + 1) *
+                    (static_cast<std::size_t>(L) + 2) / 2;
+                aux.offsets.push_back(aux.nfunctions);
+                aux.nfunctions += n_cart;
+                aux.shells.push_back(std::move(shell));
+            }
+        }
+
+        return aux;
+    }
+} // namespace HartreeFock::BasisFunctions

--- a/src/basis/rifit.h
+++ b/src/basis/rifit.h
@@ -1,0 +1,54 @@
+#ifndef HF_BASIS_RIFIT_H
+#define HF_BASIS_RIFIT_H
+
+// RI / density-fitting auxiliary basis loader.
+//
+// Auxiliary basis sets share the Gaussian94 (.gbs) file format with orbital
+// basis sets, but they serve a different role: they are the "ket" side of
+// 3-center integrals (μν|P) used to factor the 4-center AO ERI tensor as
+// (μν|λσ) ≈ Σ_PQ (μν|P) V_{PQ}^{-1} (Q|λσ). Consequently the aux basis
+// lives in its own storage, separate from the orbital `HartreeFock::Basis`,
+// and is never mixed into the orbital shell list or AO function index space.
+//
+// Conventionally, aux basis sets stay Cartesian (PySCF default). The mixed
+// Cartesian-aux × spherical-orbital case is handled inside the 3-center
+// integral routine, not here.
+
+#include <expected>
+#include <string>
+#include <vector>
+
+#include "base/types.h"
+
+namespace HartreeFock
+{
+    // A loaded auxiliary basis set. The Shell objects use the same
+    // normalization conventions (contracted norm pre-folded into _coefficients,
+    // primitive norms held separately) as the orbital basis so the existing
+    // integral machinery can consume them unchanged.
+    struct AuxBasis
+    {
+        std::vector<Shell> shells;       // aux shells, in input order
+        std::vector<std::size_t> offsets; // offsets[K] = first aux function of shell K
+        std::size_t nfunctions = 0;       // total aux function count (Σ (2L+1) or Cartesian count)
+        bool cartesian = true;            // aux functions are Cartesian by default
+    };
+
+    namespace BasisFunctions
+    {
+        // Read a Gaussian94-format auxiliary basis file and instantiate aux
+        // shells on every atom of `molecule`. Returns the populated AuxBasis
+        // or a human-readable error.
+        //
+        // The aux basis is always built in the Cartesian basis function space:
+        // a shell of angular momentum L contributes (L+1)(L+2)/2 functions to
+        // the offset table. Spherical-orbital users still load Cartesian aux
+        // shells — the contraction with spherical AOs is done downstream by
+        // the 3-center integral routine.
+        std::expected<AuxBasis, std::string> read_ri_basis(
+            const std::string &file_name,
+            const Molecule &molecule);
+    } // namespace BasisFunctions
+} // namespace HartreeFock
+
+#endif // HF_BASIS_RIFIT_H

--- a/tests/aux_basis_load.cpp
+++ b/tests/aux_basis_load.cpp
@@ -1,0 +1,201 @@
+// Unit test for HartreeFock::BasisFunctions::read_ri_basis.
+//
+// Validates the .gbs loader for RI auxiliary basis sets on a toy basis
+// (basis-sets/toy-ri) that exercises:
+//
+//   * multiple angular momenta (S, P, D)
+//   * multiple shells per element (He has two S shells)
+//   * multiple atoms (H2 to test per-atom shell instantiation)
+//   * mixed-element molecules (HeH+ to confirm dispatch on atomic_numbers)
+//
+// What we check:
+//
+//   1. shell count per element matches the file (H: 2 shells, He: 4)
+//   2. total aux function count matches Σ_K (L_K+1)(L_K+2)/2 (Cartesian)
+//   3. offsets table is monotonic and ends at nfunctions
+//   4. shell centers match the molecule coordinates exactly
+//   5. contracted normalization was folded into _coefficients (the same
+//      norm contract the orbital basis uses)
+//   6. missing-element error path returns a useful message rather than
+//      silently producing a zero-shell aux basis
+//
+// We do *not* test against PySCF reference values here. That's the right
+// gate for shipped production aux basis sets (cc-pVDZ-RI etc.); the toy
+// basis is purely a parser/structure check.
+
+#include <cstdlib>
+#include <iostream>
+#include <numbers>
+#include <string>
+
+#include "base/types.h"
+#include "basis/rifit.h"
+
+namespace
+{
+    bool g_ok = true;
+
+    void fail(const std::string &m)
+    {
+        std::cerr << "FAIL: " << m << '\n';
+        g_ok = false;
+    }
+
+    std::string aux_basis_path()
+    {
+        if (const char *env = std::getenv("BASIS_PATH"); env && *env)
+            return std::string(env) + "/toy-ri";
+        return "basis-sets/toy-ri";
+    }
+
+    HartreeFock::Molecule make_h2()
+    {
+        HartreeFock::Molecule mol;
+        mol.natoms = 2;
+        mol.atomic_numbers.resize(2);
+        mol.atomic_numbers << 1, 1;
+        mol._standard.resize(2, 3);
+        mol._standard << 0.0, 0.0, -0.7,
+                         0.0, 0.0, +0.7;
+        return mol;
+    }
+
+    HartreeFock::Molecule make_hehp()
+    {
+        HartreeFock::Molecule mol;
+        mol.natoms = 2;
+        mol.atomic_numbers.resize(2);
+        mol.atomic_numbers << 1, 2; // H, He
+        mol._standard.resize(2, 3);
+        mol._standard << 0.0, 0.0, -0.8,
+                         0.0, 0.0, +0.8;
+        return mol;
+    }
+
+    // For a Cartesian shell of angular momentum L, count of basis functions
+    // is (L+1)(L+2)/2. This mirrors what the loader computes per shell.
+    std::size_t cart_count(unsigned L)
+    {
+        return (L + 1) * (L + 2) / 2;
+    }
+} // namespace
+
+int main()
+{
+    using HartreeFock::BasisFunctions::read_ri_basis;
+    const std::string aux = aux_basis_path();
+
+    // ── Test 1: H2 with toy-ri ───────────────────────────────────────────────
+    // toy-ri H: S (1 prim) + P (1 prim) = 2 shells, 1+3 = 4 functions per H.
+    {
+        auto mol = make_h2();
+        auto res = read_ri_basis(aux, mol);
+        if (!res)
+        {
+            fail("H2 load failed: " + res.error());
+        }
+        else
+        {
+            const auto &a = *res;
+            if (a.shells.size() != 4)
+                fail("H2: expected 4 shells (2 per H), got " + std::to_string(a.shells.size()));
+            // Per H: S(1) + P(3) = 4; for 2 H atoms = 8 aux functions.
+            if (a.nfunctions != 8)
+                fail("H2: expected 8 aux functions, got " + std::to_string(a.nfunctions));
+            if (a.offsets.size() != a.shells.size())
+                fail("H2: offsets size must equal shells size");
+
+            // Offsets monotonic and end at nfunctions.
+            std::size_t expected_offset = 0;
+            for (std::size_t k = 0; k < a.shells.size(); ++k)
+            {
+                if (a.offsets[k] != expected_offset)
+                    fail("H2: offset[" + std::to_string(k) + "] mismatch");
+                expected_offset += cart_count(
+                    static_cast<unsigned>(a.shells[k]._shell));
+            }
+            if (expected_offset != a.nfunctions)
+                fail("H2: final offset does not match nfunctions");
+
+            // Each H's first shell center must be at z=-0.7, second H at z=+0.7.
+            // Shells are instantiated in order (S, P) per atom.
+            const double tol = 1e-15;
+            if (std::abs(a.shells[0]._center.z() + 0.7) > tol ||
+                std::abs(a.shells[1]._center.z() + 0.7) > tol)
+                fail("H2: first-atom shell centers wrong");
+            if (std::abs(a.shells[2]._center.z() - 0.7) > tol ||
+                std::abs(a.shells[3]._center.z() - 0.7) > tol)
+                fail("H2: second-atom shell centers wrong");
+
+            // Contracted-norm contract: single-primitive shell with raw
+            // coefficient 1.0 must have _coefficients[0] == Nc (the contracted
+            // norm folded in), and Nc must be > 0. Sanity check that
+            // normalization fired and produced a finite positive scale.
+            for (const auto &s : a.shells)
+            {
+                if (s._coefficients.size() != 1)
+                    continue;
+                const double c = s._coefficients[0];
+                if (!std::isfinite(c) || c <= 0.0)
+                    fail("Aux shell contracted coefficient must be finite and > 0");
+            }
+        }
+    }
+
+    // ── Test 2: HeH+ ─────────────────────────────────────────────────────────
+    // toy-ri He: S + S + P + D = 4 shells, 1+1+3+6 = 11 aux funcs.
+    // toy-ri H : S + P         = 2 shells, 1+3 = 4 aux funcs.
+    // Total: 6 shells, 15 aux functions.
+    {
+        auto mol = make_hehp();
+        auto res = read_ri_basis(aux, mol);
+        if (!res)
+        {
+            fail("HeH+ load failed: " + res.error());
+        }
+        else
+        {
+            const auto &a = *res;
+            if (a.shells.size() != 6)
+                fail("HeH+: expected 6 shells, got " + std::to_string(a.shells.size()));
+            if (a.nfunctions != 15)
+                fail("HeH+: expected 15 aux functions, got " + std::to_string(a.nfunctions));
+            // Atom 0 is H (z=-0.8), gets the first 2 shells.
+            // Atom 1 is He (z=+0.8), gets the next 4.
+            const double tol = 1e-15;
+            for (std::size_t k = 0; k < 2; ++k)
+                if (std::abs(a.shells[k]._center.z() + 0.8) > tol)
+                    fail("HeH+: H shell center wrong");
+            for (std::size_t k = 2; k < 6; ++k)
+                if (std::abs(a.shells[k]._center.z() - 0.8) > tol)
+                    fail("HeH+: He shell center wrong");
+        }
+    }
+
+    // ── Test 3: missing element produces a useful error ──────────────────────
+    {
+        HartreeFock::Molecule mol;
+        mol.natoms = 1;
+        mol.atomic_numbers.resize(1);
+        mol.atomic_numbers << 6; // C — not in toy-ri
+        mol._standard.resize(1, 3);
+        mol._standard << 0.0, 0.0, 0.0;
+        auto res = read_ri_basis(aux, mol);
+        if (res)
+            fail("Expected error for missing element C, got success");
+        else if (res.error().find("missing element") == std::string::npos)
+            fail("Missing-element error should mention 'missing element', got: " + res.error());
+    }
+
+    // ── Test 4: missing file path ────────────────────────────────────────────
+    {
+        HartreeFock::Molecule mol = make_h2();
+        auto res = read_ri_basis(aux + ".does-not-exist", mol);
+        if (res)
+            fail("Expected error for missing aux file, got success");
+    }
+
+    if (g_ok)
+        std::cout << "PASS: read_ri_basis on toy-ri\n";
+    return g_ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

First piece of the RI-MP2 work: file I/O and shell-construction infrastructure for density-fitting auxiliary basis sets. **No integration, no driver wiring, no 3-center integrals yet — just the loader.**

The .gbs file format is shared between orbital and aux basis sets, so the parser is extracted into a private header that both loaders use. Everything downstream — Shell construction, normalization, AO indexing, Cartesian↔spherical transform — differs between the two roles and stays in the respective .cpp files.

## Why a separate \`rifit.cpp\` instead of extending \`gaussian.cpp\`

- Aux basis sets are the "ket" side of 3-center integrals, never AO indices. They need their own storage (\`AuxBasis\`) — mixing them into \`HartreeFock::Basis._shells\` would break every shell-pair, density, and Fock-build path that iterates \`calc._shells\`.
- Aux loading skips the AO-function-index population and the spherical transform — those are orbital-specific.
- Aux loading is opt-in (only fires when \`ri_basis\` is set); no overhead for users who don't ask for it.
- Future RI-JK / DF-Coulomb / DF-exchange aux basis sets land in the same file rather than growing \`gaussian.cpp\`.

## Deliverables

- \`src/basis/gbs_parser.{h,cpp}\` — shared .gbs reader (handles SP-shell expansion, Fortran D-exponents), no dependencies beyond elements lookup.
- \`src/basis/rifit.{h,cpp}\` — public \`read_ri_basis()\` returning \`AuxBasis { shells, offsets, nfunctions, cartesian }\`. Same normalization convention as the orbital basis (contracted norm pre-folded into \`_coefficients\`) so existing integral machinery can consume aux shells unchanged once 3-center integrals land.
- \`basis-sets/toy-ri\` — minimal H/He aux basis (S+P / S+S+P+D) for the structural unit test. Real cc-pVDZ-RI etc. arrive in a follow-up commit.
- \`tests/aux_basis_load.cpp\` + \`planck-aux-basis-load\` CMake target — structural gates: H₂ (2 atoms × 2 shells, 8 aux funcs), HeH⁺ (mixed-element, 6 shells, 15 aux funcs), missing-element error, missing-file error.
- \`src/basis/gaussian.cpp\` — refactored to use the shared \`read_gbs()\`. Behavior unchanged; 134 lines of duplicated parsing removed.

## Validation

- [x] \`planck-aux-basis-load\` passes (4/4 sub-tests)
- [x] 35/35 smoke regressions pass with the refactored orbital loader
- [x] 59/59 core regressions pass with the refactored orbital loader
- [x] Shared-parser extraction is bit-identical for every existing path

## Test plan

- [ ] CI passes
- [ ] Spot-check the diff for parser equivalence with the pre-refactor \`read_gbs()\` in \`gaussian.cpp\`