### PR TITLE
docs(vault): mark Rys dynamic scratch landed (PR #126)

### DIFF
--- a/docs/PLANCK_TEACHING_GUIDE.md
+++ b/docs/PLANCK_TEACHING_GUIDE.md
@@ -2336,10 +2336,15 @@ work explicit.
 HGP and Rys quadrature *are* genuinely different schemes. For high total angular
 momentum the OS/HGP scratch buffers grow as the product of all six VRR
 extents, while Rys keeps a fixed number of quadrature roots \(n = \lfloor L/2
-\rfloor + 1\). Hybrid engines therefore typically prefer HGP at low-to-medium
-\(L\) and Rys at high \(L\); the same operation-count model used for OS-vs-Rys
-auto-dispatch (§11) applies equally to HGP-vs-Rys with only the OS flop
-estimate replaced by the HGP estimate (which has a smaller HRR coefficient).
+\rfloor + 1\). The textbook expectation is therefore that hybrid engines prefer
+HGP at low-to-medium \(L\) and Rys at high \(L\). Planck's *measured*
+calibration (§11) tells a more specific story for the angular momenta that
+shipped bases actually reach: it picks Rys only at the very bottom
+(\(L_{AB}+L_{CD}\le 1\)) and HGP everywhere above, because the asymptotic
+high-\(L\) crossover sits past those bases. The same per-bucket operation-count
+sweep used for the OS-vs-Rys decision applies equally to HGP-vs-Rys, with the
+OS flop estimate replaced by the HGP estimate (which has a smaller HRR
+coefficient).
 
 ### Screened and Range-Separated Kernels
 
@@ -2426,15 +2431,19 @@ numbers should not be compared directly against that older run.
 
 Reading the table, four patterns stand out.
 
-**1. Rys is dominated by both HGP and OS at every basis tested here.** This is
-the expected regime: STO-3G through 6-31G(d,p) puts maximum angular momentum at
-\(d\), which sits squarely in the low-to-medium-\(L\) window where the OS/HGP
-flop count is smaller than the Rys-quadrature flop count. On 6-31G(d,p) / CH₄
-(Td) the spread reaches \(\sim\)10.5× over HGP on `nosym` and \(\sim\)5.2× on
-`d2h`; Rys is not really a competitor here, and the auto-dispatch model in §11
-would only prefer Rys at higher \(L\) where the OS/HGP scratch buffers blow up
-faster than Rys's fixed root count. Rys's natural niche is the high-\(L\) tail,
-not the bulk of routine basis sets.
+**1. Rys is dominated by both HGP and OS across the bulk of these bases.** On
+6-31G(d,p) / CH₄ (Td) the spread reaches \(\sim\)10.5× over HGP on `nosym` and
+\(\sim\)5.2× on `d2h`; Rys is not a competitor across the medium-\(L\) bulk.
+Note that Planck's *calibrated* auto-dispatch (§11) does **not** match the
+textbook "Rys wins at high \(L\)" intuition: the measured per-bucket sweep
+picks Rys only at the very bottom, \(L_{AB}+L_{CD} \le 1\) (the
+\((ss|ss)\)/\((ss|sp)\) buckets), where Rys's 1–2 roots undercut HGP's
+HRR-outside setup cost; everywhere above that HGP wins. So in this codebase
+Rys's empirical niche is the low-\(L\) corner, not the high-\(L\) tail — see
+§11 and `_auto_prefers_rys`. (The asymptotic flop-count argument that Rys's
+fixed root count eventually beats the growing OS/HGP scratch extents is still
+true in the limit, but that crossover sits beyond the angular momenta any
+shipped basis reaches, so it does not drive the dispatch decision in practice.)
 
 **2. HGP is the fastest engine on every case in the table.** Unlike an earlier
 `-O0` serial run of this same benchmark — where HGP and OS were within a few
@@ -6107,7 +6116,7 @@ S_A = \sum_{\mu \in A} \sum_\nu \Delta P_{\mu\nu} S_{\mu\nu}
 
 **Code path**
 
-`src/scf/population.cpp` — `mulliken_population_analysis()`
+`src/populations/mulliken.cpp` — `mulliken_population_analysis()`
 
 The gross AO population vector is computed as a row-sum of the Hadamard product \(P \circ S\):
 
