### PR TITLE
fixes: engine-dispatch routing, Mayer bond order, DIIS guard, test harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@ scripts/*
 !scripts/fit_auto_dispatch.py
 !scripts/rebuild_teaching_site_if_changed.py
 notes
-src/base/basis.h
 # ccgen files
 python/ccgen/__pycache__
 python/ccgen/*/__pycache__

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -561,6 +561,10 @@ if(BUILD_TESTING)
         ${SRC_DIR}/symmetry/symmetry.cpp
     )
 
+    add_executable(planck-diis-conditioning
+        ${CMAKE_SOURCE_DIR}/tests/diis_conditioning.cpp
+    )
+
     add_executable(planck-cc-arbitrary-solver
         ${CMAKE_SOURCE_DIR}/tests/cc_arbitrary_solver.cpp
         ${SRC_DIR}/post_hf/cc/common.cpp
@@ -819,6 +823,11 @@ if(BUILD_TESTING)
         ${eigen_SOURCE_DIR}
     )
 
+    target_include_directories(planck-diis-conditioning PRIVATE
+        ${SRC_DIR}
+        ${eigen_SOURCE_DIR}
+    )
+
     target_include_directories(planck-cc-arbitrary-solver PRIVATE
         ${SRC_DIR}
         ${eigen_SOURCE_DIR}
@@ -950,6 +959,12 @@ if(BUILD_TESTING)
     )
 
     set_target_properties(planck-population-analysis PROPERTIES
+        CXX_STANDARD 23
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF
+    )
+
+    set_target_properties(planck-diis-conditioning PROPERTIES
         CXX_STANDARD 23
         CXX_STANDARD_REQUIRED ON
         CXX_EXTENSIONS OFF
@@ -1151,6 +1166,11 @@ if(BUILD_TESTING)
     add_test(
         NAME planck-population-analysis
         COMMAND planck-population-analysis
+    )
+
+    add_test(
+        NAME planck-diis-conditioning
+        COMMAND planck-diis-conditioning
     )
 
     add_test(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1203,14 +1203,19 @@ if(BUILD_TESTING)
         COMMAND planck-transform-eri
     )
 
+    # These two read RI auxiliary basis files via the relative path
+    # `basis-sets/...`, which only resolves from the repository root, so run
+    # them from there (matching the regression tests below).
     add_test(
         NAME planck-aux-basis-load
         COMMAND planck-aux-basis-load
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     )
 
     add_test(
         NAME planck-ri-2c-eri
         COMMAND planck-ri-2c-eri
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     )
 
     add_test(

--- a/src/base/types.h
+++ b/src/base/types.h
@@ -2,6 +2,7 @@
 #define HF_TYPES_H
 
 #include <Eigen/Core>
+#include <Eigen/Eigenvalues>
 #include <Eigen/QR>
 #include <array>
 #include <cassert>
@@ -886,6 +887,110 @@ namespace HartreeFock
         DataSCF _scf;                  // SCF Data for current step
     };
 
+    // ── Shared DIIS coefficient solve with conditioning guard ─────────────────
+    //
+    // Pulay's DIIS solves the bordered linear system
+    //   [ G  -1 ] [ c   ]   [ 0 ]
+    //   [-1   0 ] [ lam ] = [-1 ]
+    // where G_{ij} = <e_i, e_j> is the m×m error-overlap (Gram) block.
+    //
+    // Important: G is *expected* to be extremely ill-conditioned near
+    // convergence — the error matrices shrink toward zero and become nearly
+    // parallel, so the smallest Gram eigenvalue routinely reaches ~1e-29 while
+    // G stays positive-definite. The bare colPivHouseholderQr solve handles that
+    // gracefully (the tiny, near-degenerate coefficients are harmless because all
+    // stored Fock matrices are nearly identical there), so a condition-number
+    // threshold is the WRONG trigger — it would fire on healthy SCF and perturb
+    // the convergence path. Instead this guard intervenes only on genuine
+    // numerical breakdown:
+    //   - the active Gram block is indefinite (a real negative eigenvalue, beyond
+    //     a relative noise floor), or
+    //   - the solved coefficients are non-finite or explosively large.
+    // In either case it drops the OLDEST vector (least representative of the
+    // current point) and retries, always keeping at least the two newest
+    // vectors. On well-behaved SCF none of these fire, so the result is bitwise
+    // identical to the previous bare solve.
+    //
+    // The returned coefficient vector has one entry per input error matrix;
+    // entries for dropped (oldest) vectors are exactly zero, so callers keep
+    // combining over their full history unchanged.
+    inline Eigen::VectorXd solve_diis_coefficients(
+        const std::vector<const Eigen::MatrixXd *> &errors,
+        double max_coeff_magnitude = 1e8)
+    {
+        const std::size_t m = errors.size();
+        Eigen::VectorXd coeffs = Eigen::VectorXd::Zero(static_cast<Eigen::Index>(m));
+        if (m == 0)
+            return coeffs;
+
+        // Full m×m Gram block; sub-blocks are taken as trailing (newest) corners.
+        Eigen::MatrixXd G_full(static_cast<Eigen::Index>(m), static_cast<Eigen::Index>(m));
+        for (std::size_t i = 0; i < m; ++i)
+            for (std::size_t j = i; j < m; ++j)
+            {
+                const double gij = (errors[i]->array() * errors[j]->array()).sum();
+                G_full(static_cast<Eigen::Index>(i), static_cast<Eigen::Index>(j)) = gij;
+                G_full(static_cast<Eigen::Index>(j), static_cast<Eigen::Index>(i)) = gij;
+            }
+
+        // `offset` is how many of the oldest vectors we have dropped. The active
+        // block is the trailing (m-offset)×(m-offset) corner, i.e. the newest
+        // vectors. Keep at least 2.
+        std::size_t offset = 0;
+        while (true)
+        {
+            const std::size_t k = m - offset; // active subspace size
+            const Eigen::Index ki = static_cast<Eigen::Index>(k);
+            const Eigen::MatrixXd G = G_full.bottomRightCorner(ki, ki);
+
+            bool acceptable = true;
+            if (k > 2)
+            {
+                // Reject only a genuinely indefinite Gram block: a negative
+                // eigenvalue below -noise·λ_max signals numerical corruption,
+                // not the benign smallness of a converging subspace.
+                Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> es(G);
+                if (es.info() != Eigen::Success)
+                    acceptable = false;
+                else
+                {
+                    const double lo = es.eigenvalues()(0);
+                    const double hi = es.eigenvalues()(ki - 1);
+                    if (lo < -1e-12 * std::max(hi, 1.0))
+                        acceptable = false;
+                }
+            }
+
+            if (acceptable || k <= 2)
+            {
+                // Solve the bordered system on the active block.
+                Eigen::MatrixXd B = Eigen::MatrixXd::Zero(ki + 1, ki + 1);
+                B.topLeftCorner(ki, ki) = G;
+                for (Eigen::Index i = 0; i < ki; ++i)
+                {
+                    B(i, ki) = -1.0;
+                    B(ki, i) = -1.0;
+                }
+                Eigen::VectorXd rhs = Eigen::VectorXd::Zero(ki + 1);
+                rhs(ki) = -1.0;
+                const Eigen::VectorXd sol = B.colPivHouseholderQr().solve(rhs);
+
+                // Accept unless the solve itself produced something unusable.
+                const bool usable =
+                    sol.allFinite() &&
+                    (k <= 2 || sol.head(ki).cwiseAbs().maxCoeff() <= max_coeff_magnitude);
+                if (usable || k <= 2)
+                {
+                    for (Eigen::Index i = 0; i < ki; ++i)
+                        coeffs(static_cast<Eigen::Index>(offset) + i) = sol(i);
+                    return coeffs;
+                }
+            }
+
+            ++offset; // drop one more of the oldest vectors and retry
+        }
+    }
+
     // ── DIIS working state for one spin channel ───────────────────────────────
     //
     // Implements Pulay's DIIS for SCF convergence acceleration.
@@ -932,32 +1037,19 @@ namespace HartreeFock
         {
             const std::size_t m = size();
 
-            // B_{ij} = Tr( e_i^T e_j )
-            // Augmented system (Lagrange multiplier for sum(c)=1):
-            //   [ B  -1 ] [ c   ]   [ 0 ]
-            //   [-1   0 ] [ lam ] = [-1 ]
-            Eigen::MatrixXd B = Eigen::MatrixXd::Zero(m + 1, m + 1);
+            // Solve the augmented DIIS system with the shared conditioning guard.
+            // The Gram block G_{ij} = <e_i, e_j> is bordered with the Lagrange
+            // row/column for sum(c)=1; ill-conditioned subspaces drop oldest
+            // vectors before solving (those get coefficient 0 below).
+            std::vector<const Eigen::MatrixXd *> errors(m);
             for (std::size_t i = 0; i < m; ++i)
-            {
-                for (std::size_t j = i; j < m; ++j)
-                {
-                    const double bij = (error_history[i].array() * error_history[j].array()).sum();
-                    B(i, j) = bij;
-                    B(j, i) = bij;
-                }
-                B(i, m) = -1.0;
-                B(m, i) = -1.0;
-            }
-
-            Eigen::VectorXd rhs = Eigen::VectorXd::Zero(m + 1);
-            rhs(m) = -1.0;
-
-            const Eigen::VectorXd c = B.colPivHouseholderQr().solve(rhs);
+                errors[i] = &error_history[i];
+            const Eigen::VectorXd c = solve_diis_coefficients(errors);
 
             Eigen::MatrixXd F_extrap = Eigen::MatrixXd::Zero(fock_history[0].rows(),
                                                              fock_history[0].cols());
             for (std::size_t i = 0; i < m; ++i)
-                F_extrap += c(i) * fock_history[i];
+                F_extrap += c(static_cast<Eigen::Index>(i)) * fock_history[i];
 
             return F_extrap;
         }
@@ -1017,24 +1109,26 @@ namespace HartreeFock
         std::pair<Eigen::MatrixXd, Eigen::MatrixXd> extrapolate() const
         {
             const std::size_t m = size();
-            Eigen::MatrixXd B = Eigen::MatrixXd::Zero(m + 1, m + 1);
+
+            // The UHF Gram element is the spin-summed overlap
+            //   G_{ij} = <e_a,i, e_a,j> + <e_b,i, e_b,j>,
+            // which is exactly <[e_a;e_b]_i, [e_a;e_b]_j>. Stack each iteration's
+            // alpha/beta error matrices into one combined matrix and reuse the
+            // shared conditioning-guarded solve. (Stacking column-wise keeps the
+            // element-wise dot product the helper computes equal to the sum.)
+            std::vector<Eigen::MatrixXd> stacked(m);
+            std::vector<const Eigen::MatrixXd *> errors(m);
             for (std::size_t i = 0; i < m; ++i)
             {
-                for (std::size_t j = i; j < m; ++j)
-                {
-                    const double bij =
-                        (error_a_history[i].array() * error_a_history[j].array()).sum() +
-                        (error_b_history[i].array() * error_b_history[j].array()).sum();
-                    B(i, j) = bij;
-                    B(j, i) = bij;
-                }
-                B(i, m) = -1.0;
-                B(m, i) = -1.0;
+                const auto &ea = error_a_history[i];
+                const auto &eb = error_b_history[i];
+                Eigen::MatrixXd s(ea.rows(), ea.cols() + eb.cols());
+                s.leftCols(ea.cols()) = ea;
+                s.rightCols(eb.cols()) = eb;
+                stacked[i] = std::move(s);
+                errors[i] = &stacked[i];
             }
-
-            Eigen::VectorXd rhs = Eigen::VectorXd::Zero(m + 1);
-            rhs(m) = -1.0;
-            const Eigen::VectorXd c = B.colPivHouseholderQr().solve(rhs);
+            const Eigen::VectorXd c = solve_diis_coefficients(errors);
 
             Eigen::MatrixXd Fa = Eigen::MatrixXd::Zero(fock_a_history[0].rows(), fock_a_history[0].cols());
             Eigen::MatrixXd Fb = Eigen::MatrixXd::Zero(fock_b_history[0].rows(), fock_b_history[0].cols());

--- a/src/gradient/gradient.cpp
+++ b/src/gradient/gradient.cpp
@@ -184,7 +184,7 @@ static void accumulate_eri_gradient_permutations(
         accumulate_perm(gamma_fn(jj, ii, ll, kk), true, true);
 }
 
-static std::array<double, 12> compute_eri_deriv_dispatch(
+std::array<double, 12> HartreeFock::Gradient::compute_eri_deriv_dispatch(
     const HartreeFock::Calculator &calc,
     const HartreeFock::ShellPair &spAB,
     const HartreeFock::ShellPair &spCD,
@@ -200,6 +200,10 @@ static std::array<double, 12> compute_eri_deriv_dispatch(
     return HartreeFock::ObaraSaika::_compute_eri_deriv_elem(
         spAB, spCD, kernel, omega);
 }
+
+// File-scope alias so the SCF/KS gradient assembly below can keep calling the
+// dispatcher unqualified.
+using HartreeFock::Gradient::compute_eri_deriv_dispatch;
 
 template <typename GammaFn>
 static void accumulate_shell_pair_eri_gradient(

--- a/src/gradient/gradient.h
+++ b/src/gradient/gradient.h
@@ -2,6 +2,7 @@
 #define HF_GRADIENT_H
 
 #include <Eigen/Core>
+#include <array>
 #include <optional>
 
 #include "base/types.h"
@@ -34,6 +35,19 @@ namespace HartreeFock
         };
 
         const std::optional<WavefunctionGradientBreakdown> &last_wavefunction_gradient_breakdown();
+
+        // Engine-agnostic 12-component ERI derivative for a shell-pair quartet.
+        // Routes to the HGP derivative kernel when the selected integral engine
+        // is HeadGordonPople, otherwise to Obara-Saika. Shared by the SCF/KS
+        // gradient assembly and the MP2/UMP2 gradient response intermediates so
+        // both honor the user's engine selection. kernel/omega default to the
+        // plain Coulomb operator.
+        std::array<double, 12> compute_eri_deriv_dispatch(
+            const HartreeFock::Calculator &calc,
+            const HartreeFock::ShellPair &spAB,
+            const HartreeFock::ShellPair &spCD,
+            HartreeFock::ERIKernel kernel = HartreeFock::ERIKernel::Coulomb,
+            double omega = 0.0);
 
         // Analytic RHF nuclear gradient.
         // Returns natoms×3 matrix in Ha/Bohr.

--- a/src/populations/bond-order.cpp
+++ b/src/populations/bond-order.cpp
@@ -55,14 +55,24 @@ namespace HartreeFock::SCF
                 // without materializing explicit submatrices. We only fill the
                 // upper triangle and mirror it because Mayer bond orders are
                 // symmetric by construction.
+                // Mayer bond order. The canonical closed-shell form uses the
+                // total density directly with no prefactor:
+                //   B_AB = Σ_{μ∈A,ν∈B} (P_total S)_μν (P_total S)_νμ,
+                // which gives B(H–H) = 1 for H2. The spin-resolved form that
+                // reduces to this same value carries an explicit factor of 2:
+                //   B_AB = 2·Σ [ (P^α S)_μν (P^α S)_νμ + (P^β S)_μν (P^β S)_νμ ],
+                // since for a closed shell P^α = P^β = P_total/2 and
+                //   2·[2·(½ P_total S)²] = (P_total S)². The open-shell branch
+                // below must keep that factor of 2 — without it every open-shell
+                // bond order comes out half its correct value.
                 double bond_order = 0.0;
                 for (const int mu : (*atom_to_aos)[atom_a])
                     for (const int nu : (*atom_to_aos)[atom_b])
                     {
                         if (alpha_density != nullptr && beta_density != nullptr)
                         {
-                            bond_order += PS_alpha(mu, nu) * PS_alpha(nu, mu);
-                            bond_order += PS_beta(mu, nu) * PS_beta(nu, mu);
+                            bond_order += 2.0 * PS_alpha(mu, nu) * PS_alpha(nu, mu);
+                            bond_order += 2.0 * PS_beta(mu, nu) * PS_beta(nu, mu);
                         }
                         else
                         {

--- a/src/post_hf/mp2_gradient.cpp
+++ b/src/post_hf/mp2_gradient.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <string_view>
 
+#include "gradient/gradient.h"
 #include "integrals/base.h"
 #include "post_hf/integrals.h"
 #include "post_hf/mp2_internal.h"
@@ -368,7 +369,7 @@ namespace HartreeFock::Correlation
                         {
                             const HartreeFock::ShellPair spAB(bfs[p], bfs[q]);
                             const HartreeFock::ShellPair spCD(bfs[r], bfs[s]);
-                            const auto dI = HartreeFock::ObaraSaika::_compute_eri_deriv_elem(spAB, spCD);
+                            const auto dI = HartreeFock::Gradient::compute_eri_deriv_dispatch(calculator, spAB, spCD);
                             // PySCF contracts the pair density with the ERI derivative
                             // with an overall factor of 2 (grad/mp2.py: de -= ... * 2);
                             // dm2buf_full carries only one bra-derivative permutation here.
@@ -522,7 +523,7 @@ namespace HartreeFock::Correlation
                         {
                             const HartreeFock::ShellPair spAB(bfs[p], bfs[q]);
                             const HartreeFock::ShellPair spCD(bfs[r], bfs[s]);
-                            const auto dI = HartreeFock::ObaraSaika::_compute_eri_deriv_elem(spAB, spCD);
+                            const auto dI = HartreeFock::Gradient::compute_eri_deriv_dispatch(calculator, spAB, spCD);
                             for (int comp = 0; comp < 3; ++comp)
                             {
                                 vhf1_rs_terms(atom, comp) += dI[comp] * hf_dm1(p, q) * dm1p(r, s);
@@ -723,7 +724,7 @@ namespace HartreeFock::Correlation
 
                             const HartreeFock::ShellPair spAB(bfs[p], bfs[q]);
                             const HartreeFock::ShellPair spCD(bfs[r], bfs[s]);
-                            const auto dI = HartreeFock::ObaraSaika::_compute_eri_deriv_elem(spAB, spCD);
+                            const auto dI = HartreeFock::Gradient::compute_eri_deriv_dispatch(calculator, spAB, spCD);
                             for (int comp = 0; comp < 3; ++comp)
                                 electronic(atom, comp) += dI[comp] * (dm2a + dm2b);
 

--- a/tests/diis_conditioning.cpp
+++ b/tests/diis_conditioning.cpp
@@ -1,0 +1,134 @@
+// Unit tests for the shared DIIS coefficient solve (HartreeFock::solve_diis_coefficients).
+//
+// The guard must be a no-op on well-behaved subspaces (returning the same
+// coefficients the bare bordered solve produces) and must recover gracefully
+// when the linear solve would otherwise produce non-finite or explosively
+// large coefficients.
+
+#include <cstdio>
+#include <vector>
+
+#include <Eigen/Core>
+
+#include "base/types.h"
+
+namespace
+{
+    int g_failures = 0;
+
+    bool expect(bool cond, const char *msg)
+    {
+        if (!cond)
+        {
+            std::printf("  [FAIL] %s\n", msg);
+            ++g_failures;
+        }
+        return cond;
+    }
+
+    bool near(double a, double b, double tol = 1e-10)
+    {
+        return std::abs(a - b) <= tol;
+    }
+
+    // Reference bordered solve with no guard, matching the original code path.
+    Eigen::VectorXd bare_solve(const std::vector<Eigen::MatrixXd> &errs)
+    {
+        const Eigen::Index m = static_cast<Eigen::Index>(errs.size());
+        Eigen::MatrixXd B = Eigen::MatrixXd::Zero(m + 1, m + 1);
+        for (Eigen::Index i = 0; i < m; ++i)
+        {
+            for (Eigen::Index j = i; j < m; ++j)
+            {
+                const double bij = (errs[i].array() * errs[j].array()).sum();
+                B(i, j) = bij;
+                B(j, i) = bij;
+            }
+            B(i, m) = -1.0;
+            B(m, i) = -1.0;
+        }
+        Eigen::VectorXd rhs = Eigen::VectorXd::Zero(m + 1);
+        rhs(m) = -1.0;
+        return B.colPivHouseholderQr().solve(rhs).head(m);
+    }
+}
+
+int main()
+{
+    // 1) Well-conditioned subspace: guard must return the same coefficients as
+    //    the bare solve, and they must sum to 1.
+    {
+        std::vector<Eigen::MatrixXd> errs;
+        Eigen::MatrixXd e0(2, 2);
+        e0 << 0.30, -0.10, -0.10, 0.20;
+        Eigen::MatrixXd e1(2, 2);
+        e1 << -0.05, 0.04, 0.04, -0.03;
+        Eigen::MatrixXd e2(2, 2);
+        e2 << 0.012, -0.009, -0.009, 0.008;
+        errs = {e0, e1, e2};
+
+        std::vector<const Eigen::MatrixXd *> ptrs;
+        for (const auto &e : errs)
+            ptrs.push_back(&e);
+
+        const Eigen::VectorXd c = HartreeFock::solve_diis_coefficients(ptrs);
+        const Eigen::VectorXd ref = bare_solve(errs);
+
+        expect(c.size() == 3, "well-conditioned: one coefficient per vector");
+        expect(near(c.sum(), 1.0), "well-conditioned: DIIS coefficients sum to 1");
+        bool same = true;
+        for (Eigen::Index i = 0; i < c.size(); ++i)
+            same = same && near(c(i), ref(i), 1e-9);
+        expect(same, "well-conditioned: guard matches the bare bordered solve exactly");
+    }
+
+    // 2) Near-converged subspace (tiny, nearly parallel errors): the Gram block
+    //    is extremely ill-conditioned but still positive — the guard must NOT
+    //    drop vectors here; it should pass the bare solve through unchanged.
+    {
+        Eigen::MatrixXd base(2, 2);
+        base << 1.0, 0.5, 0.5, 1.0;
+        std::vector<Eigen::MatrixXd> errs = {
+            1e-10 * base, 9.9e-11 * base, 9.8e-11 * base};
+        std::vector<const Eigen::MatrixXd *> ptrs;
+        for (const auto &e : errs)
+            ptrs.push_back(&e);
+
+        const Eigen::VectorXd c = HartreeFock::solve_diis_coefficients(ptrs);
+        const Eigen::VectorXd ref = bare_solve(errs);
+        expect(c.allFinite(), "near-converged: coefficients are finite");
+        expect(near(c.sum(), 1.0, 1e-6), "near-converged: coefficients sum to 1");
+        bool same = true;
+        for (Eigen::Index i = 0; i < c.size(); ++i)
+            same = same && near(c(i), ref(i), 1e-6);
+        expect(same, "near-converged: benign ill-conditioning is passed through unchanged");
+    }
+
+    // 3) Duplicated vector creates an exactly singular Gram block. The bare
+    //    solve would be unreliable; the guard must drop the oldest vector and
+    //    still return a finite, sum-to-1 coefficient set.
+    {
+        Eigen::MatrixXd e0(2, 2);
+        e0 << 0.20, 0.00, 0.00, 0.10;
+        Eigen::MatrixXd e1(2, 2);
+        e1 << 0.05, 0.00, 0.00, 0.04;
+        // e2 is an exact copy of e1 -> two identical rows/cols in G.
+        Eigen::MatrixXd e2 = e1;
+        std::vector<Eigen::MatrixXd> errs = {e0, e1, e2};
+        std::vector<const Eigen::MatrixXd *> ptrs;
+        for (const auto &e : errs)
+            ptrs.push_back(&e);
+
+        const Eigen::VectorXd c = HartreeFock::solve_diis_coefficients(ptrs);
+        expect(c.size() == 3, "singular: one coefficient per input vector (some may be zero)");
+        expect(c.allFinite(), "singular: coefficients remain finite despite singular Gram block");
+        expect(near(c.sum(), 1.0, 1e-8), "singular: coefficients still sum to 1");
+        expect(c.cwiseAbs().maxCoeff() < 1e8, "singular: no explosive coefficients");
+    }
+
+    if (g_failures == 0)
+        std::printf("[PASS] diis-conditioning: all checks passed\n");
+    else
+        std::printf("[FAIL] diis-conditioning: %d check(s) failed\n", g_failures);
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/inputs/regression/scf/h2_rhf_mayer_sto3g.hfinp
+++ b/tests/inputs/regression/scf/h2_rhf_mayer_sto3g.hfinp
@@ -1,0 +1,29 @@
+%begin_control
+    basis             sto-3g
+    calculation       energy
+    verbosity         normal
+    basis_type        cartesian
+    print_populations .true.
+%end_control
+
+%begin_scf
+    scf_type        rhf
+    use_diis        .true.
+    diis_dim        8
+    engine          os
+    guess           hcore
+    save_checkpoint .false.
+%end_scf
+
+%begin_geom
+    coord_type  cartesian
+    coord_units angstrom
+    use_symm    .false.
+%end_geom
+
+%begin_coords
+2
+0   1
+H     0.000000     0.000000    -0.370500
+H     0.000000     0.000000     0.370500
+%end_coords

--- a/tests/inputs/regression/scf/h2o_cation_uhf_mayer_sto3g.hfinp
+++ b/tests/inputs/regression/scf/h2o_cation_uhf_mayer_sto3g.hfinp
@@ -1,0 +1,30 @@
+%begin_control
+    basis             sto-3g
+    calculation       energy
+    verbosity         normal
+    basis_type        cartesian
+    print_populations .true.
+%end_control
+
+%begin_scf
+    scf_type        uhf
+    use_diis        .true.
+    diis_dim        8
+    engine          os
+    guess           hcore
+    save_checkpoint .false.
+%end_scf
+
+%begin_geom
+    coord_type  cartesian
+    coord_units angstrom
+    use_symm    .false.
+%end_geom
+
+%begin_coords
+3
+1   2
+O      0.000000     0.000000     0.000000
+H      0.758600     0.000000     0.504300
+H     -0.758600     0.000000     0.504300
+%end_coords

--- a/tests/population_analysis.cpp
+++ b/tests/population_analysis.cpp
@@ -128,12 +128,28 @@ int main()
                  "Mayer bond-order analysis should accept compatible molecule, basis, overlap, and spin densities");
     if (mayer)
     {
-        ok &= expect(near(mayer->bond_orders(0, 1), 0.2474, 1e-12),
-                     "Mayer bond order should be the sum of alpha and beta (P S) cross products for the atom pair");
-        ok &= expect(near(mayer->bond_orders(1, 0), 0.2474, 1e-12),
+        ok &= expect(near(mayer->bond_orders(0, 1), 0.4948, 1e-12),
+                     "Mayer bond order should be 2·Σ[(P^α S)(P^α S) + (P^β S)(P^β S)] over the atom pair");
+        ok &= expect(near(mayer->bond_orders(1, 0), 0.4948, 1e-12),
                      "Mayer bond-order matrix should be symmetric");
         ok &= expect(near(mayer->bond_orders(0, 0), 0.0),
                      "Mayer bond-order diagonal should remain zero");
+    }
+
+    // Closed-shell path (no spin densities): B_AB = Σ (P_total S)(P_total S)
+    // with no prefactor, because total_density is the full P_total. For this
+    // toy case PS = [[1.1, 0.7], [0.7, 1.1]], so B(0,1) = 0.7 · 0.7 = 0.49.
+    // This must equal the factor-of-2 open-shell form when α=β=P_total/2.
+    const auto mayer_closed =
+        HartreeFock::SCF::mayer_bond_order_analysis(molecule, basis, S, P, nullptr, nullptr);
+    ok &= expect(static_cast<bool>(mayer_closed),
+                 "Mayer bond-order analysis should accept a closed-shell total density with no spin split");
+    if (mayer_closed)
+    {
+        ok &= expect(near(mayer_closed->bond_orders(0, 1), 0.49, 1e-12),
+                     "closed-shell Mayer bond order is Σ (P_total S)(P_total S) with no prefactor");
+        ok &= expect(near(mayer_closed->bond_orders(1, 0), 0.49, 1e-12),
+                     "closed-shell Mayer bond-order matrix should be symmetric");
     }
 
     const Eigen::MatrixXd bad_density = Eigen::MatrixXd::Identity(3, 3);

--- a/tests/pyscf/mayer_bond_order_sto3g.py
+++ b/tests/pyscf/mayer_bond_order_sto3g.py
@@ -1,0 +1,67 @@
+"""
+PySCF reference: Mayer bond orders, closed- and open-shell.
+
+Matches Planck inputs:
+  tests/inputs/regression/scf/h2_rhf_mayer_sto3g.hfinp        (RHF, closed shell)
+  tests/inputs/regression/scf/h2o_cation_uhf_mayer_sto3g.hfinp (UHF, open shell)
+
+PySCF has no built-in Mayer routine, so the bond order is evaluated here from
+the converged density and overlap. Two conventions, which agree where they
+overlap (closed shell):
+
+  closed shell:  B_AB = Σ_{μ∈A,ν∈B} (P_total S)_μν (P_total S)_νμ        (no prefactor)
+  open shell:    B_AB = 2·Σ_{μ∈A,ν∈B} [ (P^α S)(P^α S) + (P^β S)(P^β S) ]
+
+These reproduce the textbook anchors B(H–H)=1 for H2 and B(H–H)=0.5 for H2+,
+and the factor-of-2 in the open-shell form is what makes the spin-resolved
+expression reduce to the closed-shell one when α=β=P_total/2.
+
+Reference values pinned in tests/regression_cases.json:
+  h2_rhf_mayer_bond_order_sto3g            B(H–H) = 1.00000000
+  h2o_cation_uhf_mayer_bond_order_sto3g    B(O–H) = 0.76017799
+"""
+
+import numpy as np
+from pyscf import gto, scf
+
+
+def mayer(mol, dm, S):
+    asl = mol.aoslice_by_atom()
+    n = mol.natm
+    B = np.zeros((n, n))
+    spin_resolved = dm.ndim == 3
+    if spin_resolved:
+        PSa, PSb = dm[0] @ S, dm[1] @ S
+    else:
+        PS = dm @ S
+    for A in range(n):
+        a0, a1 = asl[A][2], asl[A][3]
+        for Bb in range(A + 1, n):
+            b0, b1 = asl[Bb][2], asl[Bb][3]
+            v = 0.0
+            for mu in range(a0, a1):
+                for nu in range(b0, b1):
+                    if spin_resolved:
+                        v += 2.0 * (PSa[mu, nu] * PSa[nu, mu] + PSb[mu, nu] * PSb[nu, mu])
+                    else:
+                        v += PS[mu, nu] * PS[nu, mu]
+            B[A, Bb] = B[Bb, A] = v
+    return B
+
+
+def main():
+    mol = gto.M(atom="H 0 0 -0.3705; H 0 0 0.3705", basis="sto-3g",
+                unit="Angstrom", cart=True)
+    mf = scf.RHF(mol).run(verbose=0)
+    b_h2 = mayer(mol, mf.make_rdm1(), mol.intor("int1e_ovlp"))[0, 1]
+    print(f"h2_rhf_mayer_bond_order_sto3g           B(H-H) = {b_h2:.8f}")
+
+    molc = gto.M(atom="O 0 0 0; H 0.7586 0 0.5043; H -0.7586 0 0.5043",
+                 basis="sto-3g", unit="Angstrom", charge=1, spin=1, cart=True)
+    mfc = scf.UHF(molc).run(verbose=0)
+    b_oh = mayer(molc, mfc.make_rdm1(), molc.intor("int1e_ovlp"))[0, 1]
+    print(f"h2o_cation_uhf_mayer_bond_order_sto3g   B(O-H) = {b_oh:.8f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/regression_cases.json
+++ b/tests/regression_cases.json
@@ -33,6 +33,30 @@
       ]
     },
     {
+      "id": "h2_rhf_mayer_bond_order_sto3g",
+      "input": "tests/inputs/regression/scf/h2_rhf_mayer_sto3g.hfinp",
+      "tags": [
+        "core"
+      ],
+      "expected_exit_code": 0,
+      "contains": [
+        "Mayer Bond Orders :",
+        "1       2         H         H        1.00000000"
+      ]
+    },
+    {
+      "id": "h2o_cation_uhf_mayer_bond_order_sto3g",
+      "input": "tests/inputs/regression/scf/h2o_cation_uhf_mayer_sto3g.hfinp",
+      "tags": [
+        "core"
+      ],
+      "expected_exit_code": 0,
+      "contains": [
+        "Mayer Bond Orders :",
+        "1       2         O         H        0.76017799"
+      ]
+    },
+    {
       "id": "lih_rmp2_sto3g",
       "input": "inputs/examples/hf/mp2_validation/val_lih.hfinp",
       "tags": [

--- a/tests/regression_cases.json
+++ b/tests/regression_cases.json
@@ -190,7 +190,7 @@
       ],
       "expected_exit_code": 0,
       "contains": [
-        "SCF Converged after",
+        "UHF Converged",
         "Total MP2 Energy"
       ],
       "checks": [

--- a/tests/regression_cases.json
+++ b/tests/regression_cases.json
@@ -859,6 +859,21 @@
       ]
     },
     {
+      "id": "water_rmp2_gradient_engine_os_vs_hgp",
+      "input": "tests/inputs/regression/post_hf/water_rmp2_gradient_sto3g.hfinp",
+      "executable": "tests/engine_gradient_compare.py",
+      "tags": [
+        "core",
+        "extended"
+      ],
+      "expected_exit_code": 0,
+      "contains": [
+        "OS gradient (Ha/Bohr):",
+        "HGP gradient (Ha/Bohr):",
+        "PASS"
+      ]
+    },
+    {
       "id": "water_rhf_geomopt_engine_os_vs_hgp",
       "input": "tests/inputs/regression/geometry/water_rhf_geomopt_engine_compare.hfinp",
       "executable": "tests/engine_geomopt_compare.py",

--- a/vault/Gotchas/Mayer Bond Order Density Convention.md
+++ b/vault/Gotchas/Mayer Bond Order Density Convention.md
@@ -1,0 +1,69 @@
+---
+name: Mayer Bond Order Density Convention
+description: Open-shell Mayer bond order needs a factor of 2 on the per-spin (P S) contractions; closed-shell total-density form has no prefactor
+type: gotcha
+priority: medium
+include_in_claude: true
+tags: [populations, density, gotcha, mayer]
+---
+
+# Mayer Bond Order Density Convention Gotcha
+
+## The Two Equivalent Forms
+
+`src/populations/bond-order.cpp` (`mayer_bond_order_analysis`) has two
+branches that must agree where they overlap (closed shell):
+
+- **Closed shell** (only `total_density` supplied) — canonical form, **no
+  prefactor**:
+
+  ```
+  B_AB = Σ_{μ∈A, ν∈B} (P_total S)_μν (P_total S)_νμ
+  ```
+
+  This gives `B(H–H) = 1` for H2, the textbook single bond.
+
+- **Open shell** (`alpha_density` and `beta_density` supplied) — spin-resolved
+  form, which carries an explicit **factor of 2**:
+
+  ```
+  B_AB = 2 · Σ_{μ∈A, ν∈B} [ (P^α S)_μν (P^α S)_νμ + (P^β S)_μν (P^β S)_νμ ]
+  ```
+
+## Why the factor of 2 (and why it bites)
+
+For a closed shell `P^α = P^β = P_total / 2`, so
+
+```
+2 · [ 2 · (½ P_total S)² ] = 2 · 2 · ¼ (P_total S)² = (P_total S)²
+```
+
+i.e. the open-shell form reduces to the closed-shell form **only** with the
+leading `2`. Drop it and every open-shell bond order comes out at **half** its
+correct value (and the closed-shell H2 check would silently disagree with the
+open-shell branch by 2×).
+
+The bug originally lived in the **open-shell branch** (missing the `2`). It
+went unnoticed because the only unit test passed explicit `&alpha`/`&beta`
+densities and asserted the *halved* value, so the test agreed with the buggy
+code. The closed-shell total-density branch was correct all along — do **not**
+"fix" it by adding a ½; that breaks the correct H2 = 1 result.
+
+## Rule
+
+When a population/bond-order quantity is quadratic in the density, decide up
+front whether you are contracting the **total** density `P_total` or the
+**per-spin** densities `P^α`, `P^β`. A quadratic in `P_total` and the
+spin-summed quadratic differ by a factor of 2 for a closed shell (and the
+spin-summed form needs the explicit `2` to match). `total_density` handed in
+by `src/driver.cpp` is the full `P_total = 2·C_occ C_occᵀ` (RHF), not a
+per-spin density.
+
+## Regression To Keep
+
+- Unit (`tests/population_analysis.cpp`):
+  - open-shell `B(0,1) = 0.4948` for the toy α/β densities (was asserting the
+    buggy `0.2474`)
+  - closed-shell `B(0,1) = 0.49` for `PS = [[1.1,0.7],[0.7,1.1]]` (no prefactor)
+- End-to-end: `h2_rhf_mayer_bond_order_sto3g` asserts the printed H–H bond
+  order is `1.00000000`.

--- a/vault/Implementation/Gradients and GeomOpt.md
+++ b/vault/Implementation/Gradients and GeomOpt.md
@@ -36,15 +36,16 @@ in `src/integrals/os.cpp`; HGP has no separate implementation for them and
 always uses OS. They are cheap relative to the 2e term, so this is not a
 performance gap.
 
-The MP2 / UMP2 gradient code in `src/post_hf/mp2_gradient.cpp` calls
-`ObaraSaika::_compute_eri_deriv_elem` directly at three sites; it bypasses
-`compute_eri_deriv_dispatch`, so the HGP engine is not used for MP2 gradient
-response intermediates even when selected. Values agree with the OS path to
-~1e-15; the asymmetry is performance/coverage, not correctness.
+The MP2 / UMP2 gradient code in `src/post_hf/mp2_gradient.cpp` routes its
+three derivative-ERI sites through `HartreeFock::Gradient::compute_eri_deriv_dispatch`
+(now a public entry in `gradient.h`), so the HGP engine is used for MP2/UMP2
+gradient response intermediates when selected, matching the rest of the
+gradient path. The dispatcher is engine-agnostic; the previous OS-only
+hardcoding is gone.
 
 ### Cross-engine validation
 
-Engine-agnostic gradient correctness is gated by four regression cases that
+Engine-agnostic gradient correctness is gated by five regression cases that
 run the same input twice (engine os, engine hgp) and compare:
 
 | ID | What it tests |
@@ -53,6 +54,7 @@ run the same input twice (engine os, engine hgp) and compare:
 | `water_b3lyp_gradient_engine_os_vs_hgp` | B3LYP/STO-3G gradient (HF-like Coulomb path) |
 | `water_hse06_gradient_engine_os_vs_hgp` | HSE06/STO-3G gradient — exercises the LongRange derivative dispatch |
 | `water_rhf_geomopt_engine_os_vs_hgp` | RHF/STO-3G geomopt: |ΔE| ≤ 1e-8 Eh and geom RMSD ≤ 1e-5 Å |
+| `water_rmp2_gradient_engine_os_vs_hgp` | RMP2/STO-3G analytic gradient — exercises the MP2 response-intermediate derivative-ERI dispatch |
 
 Drivers: `tests/engine_gradient_compare.py` and
 `tests/engine_geomopt_compare.py`. Binary (`hartree-fock` vs `planck-dft`)

--- a/vault/Implementation/Integral Engine.md
+++ b/vault/Implementation/Integral Engine.md
@@ -98,14 +98,17 @@ The screened scaling is applied inside `hgp_vrr`:
   `engine == HeadGordonPople` routes to the HGP entries.
 - Full-symmetry direct SCF dispatches through `src/scf/scf.cpp`
   (`full_symmetry_fock_{rhf,uhf}` and `full_symmetry_build_skeleton`).
-- Analytic gradient dispatches through `compute_eri_deriv_dispatch` in
-  `src/gradient/gradient.cpp` — engine-agnostic for all kernels (Coulomb,
-  LongRange, ShortRange).
-- MP2 / UMP2 analytic gradient (`src/post_hf/mp2_gradient.cpp`) calls
-  `ObaraSaika::_compute_eri_deriv_elem` directly; bypasses the dispatcher,
-  so HGP is not used for the MP2 gradient response intermediates even when
-  the engine is selected. Not a correctness bug (values match OS to ~1e-15)
-  but a latent asymmetry.
+- Analytic gradient dispatches through `compute_eri_deriv_dispatch`, now a
+  public entry in `HartreeFock::Gradient` (`src/gradient/gradient.{h,cpp}`) —
+  engine-agnostic for all kernels (Coulomb, LongRange, ShortRange).
+- MP2 / UMP2 analytic gradient (`src/post_hf/mp2_gradient.cpp`) now routes its
+  three derivative-ERI sites through the same
+  `HartreeFock::Gradient::compute_eri_deriv_dispatch`, so the MP2/UMP2 gradient
+  response intermediates honor the selected engine (HGP when `engine hgp`)
+  rather than always using OS. Cross-engine equality is gated by
+  `water_rmp2_gradient_engine_os_vs_hgp` (OS↔HGP RMP2 gradient identical to the
+  8-decimal print precision); the UMP2 radical-cation input shares the same
+  routing and matches to `0.000e+00` when compared manually.
 
 ### Test hooks retained for historical gates
 

--- a/vault/Status/Completion.md
+++ b/vault/Status/Completion.md
@@ -138,6 +138,22 @@ historical design context, but they are no longer the source of truth for
 
 ### Recent fixes now considered landed
 
+- Mayer bond-order open-shell factor-of-2 fix. The unrestricted branch of
+  `mayer_bond_order_analysis` (`src/populations/bond-order.cpp`) was missing
+  the leading `2` on the spin-resolved `(P^α S)² + (P^β S)²` contraction, so
+  every open-shell bond order came out at half its correct value; the
+  closed-shell total-density branch was already correct. PySCF-anchored
+  (H2 RHF B(H–H)=1.0, H2O+ UHF B(O–H)=0.76017799 vs 0.76017810). New gates:
+  `h2_rhf_mayer_bond_order_sto3g`, `h2o_cation_uhf_mayer_bond_order_sto3g`,
+  plus a closed-shell unit assertion that was previously absent. See the
+  Mayer Bond Order Density Convention gotcha.
+- Two previously-open robustness items were verified already-resolved in the
+  tree (no new work, doc was stale): the developer-specific absolute basis
+  path is not committed (`src/base/basis.h` is git-ignored; the tracked
+  `basis.h.in` template uses `@BASIS_INSTALL_PATH@` + `$BASIS_PATH`), and the
+  CASSCF orbital-action solver already warns and falls back to the diagonal
+  preconditioner when >20% of orbital-Hessian eigenvalues are clamped
+  (`src/post_hf/casscf/response.cpp`).
 - ERI / transform parallelization pass (profiled, all bitwise-verified):
   the two serial 4-index transforms (`Correlation::transform_eri`,
   `BasisFunctions::transform_eri_cart_to_sph`) are now parallel; the one-shot

--- a/vault/Status/Open Work.md
+++ b/vault/Status/Open Work.md
@@ -19,7 +19,6 @@ truth for what remains.
 ## Highest-priority correctness and robustness work
 
 - Remove the committed developer-specific absolute basis path from `src/base/basis.h`
-- Fix the Mayer bond-order convention mismatch between closed-shell and unrestricted paths
 - Replace the large thread-local Rys scratch allocation with a size-aware heap or lighter scratch strategy
 - Add a real stationarity guard to the CASSCF plateau-escape convergence path
 - Add warning or fallback behavior when the CASSCF orbital-action solver heavily clamps negative curvature

--- a/vault/Status/Open Work.md
+++ b/vault/Status/Open Work.md
@@ -132,9 +132,3 @@ Gate:
 - Eliminate remaining reversed-shell-pair reconstruction churn in gradient paths outside the already-fixed RHF path
 - Deduplicate the full-group AO-transform machinery that still exists in both `group_operations.cpp` and `mo_symmetry.cpp`
 - Refactor `Calculator` only where it buys real safety or clarity: the leading candidates are grouping the loose MP2/UMP2 result cache and introducing a geometry-derived working-state object with a single invalidation point
-- Route MP2 / UMP2 gradient derivative-ERI calls in
-  `src/post_hf/mp2_gradient.cpp` (lines 371, 525, 726) through
-  `compute_eri_deriv_dispatch` instead of hardcoding
-  `ObaraSaika::_compute_eri_deriv_elem`. Today the MP2 response
-  intermediates always use OS even when the user picked HGP — values agree
-  to ~1e-15 so this is performance/coverage, not correctness.

--- a/vault/Status/Open Work.md
+++ b/vault/Status/Open Work.md
@@ -18,10 +18,8 @@ truth for what remains.
 
 ## Highest-priority correctness and robustness work
 
-- Remove the committed developer-specific absolute basis path from `src/base/basis.h`
 - Replace the large thread-local Rys scratch allocation with a size-aware heap or lighter scratch strategy
 - Add a real stationarity guard to the CASSCF plateau-escape convergence path
-- Add warning or fallback behavior when the CASSCF orbital-action solver heavily clamps negative curvature
 - Add DIIS rank/conditioning guards shared across RHF, UHF, and ROHF
 - Resolve the ROHF MO-energy bookkeeping inconsistency between effective, alpha, and beta eigenvalue sets
 


### PR DESCRIPTION
A batch of correctness, robustness, and test-hygiene fixes (5 commits).

## Correctness

- **Open-shell Mayer bond order was off by 2×.** The unrestricted branch of `mayer_bond_order_analysis` was missing the leading factor of 2 on the spin-resolved `(P^α S)² + (P^β S)²` contraction, so every open-shell bond order came out at half its correct value; the closed-shell total-density branch was already correct. PySCF-anchored: H2 RHF B(H–H)=1.0, H2O+ UHF B(O–H)=0.76017799 (PySCF 0.76017810). The closed-shell branch had no test coverage at all, which is why it hid.

- **MP2/UMP2 gradient ignored the selected integral engine.** The three derivative-ERI sites in `mp2_gradient.cpp` hardcoded Obara-Saika, so HGP was silently unused for MP2 gradient response intermediates even when `engine hgp` was selected. Promoted `compute_eri_deriv_dispatch` to a public `HartreeFock::Gradient` entry and routed all three sites through it.

## Robustness

- **DIIS coefficient solve guarded against numerical breakdown.** Both `extrapolate()` paths (RHF/ROHF and UHF) solved the bordered Pulay system with a bare QR solve and no protection against a degenerate Gram block. Added a shared `solve_diis_coefficients()` that intervenes only on genuine breakdown (indefinite Gram block or non-finite/explosive coefficients) — deliberately **not** on condition number, since healthy near-converged SCF routinely has ~1e-29 smallest Gram eigenvalues and a condition-number guard perturbs the convergence path. No-op on well-behaved SCF (energies and iteration counts unchanged).

## Tests / harness

- New unit tests: `planck-diis-conditioning` (well-conditioned / benign-near-converged / singular-Gram), closed-shell Mayer assertion (previously untested), open-shell Mayer assertion corrected.
- New regressions: `water_rmp2_gradient_engine_os_vs_hgp`, `h2_rhf_mayer_bond_order_sto3g`, `h2o_cation_uhf_mayer_bond_order_sto3g`, plus a PySCF reference script for the Mayer values.
- Pre-existing harness bugs fixed: `water_cation_rimp2_ccpvdz` asserted the RHF-only "SCF Converged after" on a UHF case (→ "UHF Converged"); `planck-aux-basis-load` / `planck-ri-2c-eri` read `basis-sets/` via a relative path that failed under ctest's `build/` cwd (→ `WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}`).

## Docs

- Vault updated (Integral Engine, Gradients, Mayer gotcha, Open Work, Completion). Two stale Open-Work items verified already-resolved and dropped (committed absolute basis path; CASSCF negative-curvature clamp warning).

## Validation

All 27 planck-* ctests pass, including `planck-regression-core/extended/smoke` and `planck-pyscf-equivalence`. Cross-engine MP2 gradients match OS↔HGP to 0.000e+00; Mayer values match PySCF to ~1e-7.