@@ -6164,7 +6173,7 @@ that atom.
 
 **Code path**
 
-`src/scf/population.cpp` — `lowdin_population_analysis()`
+`src/populations/lodwin.cpp` — `lowdin_population_analysis()`
 
 The implementation diagonalizes the AO overlap with
 `Eigen::SelfAdjointEigenSolver`, clips tiny eigenvalues with a numerical
@@ -6196,11 +6205,11 @@ This measures how strongly the AO subspaces on atoms \(A\) and \(B\) mix
 through the occupied density in a non-orthogonal basis.
 
 For open-shell references Planck uses the spin-resolved form, summing separate
-\(\alpha\) and \(\beta\) contributions:
+\(\alpha\) and \(\beta\) contributions with a leading factor of 2:
 
 \[
 B_{AB}^{\mathrm{Mayer}} =
-\sum_{\mu \in A}\sum_{\nu \in B}
+2\sum_{\mu \in A}\sum_{\nu \in B}
 \left[
 (\mathbf P^\alpha \mathbf S)_{\mu\nu}(\mathbf P^\alpha \mathbf S)_{\nu\mu}
 +
@@ -6208,12 +6217,21 @@ B_{AB}^{\mathrm{Mayer}} =
 \right]
 \]
 
+The factor of 2 is what makes the spin-resolved form reduce to the closed-shell
+expression above: \(\mathbf P\) there is the *total* density \(\mathbf P =
+2\,\mathbf C_{\mathrm{occ}}\mathbf C_{\mathrm{occ}}^\top\), so for a closed shell
+\(\mathbf P^\alpha = \mathbf P^\beta = \mathbf P/2\) and
+\(2[2\,(\tfrac12\mathbf P\mathbf S)^2] = (\mathbf P\mathbf S)^2\). Dropping the
+2 halves every open-shell bond order (e.g. H–H would print \(\approx 0.5\)
+instead of 1); this was a real bug, fixed and PySCF-anchored (H₂ RHF
+\(B(\mathrm{H\text{-}H})=1\), H₂O⁺ UHF \(B(\mathrm{O\text{-}H})=0.760\)).
+
 The diagonal \(B_{AA}\) is left at zero in the printed matrix, and the
 off-diagonal matrix is symmetrized.
 
 **Code path**
 
-`src/scf/population.cpp` — `mayer_bond_order_analysis()`
+`src/populations/bond-order.cpp` — `mayer_bond_order_analysis()`
 
 The routine first validates the density dimensions and builds the AO lists for
 each atom.  It then forms either \(\mathbf P\mathbf S\) or the spin-resolved
@@ -6624,9 +6642,9 @@ driver.cpp
 | Ghost atoms (BSSE) | `src/base/types.h` | `Molecule::is_ghost`, `nuclear_charge`, `total_nuclear_charge` |
 | Counterpoise driver | `src/bsse/counterpoise.cpp` | `run_counterpoise` |
 | Ghost / `%begin_bsse` parsing | `src/io/io.cpp` | `parse_atom_token`, `_parse_bsse` |
-| Mulliken population analysis | `src/scf/population.cpp` | `mulliken_population_analysis`, `gross_ao_population` |
-| Löwdin population analysis | `src/scf/population.cpp` | `lowdin_population_analysis`, `symmetric_overlap_sqrt` |
-| Mayer bond orders | `src/scf/population.cpp` | `mayer_bond_order_analysis` |
+| Mulliken population analysis | `src/populations/mulliken.cpp` | `mulliken_population_analysis`, `gross_ao_population` |
+| Löwdin population analysis | `src/populations/lodwin.cpp` | `lowdin_population_analysis`, `symmetric_overlap_sqrt` |
+| Mayer bond orders | `src/populations/bond-order.cpp` | `mayer_bond_order_analysis` |
 | Dipole / quadrupole AO integrals | `src/integrals/os.cpp` | `_os_1d_moments`, `_compute_multipole_matrices` |
 | Multipole moments (traceless) | `src/integrals/os.cpp` | `_compute_multipole_moments` |
 | RMP2 natural orbitals | `src/post_hf/mp2.cpp` | `compute_rmp2_natural_orbitals` |

--- a/docs/index.html
+++ b/docs/index.html
@@ -1482,7 +1482,7 @@ for each ShellPair(AB) in petite list:
 <h3 id="relationship-to-os-rys-and-auto-dispatch">Relationship to OS, Rys, and Auto-Dispatch</h3>
 <p>HGP and OS are mathematically the same recurrence; HGP is a <em>factorization</em> (VRR-inside, HRR-outside) of OS that is essentially always preferable to the &quot;both-inside&quot; arrangement for contracted Gaussians. Any implementation already written in a VRR-then-HRR style can be viewed as performing the same identity; HGP simply makes the partition between contraction-inside and contraction-outside work explicit.</p>
 <p>HGP and Rys quadrature <em>are</em> genuinely different schemes. For high total angular momentum the OS/HGP scratch buffers grow as the product of all six VRR extents, while Rys keeps a fixed number of quadrature roots <span class="math-inline">\(n = \lfloor L/2
-\rfloor + 1\)</span>. Hybrid engines therefore typically prefer HGP at low-to-medium <span class="math-inline">\(L\)</span> and Rys at high <span class="math-inline">\(L\)</span>; the same operation-count model used for OS-vs-Rys auto-dispatch (§11) applies equally to HGP-vs-Rys with only the OS flop estimate replaced by the HGP estimate (which has a smaller HRR coefficient).</p>
+\rfloor + 1\)</span>. The textbook expectation is therefore that hybrid engines prefer HGP at low-to-medium <span class="math-inline">\(L\)</span> and Rys at high <span class="math-inline">\(L\)</span>. Planck&#x27;s <em>measured</em> calibration (§11) tells a more specific story for the angular momenta that shipped bases actually reach: it picks Rys only at the very bottom (<span class="math-inline">\(L_{AB}+L_{CD}\le 1\)</span>) and HGP everywhere above, because the asymptotic high-<span class="math-inline">\(L\)</span> crossover sits past those bases. The same per-bucket operation-count sweep used for the OS-vs-Rys decision applies equally to HGP-vs-Rys, with the OS flop estimate replaced by the HGP estimate (which has a smaller HRR coefficient).</p>
 <h3 id="screened-and-range-separated-kernels">Screened and Range-Separated Kernels</h3>
 <p>HGP retains the OS structure of the Boys-function seed, so range-separated operators (<span class="math-inline">\(\mathrm{erfc}(\omega r_{12})/r_{12}\)</span>, <span class="math-inline">\(\mathrm{erf}(\omega
 r_{12})/r_{12}\)</span>) drop in exactly as in OS: the long-range damping enters as a single multiplicative scaling on <span class="math-inline">\(\rho\)</span>, on the <span class="math-inline">\(W - P\)</span> and <span class="math-inline">\(W - Q\)</span> shift vectors, and on the Boys argument. In practice this is bundled as a <span class="math-inline">\(\{\rho_{\mathrm{eff}}, \text{prefactor scale}, \text{Boys-argument scale}\}\)</span> triple consumed by the VRR seed, with the unscreened Coulomb kernel as the identity case.</p>
@@ -1536,7 +1536,7 @@ r_{12})/r_{12}\)</span>) drop in exactly as in OS: the long-range damping enters
 <tr><td>CH₄ / <code>6-31G**</code> (Td, order(G)=24)</td><td>35</td><td>Auto</td><td>17.490</td><td>8.749</td><td><strong>5.871</strong></td></tr>
 </tbody></table></div>
 <p>Reading the table, four patterns stand out.</p>
-<p><strong>1. Rys is dominated by both HGP and OS at every basis tested here.</strong> This is the expected regime: STO-3G through 6-31G(d,p) puts maximum angular momentum at <span class="math-inline">\(d\)</span>, which sits squarely in the low-to-medium-<span class="math-inline">\(L\)</span> window where the OS/HGP flop count is smaller than the Rys-quadrature flop count. On 6-31G(d,p) / CH₄ (Td) the spread reaches <span class="math-inline">\(\sim\)</span>10.5× over HGP on <code>nosym</code> and <span class="math-inline">\(\sim\)</span>5.2× on <code>d2h</code>; Rys is not really a competitor here, and the auto-dispatch model in §11 would only prefer Rys at higher <span class="math-inline">\(L\)</span> where the OS/HGP scratch buffers blow up faster than Rys&#x27;s fixed root count. Rys&#x27;s natural niche is the high-<span class="math-inline">\(L\)</span> tail, not the bulk of routine basis sets.</p>
+<p><strong>1. Rys is dominated by both HGP and OS across the bulk of these bases.</strong> On 6-31G(d,p) / CH₄ (Td) the spread reaches <span class="math-inline">\(\sim\)</span>10.5× over HGP on <code>nosym</code> and <span class="math-inline">\(\sim\)</span>5.2× on <code>d2h</code>; Rys is not a competitor across the medium-<span class="math-inline">\(L\)</span> bulk. Note that Planck&#x27;s <em>calibrated</em> auto-dispatch (§11) does <strong>not</strong> match the textbook &quot;Rys wins at high <span class="math-inline">\(L\)</span>&quot; intuition: the measured per-bucket sweep picks Rys only at the very bottom, <span class="math-inline">\(L_{AB}+L_{CD} \le 1\)</span> (the <span class="math-inline">\((ss|ss)\)</span>/<span class="math-inline">\((ss|sp)\)</span> buckets), where Rys&#x27;s 1–2 roots undercut HGP&#x27;s HRR-outside setup cost; everywhere above that HGP wins. So in this codebase Rys&#x27;s empirical niche is the low-<span class="math-inline">\(L\)</span> corner, not the high-<span class="math-inline">\(L\)</span> tail — see §11 and <code>_auto_prefers_rys</code>. (The asymptotic flop-count argument that Rys&#x27;s fixed root count eventually beats the growing OS/HGP scratch extents is still true in the limit, but that crossover sits beyond the angular momenta any shipped basis reaches, so it does not drive the dispatch decision in practice.)</p>
 <p><strong>2. HGP is the fastest engine on every case in the table.</strong> Unlike an earlier <code>-O0</code> serial run of this same benchmark — where HGP and OS were within a few percent of each other on STO-3G and OS actually edged ahead on the larger NH₃ basis — the <code>-O3</code> build here puts HGP clearly in front everywhere, by roughly 1.4–2.0× over OS on <code>nosym</code>. The optimization level matters because HGP&#x27;s hot loop is the tight per-primitive VRR into a small <span class="math-inline">\((a0|c0)\)</span> block with the HRR hoisted out; <code>-O3</code> vectorizes and unrolls that kernel aggressively, whereas OS&#x27;s larger per-primitive scratch traffic leaves less on the table. At <code>-O0</code> those advantages are masked, which is why the ordering flips:</p>
 <div class="table-wrap"><table>
 <thead><tr>
@@ -3395,7 +3395,7 @@ Q_A = Z_A - N_A
 S_A = \sum_{\mu \in A} \sum_\nu \Delta P_{\mu\nu} S_{\mu\nu}
 \]</span></p>
 <p><strong>Code path</strong></p>
-<p><code>src/scf/population.cpp</code> — <code>mulliken_population_analysis()</code></p>
+<p><code>src/populations/mulliken.cpp</code> — <code>mulliken_population_analysis()</code></p>
 <p>The gross AO population vector is computed as a row-sum of the Hadamard product <span class="math-inline">\(P \circ S\)</span>:</p>
 <pre><code class="language-cpp">
 Eigen::VectorXd gross = (density.array() * overlap.array()).rowwise().sum();
@@ -3428,7 +3428,7 @@ N_A^{\mathrm{L\ddot owdin}} = \sum_{\mu \in A} \widetilde P_{\mu\mu}
 \]</span></p>
 <p>and the atomic spin population is the sum of the diagonal entries belonging to that atom.</p>
 <p><strong>Code path</strong></p>
-<p><code>src/scf/population.cpp</code> — <code>lowdin_population_analysis()</code></p>
+<p><code>src/populations/lodwin.cpp</code> — <code>lowdin_population_analysis()</code></p>
 <p>The implementation diagonalizes the AO overlap with <code>Eigen::SelfAdjointEigenSolver</code>, clips tiny eigenvalues with a numerical threshold, reconstructs the symmetric square root <span class="math-inline">\(\mathbf S^{1/2}\)</span>, and forms the orthogonalized density and spin-density matrices.  The atomic accumulation step is then shared with Mulliken analysis through <code>accumulate_atomic_populations()</code>, so the printed report has the same table layout: per-atom electron population, net charge, and optional spin population.</p>
 <h3 id="mayer-bond-orders">Mayer Bond Orders</h3>
 <p><strong>Theory</strong></p>
@@ -3443,19 +3443,21 @@ B_{AB}^{\mathrm{Mayer}} =
 (\mathbf{PS})_{\mu\nu}(\mathbf{PS})_{\nu\mu}
 \]</span></p>
 <p>This measures how strongly the AO subspaces on atoms <span class="math-inline">\(A\)</span> and <span class="math-inline">\(B\)</span> mix through the occupied density in a non-orthogonal basis.</p>
-<p>For open-shell references Planck uses the spin-resolved form, summing separate <span class="math-inline">\(\alpha\)</span> and <span class="math-inline">\(\beta\)</span> contributions:</p>
+<p>For open-shell references Planck uses the spin-resolved form, summing separate <span class="math-inline">\(\alpha\)</span> and <span class="math-inline">\(\beta\)</span> contributions with a leading factor of 2:</p>
 <p><span class="math-display">\[
 B_{AB}^{\mathrm{Mayer}} =
-\sum_{\mu \in A}\sum_{\nu \in B}
+2\sum_{\mu \in A}\sum_{\nu \in B}
 \left[
 (\mathbf P^\alpha \mathbf S)_{\mu\nu}(\mathbf P^\alpha \mathbf S)_{\nu\mu}
 +
 (\mathbf P^\beta \mathbf S)_{\mu\nu}(\mathbf P^\beta \mathbf S)_{\nu\mu}
 \right]
 \]</span></p>
+<p>The factor of 2 is what makes the spin-resolved form reduce to the closed-shell expression above: <span class="math-inline">\(\mathbf P\)</span> there is the <em>total</em> density <span class="math-inline">\(\mathbf P =
+2\,\mathbf C_{\mathrm{occ}}\mathbf C_{\mathrm{occ}}^\top\)</span>, so for a closed shell <span class="math-inline">\(\mathbf P^\alpha = \mathbf P^\beta = \mathbf P/2\)</span> and <span class="math-inline">\(2[2\,(\tfrac12\mathbf P\mathbf S)^2] = (\mathbf P\mathbf S)^2\)</span>. Dropping the 2 halves every open-shell bond order (e.g. H–H would print <span class="math-inline">\(\approx 0.5\)</span> instead of 1); this was a real bug, fixed and PySCF-anchored (H₂ RHF <span class="math-inline">\(B(\mathrm{H\text{-}H})=1\)</span>, H₂O⁺ UHF <span class="math-inline">\(B(\mathrm{O\text{-}H})=0.760\)</span>).</p>
 <p>The diagonal <span class="math-inline">\(B_{AA}\)</span> is left at zero in the printed matrix, and the off-diagonal matrix is symmetrized.</p>
 <p><strong>Code path</strong></p>
-<p><code>src/scf/population.cpp</code> — <code>mayer_bond_order_analysis()</code></p>
+<p><code>src/populations/bond-order.cpp</code> — <code>mayer_bond_order_analysis()</code></p>
 <p>The routine first validates the density dimensions and builds the AO lists for each atom.  It then forms either <span class="math-inline">\(\mathbf P\mathbf S\)</span> or the spin-resolved <span class="math-inline">\(\mathbf P^\alpha\mathbf S\)</span> / <span class="math-inline">\(\mathbf P^\beta\mathbf S\)</span> products and loops over atom pairs <span class="math-inline">\(A < B\)</span>.  For each AO pair <span class="math-inline">\(\mu \in A\)</span>, <span class="math-inline">\(\nu \in B\)</span> it accumulates the appropriate product into a dense <code>natoms × natoms</code> bond-order matrix.  <code>src/driver.cpp</code> prints the final matrix below the Mulliken and Löwdin tables whenever population reporting is enabled.</p>
 <h3 id="electric-dipole-moment">Electric Dipole Moment</h3>
 <p><strong>Theory</strong></p>
@@ -3780,9 +3782,9 @@ driver.cpp
 <tr><td>Ghost atoms (BSSE)</td><td><code>src/base/types.h</code></td><td><code>Molecule::is_ghost</code>, <code>nuclear_charge</code>, <code>total_nuclear_charge</code></td></tr>
 <tr><td>Counterpoise driver</td><td><code>src/bsse/counterpoise.cpp</code></td><td><code>run_counterpoise</code></td></tr>
 <tr><td>Ghost / <code>%begin_bsse</code> parsing</td><td><code>src/io/io.cpp</code></td><td><code>parse_atom_token</code>, <code>_parse_bsse</code></td></tr>
-<tr><td>Mulliken population analysis</td><td><code>src/scf/population.cpp</code></td><td><code>mulliken_population_analysis</code>, <code>gross_ao_population</code></td></tr>
-<tr><td>Löwdin population analysis</td><td><code>src/scf/population.cpp</code></td><td><code>lowdin_population_analysis</code>, <code>symmetric_overlap_sqrt</code></td></tr>
-<tr><td>Mayer bond orders</td><td><code>src/scf/population.cpp</code></td><td><code>mayer_bond_order_analysis</code></td></tr>
+<tr><td>Mulliken population analysis</td><td><code>src/populations/mulliken.cpp</code></td><td><code>mulliken_population_analysis</code>, <code>gross_ao_population</code></td></tr>
+<tr><td>Löwdin population analysis</td><td><code>src/populations/lodwin.cpp</code></td><td><code>lowdin_population_analysis</code>, <code>symmetric_overlap_sqrt</code></td></tr>
+<tr><td>Mayer bond orders</td><td><code>src/populations/bond-order.cpp</code></td><td><code>mayer_bond_order_analysis</code></td></tr>
 <tr><td>Dipole / quadrupole AO integrals</td><td><code>src/integrals/os.cpp</code></td><td><code>_os_1d_moments</code>, <code>_compute_multipole_matrices</code></td></tr>
 <tr><td>Multipole moments (traceless)</td><td><code>src/integrals/os.cpp</code></td><td><code>_compute_multipole_moments</code></td></tr>
 <tr><td>RMP2 natural orbitals</td><td><code>src/post_hf/mp2.cpp</code></td><td><code>compute_rmp2_natural_orbitals</code></td></tr>

--- a/vault/Implementation/Integral Engine.md
+++ b/vault/Implementation/Integral Engine.md
@@ -178,7 +178,14 @@ brute-force oracle, multi- and single-threaded).
 ## Key Files
 
 - `src/integrals/os.cpp` + `os.h` — Obara-Saika ERI
-- `src/integrals/rys.cpp` — Rys quadrature ERI
+- `src/integrals/rys.cpp` — Rys quadrature ERI. The 6D accumulator is a
+  thread-local `RysScratch` sized per quartet (`resize_for_quartet` + flat
+  `index()`/`at()`), reused across quartets — the same per-quartet scratch
+  model as HGP's `g_hgp_scratch`/OS's `_eri_scratch`, but minimal (spatial-only,
+  no Boys `m` axis, since Rys gets its angular dependence from quadrature
+  roots). Replaced a fixed `[2·MAX_L+1]^6 = 38.5 MB`/thread buffer; see
+  Completion. The small 1D VRR tables and 3D CD-HRR slice stay as fixed
+  `VRR_DIM` stack arrays.
 - `src/integrals/hgp.cpp` + `hgp.h` — HGP ERI (VRR-per-pair + HRR-outside)
 - `src/integrals/base.h` — engine-dispatch wrappers for `_compute_2e` /
   `_compute_2e_fock` / `_compute_2e_fock_uhf`

--- a/vault/Status/Completion.md
+++ b/vault/Status/Completion.md
@@ -138,6 +138,23 @@ historical design context, but they are no longer the source of truth for
 
 ### Recent fixes now considered landed
 
+- Rys 6D ERI accumulator sized per quartet (PR #126). `_rys_sum_buf` in
+  `src/integrals/rys.cpp` was a thread-local `double[2·MAX_L+1]^6 = [13]^6 =
+  38.5 MB` sized off the global `MAX_L=6`; on the g++-15 / emulated-TLS build
+  emutls `calloc`s the full block on each thread's first Rys-kernel access, so
+  every Rys-active worker thread paid 38.5 MB despite the reachable angular
+  momentum being far lower (Auto only routes `L_AB+L_CD≤1` to Rys; explicit
+  `engine rys` tops out at F in the suite). Replaced with a thread-local
+  `RysScratch` struct sized per quartet via `resize_for_quartet` with flat
+  `index()`/`at()` accessors, reused across quartets — mirroring the HGP/OS
+  `EriScratch` pattern but minimal (spatial-only, no Boys `m` axis). No L
+  ceiling and no rejection guard: explicit `engine rys` at g/h just sizes the
+  vector larger. Footprint ~KB/thread under Auto, ≤0.94 MB at the explicit-rys
+  F worst case. Index layout unchanged, so bitwise-identical — gated by
+  `planck-compute-2e` + `planck-hgp-engine-smoke` and the full extended
+  regression suite (RYS/OS/Auto engine comparisons). `MAX_L` and `os.cpp`
+  untouched. Follow-up (Open Work): factor the shared 6-axis spatial layout out
+  of the OS/HGP/Rys scratch structs.
 - DIIS coefficient-solve conditioning guard (shared across RHF/ROHF and UHF).
   Both `extrapolate()` paths now route through
   `HartreeFock::solve_diis_coefficients` (`src/base/types.h`), which drops the

--- a/vault/Status/Open Work.md
+++ b/vault/Status/Open Work.md
@@ -18,67 +18,6 @@ truth for what remains.
 
 ## Highest-priority correctness and robustness work
 
-- Replace the large thread-local Rys scratch allocation with a size-aware
-  heap or lighter scratch strategy. `_rys_sum_buf` in `src/integrals/rys.cpp`
-  is a thread-local `double[2·MAX_L+1]^6 = [13]^6 = 38.5 MB` sized off the
-  global `MAX_L=6` (H shells). Allocation semantics (g++-15 / emulated TLS on
-  this build): the buffer is **not** allocated at engine selection; only a
-  small `___emutls_v.` control descriptor sits in `__DATA`, and
-  `__emutls_get_address` `calloc`s the full 38.5 MB lazily the first time each
-  thread *accesses* the symbol — i.e. the first time that thread runs the Rys
-  primitive kernel. So `engine os` / `engine hgp` never pay it. But under
-  `engine auto` every basis has s-shells → (ss|ss) quartets always reach Rys,
-  so every multithreaded SCF worker thread does `calloc(38.5 MB)` once and
-  reuses it; emutls allocates the whole declared size (no lazy page-commit
-  rescue). So the per-Rys-thread cost is real for both `auto` (common) and
-  explicit `rys`. The reachable angular momentum is far lower than the
-  declared size, and is bounded by **which quartets actually reach the Rys
-  buffer**, not by the basis:
-  - Auto dispatch (`_auto_prefers_rys`, `rys.cpp`) sends a quartet to Rys only
-    when `L_AB + L_CD <= 1` — i.e. (ss|ss)/(ss|sp)/(sp|ss); everything else
-    goes to HGP. So under Auto the per-axis index never exceeds 1.
-  - Explicit `engine rys` routes every quartet through Rys, but the highest-L
-    basis used with explicit Rys in the suite is cc-pVDZ (**F, L=3**). cc-pVTZ
-    (which has g) is only in the auto-dispatch benchmark, where g quartets go
-    to HGP, never to the Rys buffer.
-
-  So even the explicit-rys worst case (F+F, per-axis index `2·3 = 6`) needs
-  only a `7^6 = 0.94 MB` slice, and the common `auto` path needs `~[2]^6 ≈ 64`
-  doubles. `MAX_L` is global (8 files) so it must not move; the fix is local to
-  `rys.cpp`.
-
-  **Design: mirror the HGP `EriScratch` model** (`src/integrals/hgp.cpp`),
-  which already solves exactly this — a thread-local struct of
-  `std::vector<double>` with `resize_for_quartet(lAB*, lCD*, …)` and flat
-  `spatial_index()` accessors, reused across quartets and only reallocated when
-  the dimension actually changes (`if (vrr.size() != needed) resize()`). Replace
-  the fixed `[13]^6` `_rys_sum_buf` with a `RysScratch` struct sized per
-  quartet, and rewrite `_rys_hrr_ab` to take the flat buffer + strides instead
-  of the `double[VRR_DIM]^6` array parameter. This is strictly better than a
-  fixed `[7]^6` bound: no L ceiling (explicit `engine rys` keeps working at g/h,
-  just allocates more), no rejection guard, and the `auto` path allocates ~KB
-  not MB. Under `auto` the dimension is constant (`L_AB+L_CD≤1`) so it resizes
-  once per thread then pure-reuses — no hot-path allocation churn, same as HGP.
-  Bitwise-gated by `planck-compute-2e` + `planck-hgp-engine-smoke`; spot-check
-  that `auto` allocates ~KB/thread and that explicit rys on cc-pVTZ (g) now
-  succeeds instead of relying on the oversized fixed buffer.
-
-  Note on sharing: OS (`src/integrals/os.cpp`) and HGP each already carry a
-  near-duplicate `EriScratch` struct (same 6-axis spatial dims/strides,
-  `resize_for_quartet`, `spatial_index`); Rys would be a third copy. The
-  genuinely shared part is the 6-axis *spatial layout* (dims + strides +
-  `spatial_index` + resize). What sits on top is engine-specific and not
-  shareable: OS/HGP `vrr` carries an extra Boys-order `m` axis that Rys lacks
-  (Rys does angular dependence via quadrature roots, not an m recurrence), HGP
-  adds an `a0c0_accum`, OS deliberately skips zero-init as a profiled hotspot
-  fix, and the accessor flavors differ (`v(...,m)` vs `v_ptr` vs
-  `h_block_ptr`). So do **not** force a single monolithic shared struct.
-  Sequencing: land the Rys dynamic scratch first (its own minimal,
-  spatial-only struct, no `m` axis), then as a separate maintenance item
-  extract a shared `SpatialQuartetLayout` (dims/strides/index/resize) and
-  retrofit all three engines onto it — which also removes the existing OS↔HGP
-  duplication, not just avoids a third. Tracked below under Performance and
-  maintenance.
 - Resolve the ROHF MO-energy bookkeeping inconsistency between effective, alpha, and beta eigenvalue sets
 
 ## Verification and regression gaps
@@ -208,12 +147,12 @@ Gate:
 - Deduplicate the full-group AO-transform machinery that still exists in both `group_operations.cpp` and `mo_symmetry.cpp`
 - Extract a shared `SpatialQuartetLayout` (6-axis dims + strides +
   `spatial_index` + `resize_for_quartet`) and retrofit the OS, HGP, and Rys
-  per-quartet scratch onto it. OS and HGP already carry near-duplicate
-  `EriScratch` structs and the Rys footprint fix adds a third; only the
-  spatial-layout core is common (the Boys `m` axis, HGP's `a0c0_accum`, OS's
-  no-zero-init policy, and the differing accessors stay engine-specific). Do
-  this *after* the Rys dynamic-scratch lands, so the shared interface is shaped
-  by three concrete call sites rather than speculation. Bitwise-gate across all
-  three engines (`planck-compute-2e`, `planck-hgp-engine-smoke`, plus the OS
-  path via the existing ERI gates).
+  per-quartet scratch onto it. All three now carry near-duplicate per-quartet
+  scratch structs — OS's `_eri_scratch`, HGP's `g_hgp_scratch`, and (as of
+  PR #126) Rys's `RysScratch` — so the three concrete call sites exist to shape
+  the shared interface. Only the spatial-layout core is common; the Boys `m`
+  axis, HGP's `a0c0_accum`, OS's no-zero-init policy, and the differing
+  accessors stay engine-specific. Bitwise-gate across all three engines
+  (`planck-compute-2e`, `planck-hgp-engine-smoke`, plus the OS path via the
+  existing ERI gates).
 - Refactor `Calculator` only where it buys real safety or clarity: the leading candidates are grouping the loose MP2/UMP2 result cache and introducing a geometry-derived working-state object with a single invalidation point


### PR DESCRIPTION
Documentation-only. PR #125's vault edits predated PR #126, so Open Work still listed the Rys scratch footprint fix as a highest-priority open item after it had merged.

- Move the Rys scratch entry from Open Work's highest-priority list to Completion's "Recent fixes now considered landed", summarizing the per-quartet `RysScratch` change and its verification.
- Add a Rys per-quartet-scratch note to the Integral Engine implementation doc for parity with the existing HGP `g_hgp_scratch` description.
- Update the shared `SpatialQuartetLayout` follow-up to note all three engine scratch structs (OS `_eri_scratch`, HGP `g_hgp_scratch`, Rys `RysScratch`) now exist as concrete call sites.

No code changes; CLAUDE.md regenerated from the vault.